### PR TITLE
Create the OpLike protocol and refactor Op | feat(values)

### DIFF
--- a/onnxscript/irbuilder.py
+++ b/onnxscript/irbuilder.py
@@ -202,7 +202,7 @@ class IRStmt:
 
         args = _format(self.args, "(", ", ", ")", _opt_var_to_str)
         domain = self.callee.opset.domain
-        opname = self.callee.opname
+        opname = self.callee.name
         callee = f"{domain}.{opname}" if (domain != "") else opname
         return f"{lhs} = {callee} {attrs}{args}"
 
@@ -212,7 +212,7 @@ class IRStmt:
 
     def to_node_proto(self, node_name: str) -> onnx.NodeProto:
         n = helper.make_node(
-            self.callee.opname,
+            self.callee.name,
             [_opt_var_to_str(x) for x in self.args],
             [str(x) for x in self.result],
             domain=self.callee.opset.domain,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #692
* #674
* #698

## Changes

- Creates the `OpLike` protocol that defines common attributes and methods for `Op`, `OnnxFunction` and `TraceOnlyFunction` so we can assume a common interface.
- Implement `param_schemas` for `TraceOnlyFunction`
- Refactor `param_schemas` to extract common logic.
- Removes `is_single_op` from `Op` because it is unused.

Signed-off-by: Justin Chu <justinchu@microsoft.com>