### PR TITLE
Update test pipelines | chore(ci)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,7 +28,6 @@ jobs:
           - py310
           - py39
           - py38
-          - py310-experimental
           - py310-torch-nightly
           - py310-onnx-weekly
           - py310-ort-nightly
@@ -42,9 +41,6 @@ jobs:
           - name: py38
             python-version: "3.8"
             nox-tag: test
-          - name: py310-experimental
-            python-version: "3.10"
-            nox-tag: test-function-experiment
           - name: py310-torch-nightly
             python-version: "3.10"
             nox-tag: test-torch-nightly

--- a/noxfile.py
+++ b/noxfile.py
@@ -61,44 +61,14 @@ def test(session):
     session.run("pytest", "docs/test", *session.posargs)
 
 
-@nox.session(tags=["test-function-experiment"])
-def test_onnx_func_expe(session):
-    """Test with onnx function experiment builds."""
-    # TODO(justinchuby): Remove when test-ort-nightly contains this change.
-    session.install(
-        *COMMON_TEST_DEPENDENCIES,
-        PYTORCH,
-    )
-    # Install ONNX and ORT with experimental ONNX function support
-    session.install(
-        "-f",
-        "https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime-function-experiment.html",
-        "--pre",
-        "ort-function-experiment-nightly",
-    )
-
-    session.install("-r", "requirements/ci/requirements-onnx-weekly.txt")
-    session.install(".", "--no-deps")
-    session.run("pip", "list")
-    # Ignore ops_correctness_test because this version of ORT does not contain the
-    # latest fixes and may fail some tests in the torch op tests.
-    session.run(
-        "pytest",
-        "onnxscript",
-        "--ignore=onnxscript/tests/function_libs/torch_lib/ops_test.py",
-        *session.posargs,
-    )
-    session.run("pytest", "docs/test", *session.posargs)
-
-
 @nox.session(tags=["test-torch-nightly"])
 def test_torch_nightly(session):
     """Test with PyTorch nightly (preview) build."""
     session.install(
         *COMMON_TEST_DEPENDENCIES,
-        ONNX,
         ONNX_RUNTIME,
     )
+    session.install("-r", "requirements/ci/requirements-onnx-weekly.txt")
     session.install("-r", "requirements/ci/requirements-pytorch-nightly.txt")
     session.install(".", "--no-deps")
     session.run("pip", "list")


### PR DESCRIPTION
- Updated the torch-nightly action to also use onnx-weekly, so we can run op tests with torch-nightly.
- Remove the function experiment test because microsoft/onnxruntime#14929 was merged