### PR TITLE
Liveness analysis for loops

### DIFF
--- a/onnxscript/analysis.py
+++ b/onnxscript/analysis.py
@@ -111,7 +111,8 @@ def do_liveness_analysis(fun, converter):
         if isinstance(stmt, ast.Break):
             # The following is sufficient for the current restricted usage, where
             # a (conditional) break is allowed only as the last statement of a loop.
-            # Break statements in the middle of the loop, however, will require a generalization.
+            # Break statements in the middle of the loop, however, will require
+            # a generalization.
             return live_out
         if isinstance(stmt, ast.Expr) and hasattr(stmt, 'value'):
             # docstring

--- a/onnxscript/main.py
+++ b/onnxscript/main.py
@@ -27,9 +27,11 @@ def get_src_and_ast(f):
     assert type(f_ast) == ast.FunctionDef
     return src, f_ast
 
+
 def get_ast(f):
     src, ast = get_src_and_ast(f)
     return ast
+
 
 def script_check(f: ast.FunctionDef, opset, global_names, source,
                  default_opset=None):

--- a/onnxscript/test/analysis_test.py
+++ b/onnxscript/test/analysis_test.py
@@ -4,7 +4,6 @@ import unittest
 from onnxscript.main import get_ast
 from onnxscript.analysis import do_liveness_analysis
 from onnxscript.converter import Converter
-from onnxscript.onnx_opset import opset15 as op
 
 
 class AnalysisResultsVisitor(ast.NodeVisitor):


### PR DESCRIPTION
Loops require an iterative analysis to compute live variables, which was missing. This PR adds the iterative analysis for loops, and adds unit test-cases for liveness analysis.

TODO: This does not yet handle break-statements in the middle of loops, which is a separate extension.