### PR TITLE
Implement onnx reference evaluator as an eager backend | evaluator

### DIFF
--- a/onnxscript/evaluator.py
+++ b/onnxscript/evaluator.py
@@ -381,10 +381,11 @@ def _ort_to_os_value(v):
     """Converts an ORT encoding of an ONNX value into the encoding used by onnxscript."""
     if isinstance(v, np.ndarray):
         return tensor.Tensor(v)
+    if np.issctype(type(v)):
+        # E.g. np.int64
+        return tensor.Tensor(np.array(v))
     if isinstance(v, list):
         return [_ort_to_os_value(x) for x in v]
-    if isinstance(v, np.bool_):
-        return tensor.Tensor(np.array(v))
     if v is None:
         raise TypeError("Dynamic optional values not yet supported.")
     raise TypeError(f"Unexpected ORT value type {type(v)}.")
@@ -503,7 +504,7 @@ class ORTEvaluator(BaseEvaluator):
         return _call_ort(schema, inputs, attributes, closure)
 
 
-class OnnxReferenceRuntimeEvaluator(Evaluator):
+class OnnxReferenceRuntimeEvaluator(BaseEvaluator):
     """Evaluates ONNX ops using ONNX Runtime."""
 
     def _eval(self, schema, inputs, attributes, closure):

--- a/onnxscript/evaluator.py
+++ b/onnxscript/evaluator.py
@@ -397,9 +397,6 @@ def _prepare_model_and_inputs_for_eager(
     kwargs: Mapping[str, Any],
     implicit_args: Optional[Mapping[str, Any]] = None,
 ):
-    # Delay import onnxruntime so that onnxscript can be used without
-    # installing onnxruntime.
-
     implicit_args = implicit_args or {}
     # Convert input values to ORT representation-type:
     args = [_os_to_ort_value(x) for x in args]
@@ -455,7 +452,7 @@ def _call_ort(
 ):
     # Delay import onnxruntime so that onnxscript can be used without
     # installing onnxruntime.
-    import onnxruntime as ort
+    import onnxruntime as ort  # pylint: disable=import-outside-toplevel
     from onnxruntime.capi.onnxruntime_pybind11_state import (  # pylint: disable=import-outside-toplevel
         Fail,
         InvalidArgument,

--- a/onnxscript/evaluator.py
+++ b/onnxscript/evaluator.py
@@ -398,12 +398,6 @@ def _prepare_model_and_inputs_for_eager(
 ):
     # Delay import onnxruntime so that onnxscript can be used without
     # installing onnxruntime.
-    import onnxruntime as ort  # pylint: disable=import-outside-toplevel
-    from onnxruntime.capi.onnxruntime_pybind11_state import (  # pylint: disable=import-outside-toplevel
-        Fail,
-        InvalidArgument,
-        InvalidGraph,
-    )
 
     implicit_args = implicit_args or {}
     # Convert input values to ORT representation-type:
@@ -460,6 +454,7 @@ def _call_ort(
 ):
     # Delay import onnxruntime so that onnxscript can be used without
     # installing onnxruntime.
+    import onnxruntime as ort
     from onnxruntime.capi.onnxruntime_pybind11_state import (  # pylint: disable=import-outside-toplevel
         Fail,
         InvalidArgument,

--- a/onnxscript/evaluator.py
+++ b/onnxscript/evaluator.py
@@ -383,6 +383,8 @@ def _ort_to_os_value(v):
         return tensor.Tensor(v)
     if isinstance(v, list):
         return [_ort_to_os_value(x) for x in v]
+    if isinstance(v, np.bool_):
+        return tensor.Tensor(np.array(v))
     if v is None:
         raise TypeError("Dynamic optional values not yet supported.")
     raise TypeError(f"Unexpected ORT value type {type(v)}.")

--- a/onnxscript/tests/eager_mode_test.py
+++ b/onnxscript/tests/eager_mode_test.py
@@ -6,14 +6,41 @@
 import unittest
 
 import numpy as np
+import parameterized
 
 import onnxscript
+import onnxscript.evaluator
 import onnxscript.tensor
 from onnxscript import opset17 as op
 from onnxscript import script
 
 
+@parameterized.parameterized_class(
+    (
+        "name",
+        "evaluator",
+    ),
+    [
+        (
+            "reference_runtime",
+            onnxscript.evaluator.OnnxReferenceRuntimeEvaluator(),
+        ),
+        (
+            "onnxruntime",
+            onnxscript.evaluator.ORTEvaluator(),
+        ),
+    ],
+)
 class EagerModeTest(unittest.TestCase):
+    evaluator: onnxscript.evaluator.Evaluator
+
+    def setUp(self):
+        self.default_evaluator = onnxscript.evaluator.default()
+        onnxscript.evaluator.set_default(self.evaluator)
+
+    def tearDown(self):
+        onnxscript.evaluator.set_default(self.default_evaluator)
+
     def test_sequence_input(self):
         @script()
         def Concat(seq):
@@ -35,7 +62,32 @@ def add_with_alpha(this, other, alpha: float = 1.0):
     return op.Add(this, other)
 
 
+@parameterized.parameterized_class(
+    (
+        "name",
+        "evaluator",
+    ),
+    [
+        (
+            "reference_runtime",
+            onnxscript.evaluator.OnnxReferenceRuntimeEvaluator(),
+        ),
+        (
+            "onnxruntime",
+            onnxscript.evaluator.ORTEvaluator(),
+        ),
+    ],
+)
 class TestEagerModeArguments(unittest.TestCase):
+    evaluator: onnxscript.evaluator.Evaluator
+
+    def setUp(self):
+        self.default_evaluator = onnxscript.evaluator.default()
+        onnxscript.evaluator.set_default(self.evaluator)
+
+    def tearDown(self):
+        onnxscript.evaluator.set_default(self.default_evaluator)
+
     def test_op_some_input_by_kwargs(self):
         self.assertEqual(op.Add(1, B=2), 3)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #383

In this PR

- Implement onnx reference evaluator as an eager backend
- Refactor some code in evaluator

I tested locally by replacing the ort evaluator with the reference evaluator. Most tests passed and some tests failed. I did not want to add xfails or bring the change to the torchlib tests yet. Would be good to merge as-is so that we at least have an alternative backend implemented.

Fixes #209