### PR TITLE
Add an environment variable to disable ort session cache if necessary | fix(atenlib)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -66,6 +66,7 @@ jobs:
       - name: Run tests
         run: nox -t ${{ matrix.nox-tag }} --forcecolor -- -v --cov=onnxscript --cov-report=xml --cov-append --cov-branch -n=auto
         env:
+          CACHE_ORT_SESSION: "${{ matrix.os == 'windows-latest' && '0' || '1' }}"
           CATCH_ORT_SEGFAULT: "${{ matrix.os == 'ubuntu-latest' && '1' || '0' }}"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Run tests
         run: nox -t ${{ matrix.nox-tag }} --forcecolor -- -v --cov=onnxscript --cov-report=xml --cov-append --cov-branch -n=auto
         env:
-          CACHE_ORT_SESSION: "${{ matrix.os == 'windows-latest' && '0' || '1' }}"
+          CACHE_ORT_SESSIONS: "${{ matrix.os == 'windows-latest' && '0' || '1' }}"
           CATCH_ORT_SEGFAULT: "${{ matrix.os == 'ubuntu-latest' && '1' || '0' }}"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/onnxscript/_internal/feature_switch.py
+++ b/onnxscript/_internal/feature_switch.py
@@ -1,0 +1,10 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Switches to determine if the corresponding feature of onnxscript is enabled or not."""
+
+import os
+
+# By default: Enable
+cache_ort_session = os.environ.get("CACHE_ORT_SESSION", "1")

--- a/onnxscript/_internal/feature_switch.py
+++ b/onnxscript/_internal/feature_switch.py
@@ -7,4 +7,4 @@
 import os
 
 # By default: Enable
-cache_ort_session = os.environ.get("CACHE_ORT_SESSION", "1")
+CACHE_ORT_SESSIONS: bool = os.getenv("CACHE_ORT_SESSIONS", "1") != "0"

--- a/onnxscript/evaluator.py
+++ b/onnxscript/evaluator.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import abc
 import contextlib
-import os
 import pprint
 import typing
 from typing import (
@@ -28,7 +27,7 @@ import onnx.helper
 from typing_extensions import TypeAlias
 
 from onnxscript import autocast, irbuilder, onnx_opset, tensor, utils, values
-from onnxscript._internal import param_manipulation
+from onnxscript._internal import feature_switch, param_manipulation
 
 if typing.TYPE_CHECKING:
     import onnxruntime as ort
@@ -347,8 +346,6 @@ def _compute_num_outputs(schema: onnx.defs.OpSchema, *args: Any, **kwargs: Any):
 
 
 _cache_models: dict[Any, ort.InferenceSession] = {}
-cache_ort_session = os.environ.get("CACHE_ORT_SESSION", "1")
-
 
 def _cache_(model, providers):
     # Delay import onnxruntime so that onnxscript can be used without
@@ -356,7 +353,7 @@ def _cache_(model, providers):
     import onnxruntime as ort  # pylint: disable=import-outside-toplevel
 
     serialized = model.SerializeToString()
-    if cache_ort_session == "0":
+    if feature_switch.cache_ort_session == "0":
         return ort.InferenceSession(serialized, providers=providers)
 
     key = serialized, tuple(providers)

--- a/onnxscript/evaluator.py
+++ b/onnxscript/evaluator.py
@@ -349,6 +349,7 @@ def _compute_num_outputs(schema: onnx.defs.OpSchema, *args: Any, **kwargs: Any):
 _cache_models: dict[Any, ort.InferenceSession] = {}
 cache_ort_session = os.environ.get("CACHE_ORT_SESSION", "1")
 
+
 def _cache_(model, providers):
     # Delay import onnxruntime so that onnxscript can be used without
     # installing onnxruntime.


### PR DESCRIPTION
Try to disable ort session cache to avoid Windows memory exception caused by CI tests.
Fix #614 