### PR TITLE
Skip incompatible dtypes in op_test using OpSchema | test(torchlib)

### DIFF
--- a/onnxscript/tests/function_libs/torch_lib/ops_test.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test.py
@@ -162,6 +162,11 @@ def run_test_output_match(
     # An example is nn.functional.upsample_nearest2d, which has a different signature
     # than the aten operator upsample_nearest2d
     onnx_function, input_wrangler = _split_function_and_wrangler(onnx_function_and_wrangler)
+    if not ops_test_common.dtype_op_schema_compatible(dtype, onnx_function.opschema):
+        test_suite.skipTest(
+            f"dtype '{dtype}' is not supported by the op '{op.name}'. "
+            f"Type constraints: {onnx_function.opschema.type_constraints}"
+        )
 
     for i, cpu_sample in enumerate(samples):
         inputs = (cpu_sample.input, *cpu_sample.args)

--- a/onnxscript/tests/function_libs/torch_lib/ops_test.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test.py
@@ -165,7 +165,7 @@ def run_test_output_match(
     if not ops_test_common.dtype_op_schema_compatible(dtype, onnx_function.opschema):
         test_suite.skipTest(
             f"dtype '{dtype}' is not supported by the op '{op.name}'. "
-            f"Type constraints: {onnx_function.opschema.type_constraints}"
+            f"Type constraints: {onnx_function.op_schema.type_constraints}"
         )
 
     for i, cpu_sample in enumerate(samples):

--- a/onnxscript/tests/function_libs/torch_lib/ops_test.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test.py
@@ -162,7 +162,7 @@ def run_test_output_match(
     # An example is nn.functional.upsample_nearest2d, which has a different signature
     # than the aten operator upsample_nearest2d
     onnx_function, input_wrangler = _split_function_and_wrangler(onnx_function_and_wrangler)
-    if not ops_test_common.dtype_op_schema_compatible(dtype, onnx_function.opschema):
+    if not ops_test_common.dtype_op_schema_compatible(dtype, onnx_function.op_schema):
         test_suite.skipTest(
             f"dtype '{dtype}' is not supported by the op '{op.name}'. "
             f"Type constraints: {onnx_function.op_schema.type_constraints}"

--- a/onnxscript/tests/function_libs/torch_lib/ops_test.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test.py
@@ -256,6 +256,10 @@ def run_test_output_match(
                         raise
 
 
+@unittest.skipIf(
+    version_utils.onnx_older_than("1.14"),
+    "OpSchema not available for functions before ONNX 1.14",
+)
 class TestOutputConsistencyEager(unittest.TestCase):
     """Test output consistency between the ONNX op run with ONNX eager mode and PyTorch eager mode.
 
@@ -284,6 +288,10 @@ class TestOutputConsistencyEager(unittest.TestCase):
         run_test_output_match(self, device, dtype, op, ops_test_common.eager_executor)
 
 
+@unittest.skipIf(
+    version_utils.onnx_older_than("1.14"),
+    "OpSchema not available for functions before ONNX 1.14",
+)
 class TestOutputConsistencyFullGraph(unittest.TestCase):
     """Test output consistency between exported ONNX op run as a graph and PyTorch eager mode.
 

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_common.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_common.py
@@ -397,12 +397,13 @@ def dtype_op_schema_compatible(dtype: torch.dtype, schema: onnx.defs.OpSchema) -
         # has the first input as `size`, which is an integer, but it can support
         # any dtype.
         return True
-    first_input_dtype = schema.inputs[0].type_str
-    compatible_types = next(
-        (x for x in schema.type_constraints if x.type_param_str == first_input_dtype), None
+    first_input_type_name = schema.inputs[0].type_str
+    # Find the type constraint for the first input by matching the parameter name
+    first_input_type_constraint = next(
+        (x for x in schema.type_constraints if x.type_param_str == first_input_type_name), None
     )
-    assert compatible_types is not None
-    allowed_type_strs = compatible_types.allowed_type_strs
+    assert first_input_type_constraint is not None
+    allowed_type_strs = first_input_type_constraint.allowed_type_strs
     return TORCH_DTYPE_TO_ONNX_STRING[dtype] in allowed_type_strs
 
 

--- a/requirements/ci/requirements-pytorch-nightly.txt
+++ b/requirements/ci/requirements-pytorch-nightly.txt
@@ -1,3 +1,3 @@
 --index-url=https://download.pytorch.org/whl/nightly/cpu
 --pre
-torch==2.1.0.dev20230418
+torch


### PR DESCRIPTION
This requires ONNX 1.14. I am skipping the op test for ONNX<1.14 altogether.

I tested locally to make sure no float32 test is skipped with this mechanism, and that it skips properly according to the type annotation.

Currently no new dtypes are enabled because there are too many failures.

Requires 
- #701 
- #698