### PR TITLE
Enable RUFF as a formatter | chore(lint)

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -29,35 +29,6 @@ init_command = [
     '--dry-run={{DRYRUN}}',
     '--requirement=requirements/lintrunner/requirements.txt',
 ]
-
-[[linter]]
-code = 'RUFF-FIX'
-include_patterns = [
-    '**/*.py',
-    '**/*.pyi',
-]
-exclude_patterns = [
-    'docs/**',
-    'onnxscript/tests/models/**',
-]
-command = [
-    'python',
-    '-m',
-    'lintrunner_adapters',
-    'run',
-    'ruff_fix_linter',
-    '--config=pyproject.toml',
-    '@{{PATHSFILE}}'
-]
-init_command = [
-    'python',
-    '-m',
-    'lintrunner_adapters',
-    'run',
-    'pip_init',
-    '--dry-run={{DRYRUN}}',
-    '--requirement=requirements/lintrunner/requirements.txt',
-]
 is_formatter = true
 
 [[linter]]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,4 +30,4 @@ torch>=1.13
 
 # Lint
 lintrunner>=0.10.7
-lintrunner_adapters>=0.7.0
+lintrunner_adapters>=0.8.0

--- a/requirements/lintrunner/requirements.txt
+++ b/requirements/lintrunner/requirements.txt
@@ -1,4 +1,5 @@
 # This file is auto updated by dependabot
+lintrunner-adapters>=0.8.0
 # RUFF, RUFF-FIX
 ruff==0.0.262
 # MYPY


### PR DESCRIPTION
RUFF can now format since lintrunner-adapters v0.8. Removed the RUFF-FIX linter