### PR TITLE
Refine op(chunk) | feat(atenlib)

### DIFF
--- a/onnxscript/evaluator.py
+++ b/onnxscript/evaluator.py
@@ -316,10 +316,12 @@ def _rename_io(prefix, i, arg):
     return f"{prefix}{i}"
 
 
-def _compute_num_outputs(schema: onnx.defs.OpSchema, *args: Any, **kwargs: Any):
-    """Returns the number of outputs expected.
-    TODO: Use ONNX type inference to replace the special-case handling below.
-    """
+def compute_num_outputs(
+    schema: onnx.defs.OpSchema, args: Sequence[Any], kwargs: Mapping[str, Any]
+):
+    """Returns the number of outputs expected."""
+
+    # TODO: Use ONNX type inference to replace the special-case handling below.
     if schema.domain == "":
         if schema.name == "BatchNormalization":
             if not kwargs.get("training_mode", 0):
@@ -410,7 +412,7 @@ def _call_ort(
     # Construct ONNX model with a single op call:
     inputs = [_rename_io("input", i, arg) for i, arg in enumerate(args)]
 
-    num_outputs = _compute_num_outputs(schema, *args, **kwargs)
+    num_outputs = compute_num_outputs(schema, args, kwargs)
     outputs = [f"output{i}" for i in range(num_outputs)]
 
     node = onnx.helper.make_node(schema.name, inputs, outputs, domain=schema.domain, **kwargs)

--- a/onnxscript/evaluator.py
+++ b/onnxscript/evaluator.py
@@ -318,7 +318,7 @@ def _rename_io(prefix, i, arg):
 
 def compute_num_outputs(
     schema: onnx.defs.OpSchema, args: Sequence[Any], kwargs: Mapping[str, Any]
-):
+) -> int:
     """Returns the number of outputs expected."""
 
     # TODO: Use ONNX type inference to replace the special-case handling below.

--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -458,11 +458,12 @@ class TorchScriptGraph:
         onnx_attributes: Mapping[str, ValidArgumentType],
     ):
         # Compute outputs from the onnx_op op schema
+        n_outputs = evaluator.compute_num_outputs(onnx_op_schema, onnx_inputs, onnx_attributes)
         result = self._add_torchscript_op_call(
             f"onnx::{onnx_op_schema.name}",
             onnx_inputs,
             onnx_attributes,
-            n_outputs=len(onnx_op_schema.outputs),
+            n_outputs=n_outputs,
         )
 
         return result

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -1028,27 +1028,10 @@ def aten_choose_qparams_optimized(
 
 
 @torch_op("aten::chunk")
-def aten_chunk(self: TTensor, chunks: INT64, dim: int = 0) -> TTensor:
+def aten_chunk(self: TTensor, chunks: int, dim: int = 0) -> TTensor:
     """chunk(Tensor(a -> *) self, int chunks, int dim=0) -> Tensor(a)[]"""
 
-    neg_1 = op.Constant(value_ints=[-1])
-    # Get size of specified dim
-    self_shape = op.Shape(self)
-    dim_size = op.Gather(self_shape, dim, axis=0)
-    # Compute size/chunk to get the number of data in one chunk
-    num_per_chunk = op.Div(dim_size, chunks)
-    num_per_chunk = op.Cast(op.Mod(dim_size, chunks) > 0, to=INT64.dtype) + num_per_chunk  # type: ignore[operator]
-
-    # Compute real chunk number
-    num_chunk = op.Div(dim_size, num_per_chunk)
-    # Get something like [n, n, n, n, ...], total num_chunk
-    list_split = op.Expand(num_per_chunk, op.Reshape(num_chunk, neg_1))
-
-    remainder = op.Mod(dim_size, num_per_chunk)
-    if remainder > 0:  # type: ignore[operator]
-        # Append the remainder to the [n, n, n, n, ..., r]
-        list_split = op.Concat(list_split, op.Reshape(remainder, neg_1), axis=0)
-    return op.Split(self, list_split, axis=dim)
+    return op.Split(self, axis=dim, num_outputs=chunks)
 
 
 @torch_op("aten::clamp", trace_only=True)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -1028,7 +1028,7 @@ def aten_choose_qparams_optimized(
 
 
 @torch_op("aten::chunk")
-def aten_chunk(self: TTensor, chunks: int, dim: int = 0) -> TTensor:
+def aten_chunk(self: TTensor, chunks: int, dim: int = 0) -> Tuple[TTensor, ...]:
     """chunk(Tensor(a -> *) self, int chunks, int dim=0) -> Tensor(a)[]"""
 
     return op.Split(self, axis=dim, num_outputs=chunks)

--- a/onnxscript/tests/function_libs/torch_lib/ops_test.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test.py
@@ -193,8 +193,8 @@ def run_test_output_match(
                 torch_output = op(*inputs, **cpu_sample.kwargs)
 
                 reference_torch_outputs, _ = pytree.tree_flatten(torch_output)
-                if op.name.startswith("split"):
-                    # Hack for handling split
+                if op.name.startswith("split") or op.name.startswith("chunk"):
+                    # Hack for handling split and chunk
                     # Split returns a Sequence that should be treats as a single
                     # value. So we wrap it into a tuple.
                     # TODO(justinchuby): Find a more general solution

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -602,11 +602,6 @@ EXPECTED_SKIPS_OR_FAILS = (
         variant_name="partial_views",
         reason="ONNX doesn't have partial view for tensor",
     ),
-    xfail(
-        "index_select",
-        reason="fixme: ORT shape inference error on rank-0 input",
-        test_class_name="TestOutputConsistencyFullGraph",
-    ),
     xfail("logcumsumexp", reason="naive implementation not numerically stable"),
     xfail(
         "max",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -606,9 +606,9 @@ EXPECTED_SKIPS_OR_FAILS = (
         variant_name="partial_views",
         reason="ONNX doesn't have partial view for tensor",
     ),
-    xfail(
-        "chunk", reason="fixme: ORT error", test_class_name="TestOutputConsistencyFullGraph"
-    ),
+    # xfail(
+    #     "chunk", reason="fixme: ORT error", test_class_name="TestOutputConsistencyFullGraph"
+    # ),
     xfail(
         "index_select",
         reason="fixme: ORT shape inference error on rank-0 input",


### PR DESCRIPTION
The previous implementation is based on op17. For op18, using op.Split() by specified num_outputs attribute.

This change updates the graph builder to create a correct number of outputs for Split when num_outputs is specified.

Closes #622