### PR TITLE
Fix future while checking existence of a file

### DIFF
--- a/onnxscript/converter.py
+++ b/onnxscript/converter.py
@@ -573,7 +573,7 @@ class Converter:
 
     def convert(self, f):
         if isinstance(f, str):
-            if os.path.exists(f):
+            if '\n' not in f and os.path.exists(f):
                 return self.convert_file(f)
             return self.convert_source(f)
         if inspect.isfunction(f):


### PR DESCRIPTION
os.path.exists(name) crashes if name is too long a contains unexpected characters.