### PR TITLE
Expose proto2python at top-level

### DIFF
--- a/docs/examples/01_plot_selu.py
+++ b/docs/examples/01_plot_selu.py
@@ -32,8 +32,8 @@ onnx_fun = Selu.to_function_proto()
 
 #%%
 # Let's see what the translated function looks like:
-from onnxscript.utils import proto_to_text
-print(proto_to_text(onnx_fun))
+from onnxscript.utils import proto2text
+print(proto2text(onnx_fun))
 
 #%%
 # 

--- a/docs/examples/02_plot_square_loss.py
+++ b/docs/examples/02_plot_square_loss.py
@@ -27,8 +27,8 @@ model = square_loss.to_model_proto()
 
 #%%
 # Let's see what the generated model looks like.
-from onnxscript.utils import proto_to_text
-print(proto_to_text(model))
+from onnxscript.utils import proto2text
+print(proto2text(model))
 
 #%%
 # We can run shape-inference and type-check the model using the standard ONNX API.

--- a/docs/examples/05_plot_model_props.py
+++ b/docs/examples/05_plot_model_props.py
@@ -27,5 +27,5 @@ def square_loss(X: FLOAT["N"], Y: FLOAT["N"]) -> FLOAT[1]:
 #%%
 # Let's see what the generated model looks like.
 model = square_loss.to_model_proto()
-from onnxscript.utils import proto_to_text
-print(proto_to_text(model))
+from onnxscript.utils import proto2text
+print(proto2text(model))

--- a/docs/examples/06_plot_model_local_funs.py
+++ b/docs/examples/06_plot_model_local_funs.py
@@ -18,7 +18,7 @@ from onnxscript import script
 from onnxscript.onnx_opset import opset15 as op
 from onnxscript.onnx_types import FLOAT
 from onnxscript.values import Opset
-from onnxscript.utils import proto_to_text
+from onnxscript.utils import proto2text
 
 # A dummy opset used for model-local functions
 local = Opset("local", 1)
@@ -40,17 +40,17 @@ def l2norm (x : FLOAT["N"], y : FLOAT["N"]) -> FLOAT[1]:
 # Let's see what the generated model looks like by default:
 
 model = l2norm.to_model_proto()
-print(proto_to_text(model))
+print(proto2text(model))
 
 #%%
 # Let's now explicitly specify which functions to include.
 # First, generate a model with no model-local functions:
 
 model = l2norm.to_model_proto(functions=[])
-print(proto_to_text(model))
+print(proto2text(model))
 
 #%%
 # Now, generate a model with one model-local function:
 
 model = l2norm.to_model_proto(functions=[sum])
-print(proto_to_text(model))
+print(proto2text(model))

--- a/onnxscript/__init__.py
+++ b/onnxscript/__init__.py
@@ -6,5 +6,6 @@
 __version__ = '0.1'
 
 from .main import script, export_onnx_lib, OnnxFunction
+from .backend.onnx_export import export2python as proto2python
 
-__all__ = [script, export_onnx_lib, OnnxFunction]
+__all__ = [script, export_onnx_lib, OnnxFunction, proto2python]

--- a/onnxscript/utils.py
+++ b/onnxscript/utils.py
@@ -11,10 +11,9 @@ from onnx import TensorProto, ValueInfoProto, ModelProto, FunctionProto
 
 # print utility unavailable in ONNX 1.12 or earlier:
 try:
-    from onnx.printer import to_text as proto_to_text
+    from onnx.printer import to_text as proto2text
 except ImportError:
-    def proto_to_text(
-        x): return "<print utility unavailable>"
+    def proto2text(x): return "<print utility unavailable>"
 
 
 def map_pytype_to_schema_allowed_dtype(onnx_schema_types, dtype):


### PR DESCRIPTION
Expose proto2python at top-level.

Rename proto_to_text to proto2text to be consistent and expose it too.