### PR TITLE
Disable `py/cyclic-import` in codeql

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,3 +1,7 @@
 query-filters:
 - exclude:
     id: py/import-and-import-from
+    # Module level cyclic import, although should be avoided, is not a problem
+    # from the perspective of functionality. Follow advice on 
+    # https://codeql.github.com/codeql-query-help/python/py-cyclic-import/ to break the cycle if needed.
+    id: py/cyclic-import

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,6 +3,6 @@ query-filters:
     id: py/import-and-import-from
 - exclude:
     # Module level cyclic import, although should be avoided, is not a problem
-    # from the perspective of functionality. Follow advice on 
+    # from the perspective of functionality. Follow advice on
     # https://codeql.github.com/codeql-query-help/python/py-cyclic-import/ to break the cycle if needed.
     id: py/cyclic-import

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,6 +1,7 @@
 query-filters:
 - exclude:
     id: py/import-and-import-from
+- exclude:
     # Module level cyclic import, although should be avoided, is not a problem
     # from the perspective of functionality. Follow advice on 
     # https://codeql.github.com/codeql-query-help/python/py-cyclic-import/ to break the cycle if needed.


### PR DESCRIPTION
Module level cyclic import, although should be avoided if possible, is not a problem from the perspective of functionality. It is more preferable than hiding imports in functions from a readability and maintainability point of view.