### PR TITLE
Model local function building | feat(graph_building)

### DIFF
--- a/onnxscript/function_libs/torch_lib/graph_building_test.py
+++ b/onnxscript/function_libs/torch_lib/graph_building_test.py
@@ -78,6 +78,46 @@ class TestTorchScriptTracingEvaluator(unittest.TestCase):
         expected = expected_model.to_model_proto()
         onnxscript.testing.assert_isomorphic(traced, expected)
 
+    def test_model_local_function_constructed_by_traced_graph_is_same_as_compiled_graph(
+        self,
+    ):
+        aten_abs = ops.core.aten_abs
+        aten_relu = ops.nn.aten_relu
+
+        inner_graph = graph_building.TorchScriptGraph()
+        inner_tracer = graph_building.TorchScriptTracingEvaluator(inner_graph)
+
+        x_tensor = torch.ones((1, 2, 3), dtype=torch.float32)
+        x = inner_graph.add_input("x", x_tensor.shape, x_tensor.dtype)
+        with evaluator.default_as(inner_tracer):
+            output = aten_abs(x)
+        inner_graph.register_outputs(output)
+
+        outer_graph = graph_building.TorchScriptGraph()
+        outer_tracer = graph_building.TorchScriptTracingEvaluator(outer_graph)
+        x_tensor = torch.ones((1, 2, 3), dtype=torch.float32)
+        x = outer_graph.add_input("x", x_tensor.shape, x_tensor.dtype)
+        with evaluator.default_as(outer_tracer):
+            output = aten_relu(x)
+        output = outer_graph.add_module_call("inner", inner_graph, (output,))
+        outer_graph.register_outputs(output)
+        traced = outer_graph.to_model_proto(self.opset_version)
+
+        @onnxscript.script(
+            opset=onnxscript.values.Opset("torch_export", 1),
+            default_opset=op,
+        )
+        def inner(x: FLOAT[1, 2, 3]):
+            return aten_abs(x)
+
+        @onnxscript.script(default_opset=op)
+        def outer(x: FLOAT[1, 2, 3]):
+            output = aten_relu(x)
+            return inner(output)
+
+        expected = outer.to_model_proto()
+        onnxscript.testing.assert_isomorphic(traced, expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Extend `TorchScriptGraph` to allow the concept of nested graphs. When serializing,
the root graph serializes to `ModelProto`, while all sub graphs are serialized as `FunctionProto`.