### PR TITLE
Update .flake8 to allow 120 columns

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,8 +2,10 @@
 # Please move this into pyproject.toml, when it does.
 
 [flake8]
-max-line-length = 95
-### DEFAULT IGNORES FOR 4-space INDENTED PROJECTS ###
+# The formatter we use (black) formats code to 95 columns, which is what we prefer.
+# We set max-line-length to 120 to be more lenient toward comments and long strings.
+max-line-length = 120
+
 # W503 talks about operator formatting which is too opinionated.
 # E203 is need to support black formatting.
 # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html


### PR DESCRIPTION
The formatter we use (black) formats code to 95 columns, which is what we prefer.
We set max-line-length to 120 to be more lenient toward comments and long strings.