### PR TITLE
Refactor Overloads | feat(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -44,7 +44,7 @@ def aten_abs(self: TReal) -> TReal:
     return op.Abs(self)
 
 
-@torch_op("aten::abs", overload=True)
+@torch_op("aten::abs")
 def aten_abs_complex(self: TReal) -> TReal:
     """abs(Tensor self) -> Tensor"""
     # self_real = self[..., 0]
@@ -205,9 +205,9 @@ def aten_all(self: TTensor) -> BOOL:
     return result
 
 
-@torch_op("aten::all", overload=True)
+@torch_op("aten::all.dim")
 def aten_all_dim(self: TTensor, dim: int, keepdim: bool = False) -> BOOL:
-    """all(Tensor self) -> Tensor"""
+    """all.dim(Tensor self, int dim, bool keepdim=False) -> Tensor"""
 
     if op.Size(op.Shape(self)) == 0:
         result = op.Cast(self, to=BOOL.dtype)
@@ -305,9 +305,9 @@ def aten_any(
     return result
 
 
-@torch_op("aten::any", overload=True)
+@torch_op("aten::any.dim")
 def aten_any_dim(self: TTensor, dim: int, keepdim: bool = True) -> BOOL:
-    """any(Tensor self) -> Tensor"""
+    """any.dim(Tensor self, int dim, bool keepdim=False) -> Tensor"""
 
     self_rank = op.Size(op.Shape(self))
     if self_rank == 0:
@@ -364,7 +364,7 @@ def aten_arange(end: Union[DOUBLE, FLOAT, INT16, INT32, INT64], dtype: int = -1)
     return result
 
 
-@torch_op("aten::arange", overload=True, trace_only=True)
+@torch_op("aten::arange.start", trace_only=True)
 def aten_arange_start(
     start: TRealUnlessFloat16OrInt8, end: TRealUnlessFloat16OrInt8, dtype: int = -1
 ) -> TensorType:
@@ -394,7 +394,7 @@ def aten_arange_start(
     return result
 
 
-@torch_op("aten::arange", overload=True, trace_only=True)
+@torch_op("aten::arange.start_step", trace_only=True)
 def aten_arange_start_step(
     start: TRealUnlessFloat16OrInt8,
     end: TRealUnlessFloat16OrInt8,
@@ -478,7 +478,7 @@ def aten_argmax(self: TReal, dim: Optional[int] = None, keepdim: bool = False) -
     return aten_argmax_dim(self, dim=dim, keepdim=keepdim)
 
 
-@torch_op("aten::argmax", overload=True)
+@torch_op("aten::argmax")
 def aten_argmax_dim(self: TReal, dim: int, keepdim: bool = False) -> TReal:
     """argmax(Tensor self, int? dim=None, bool keepdim=False) -> Tensor"""
 
@@ -503,7 +503,7 @@ def aten_argmin(self: TReal, dim: Optional[int] = None, keepdim: bool = False) -
     return aten_argmin_dim(self, dim=dim, keepdim=keepdim)
 
 
-@torch_op("aten::argmin", overload=True)
+@torch_op("aten::argmin")
 def aten_argmin_dim(self: TReal, dim: int, keepdim: bool = False) -> TReal:
     """argmin(Tensor self, int? dim=None, bool keepdim=False) -> Tensor"""
 
@@ -888,7 +888,7 @@ def aten_bitwise_not(self: TInt) -> TInt:
     return op.BitwiseNot(self)
 
 
-@torch_op("aten::bitwise_not", overload=True)
+@torch_op("aten::bitwise_not")
 def aten_bitwise_not_bool(self: BOOL) -> BOOL:
     """bitwise_not(Tensor self) -> Tensor"""
     return op.Not(self)
@@ -2877,7 +2877,7 @@ def aten_index_put(
     return result
 
 
-@torch_op("aten::index_put_bool", overload=True)
+@torch_op("aten::index_put")
 def aten_index_put_bool(
     self: TReal,
     indices: Sequence[BOOL],
@@ -3703,8 +3703,9 @@ def aten_min(self: TReal) -> TReal:
     return op.ReduceMin(self, keepdims=0)
 
 
-@torch_op("aten::min", overload=True)
+@torch_op("aten::min.dim")
 def aten_min_dim(self: TReal, dim: int, keepdim: bool = False) -> Tuple[TReal, TInt]:
+    """min.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)"""
     if op.Size(op.Shape(self)) == 0:
         result = self
         indices = op.Constant(value_int=0)
@@ -3716,8 +3717,9 @@ def aten_min_dim(self: TReal, dim: int, keepdim: bool = False) -> Tuple[TReal, T
     return result, indices
 
 
-@torch_op("aten::min", overload=True)
+@torch_op("aten::min.other")
 def aten_min_other(self: TReal, other: TReal) -> TReal:
+    """min.other(Tensor self, Tensor other) -> Tensor"""
     return op.Min(self, other)
 
 
@@ -4073,7 +4075,7 @@ def aten_mul(self: TReal, other: TReal) -> TReal:
     return op.Mul(self, other)
 
 
-@torch_op("aten::mul", overload=True)
+@torch_op("aten::mul")
 def aten_mul_bool(self: BOOL, other: BOOL) -> BOOL:
     """ONNX Mul doesn't support Boolean, so use And as an equivalent operator."""
 
@@ -4511,7 +4513,7 @@ def aten_new_empty(self: TTensor, size: INT64) -> TTensor:
     return op.CastLike(result, self)
 
 
-@torch_op("aten::new_empty", overload=True)
+@torch_op("aten::new_empty")
 def aten_new_empty_dtype(
     self: TTensor,  # pylint: disable=unused-argument
     size: INT64,
@@ -4537,7 +4539,7 @@ def aten_new_empty_strided(
     return op.CastLike(zero, self)
 
 
-@torch_op("aten::new_empty_strided", overload=True)
+@torch_op("aten::new_empty_strided")
 def aten_new_empty_strided_dtype(
     self: TTensor,  # pylint: disable=unused-argument
     size: INT64,
@@ -4559,7 +4561,7 @@ def aten_new_full(self: TTensor, size: INT64, fill_value: TTensor) -> TTensor:
     return op.Expand(fill_value, size)
 
 
-@torch_op("aten::new_full", overload=True)
+@torch_op("aten::new_full")
 def aten_new_full_dtype(
     self: TTensor,  # pylint: disable=unused-argument
     size: INT64,
@@ -4581,7 +4583,7 @@ def aten_new_ones(self: TReal, size: INT64) -> TReal:  # pylint: disable=unused-
     return op.CastLike(result, self)
 
 
-@torch_op("aten::new_ones", overload=True)
+@torch_op("aten::new_ones")
 def aten_new_ones_dtype(
     self: TReal,  # pylint: disable=unused-argument
     size: INT64,
@@ -4600,7 +4602,7 @@ def aten_new_zeros(self: TReal, size: INT64) -> TReal:
     return op.CastLike(result, self)
 
 
-@torch_op("aten::new_zeros", overload=True)
+@torch_op("aten::new_zeros")
 def aten_new_zeros_dtype(
     self: TReal,  # pylint: disable=unused-argument
     size: INT64,
@@ -5169,7 +5171,7 @@ def aten_remainder(self: TFloatOrBFloat16, other: TFloatOrBFloat16) -> TFloatOrB
     return op.Sub(self, op.Mul(rounded_quotient, other))
 
 
-@torch_op("aten::remainder", overload=True)
+@torch_op("aten::remainder")
 def aten_remainder_int(self: TInt, other: TInt) -> TInt:
     """remainder.Tensor(Tensor self, Tensor other) -> Tensor"""
 
@@ -5403,7 +5405,7 @@ def aten_scatter_reduce(
     return _aten_scatter_reduce_onnx(self, index, src, dim, onnx_reduce)
 
 
-@torch_op("aten::scatter_reduce", overload=True)
+@torch_op("aten::scatter_reduce", private=True)
 def _aten_scatter_reduce_onnx(
     self: TReal,
     index: TInt,
@@ -5719,7 +5721,7 @@ def aten_squeeze(self: TTensor) -> TTensor:
     return op.Squeeze(self)
 
 
-@torch_op("aten::squeeze", overload=True)
+@torch_op("aten::squeeze.dim")
 def aten_squeeze_dim(self: TTensor, dim: int) -> TTensor:
     result = self
     if op.Size(op.Shape(self)) > 0:  # type: ignore[operator]
@@ -6334,7 +6336,7 @@ def aten_var_mean(self: TReal, unbiased: bool = True) -> Tuple[TReal, TReal]:
     return _aten_var_mean_onnx(self, correction=float(unbiased), keepdim=False)
 
 
-@torch_op("aten::var_mean", overload=True, trace_only=True)
+@torch_op("aten::var_mean.dim", trace_only=True)
 def aten_var_mean_dim(
     self: TReal, dim: Optional[int], unbiased: bool = True, keepdim: bool = False
 ) -> Tuple[TReal, TReal]:
@@ -6351,7 +6353,7 @@ def aten_var_mean_dim(
     )
 
 
-@torch_op("aten::var_mean", overload=True, trace_only=True)
+@torch_op("aten::var_mean.correction", trace_only=True)
 def aten_var_mean_correction(
     self: TReal,
     dim: Optional[int] = None,
@@ -6394,7 +6396,7 @@ def _aten_var_mean_onnx(
     return var, mean
 
 
-@torch_op("aten::var_mean", private=True)
+@torch_op("aten::var_mean.dim", private=True)
 def _aten_var_mean_dim_onnx(
     self: TReal, dim: INT64, correction: float, keepdim: bool = False
 ) -> Tuple[TReal, TReal]:

--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -1126,7 +1126,7 @@ def aten_nll_loss(
     return result
 
 
-@torch_op("aten::nll_loss", overload=True)
+@torch_op("aten::nll_loss")
 def aten_nll_loss_weight(
     self: TFloat,
     target: INT64,
@@ -1548,7 +1548,7 @@ def aten_scaled_dot_product_attention(
     )
 
 
-@torch_op("aten::scaled_dot_product_attention", trace_only=True, overload=True)
+@torch_op("aten::scaled_dot_product_attention", trace_only=True)
 def aten_scaled_dot_product_attention_bool_mask(
     query: TFloat,
     key: TFloat,

--- a/onnxscript/function_libs/torch_lib/registration.py
+++ b/onnxscript/function_libs/torch_lib/registration.py
@@ -13,14 +13,12 @@ class OverloadedFunction:
 
     Attributes:
         name: Name of the op. E.g. "aten::add".
-        default: Default function.
-        overloads: Overloads.
+        overloads: Overloads function.
         privates: Private functions not exposed to users.
     """
 
     def __init__(self, name: str):
         self.name = name
-        self.default: Optional[Any] = None
         self.overloads: list[Any] = []
         self.privates: list[Any] = []
 
@@ -31,17 +29,13 @@ class Registry:
     def __init__(self):
         self._registry: dict[str, OverloadedFunction] = {}
 
-    def register(
-        self, func: Any, name: str, *, overload: bool = False, private: bool = False
-    ) -> None:
+    def register(self, func: Any, name: str, *, private: bool = False) -> None:
         """Register a function."""
 
-        if overload:
-            self._registry.setdefault(name, OverloadedFunction(name)).overloads.append(func)
-        elif private:
+        if private:
             self._registry.setdefault(name, OverloadedFunction(name)).privates.append(func)
         else:
-            self._registry.setdefault(name, OverloadedFunction(name)).default = func
+            self._registry.setdefault(name, OverloadedFunction(name)).overloads.append(func)
 
     def __getitem__(self, name):
         return self._registry[name]
@@ -63,7 +57,6 @@ default_registry = Registry()
 def torch_op(
     name,
     *,
-    overload: bool = False,
     registry: Optional[Registry] = None,
     trace_only: bool = False,
     private: bool = False,
@@ -72,7 +65,6 @@ def torch_op(
 
     Args:
         name: ATen name of the function. E.g. "aten::add".
-        overload: Whether the function is an overload (not default).
         registry: Registry to register the function to. If None, the default registry is used.
         trace_only: Whether the function should only be traced and not compiled.
         private: Whether the function is private (not directly exposed). It should
@@ -95,7 +87,7 @@ def torch_op(
             processed_func = onnxscript.script(opset=custom_opset)(func)
 
         assert registry is not None
-        registry.register(processed_func, name, overload=overload, private=private)
+        registry.register(processed_func, name, private=private)
         return processed_func
 
     return wrapper


### PR DESCRIPTION
After this PR, overloads is deleted, and when we register a **aten overload**, we use it's specific name: `aten::mean.dim`. If it's an **onnx overload** created regarding ONNXFunction limitations, such as `aten_bitwise_not_bool`, we can simply register it under the same aten name. The dispatcher in converter side is expected to find the proper one with op schema.
