### PR TITLE
RefineOpForFP16(2)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -3171,9 +3171,10 @@ def aten_isfinite(self: TFloatOrBFloat16) -> BOOL:
 
 
 @torch_op("aten::isinf")
-def aten_isinf(self: Union[FLOAT, DOUBLE]) -> BOOL:
+def aten_isinf(self: TFloatOrBFloat16) -> BOOL:
     """isinf(Tensor self) -> Tensor"""
 
+    self = op.Cast(self, to=FLOAT.dtype)  # Make this function support all float types
     return op.IsInf(self)
 
 
@@ -3181,20 +3182,23 @@ def aten_isinf(self: Union[FLOAT, DOUBLE]) -> BOOL:
 def aten_isnan(self: TFloatOrBFloat16) -> BOOL:
     """isnan(Tensor self) -> Tensor"""
 
+    self = op.Cast(self, to=FLOAT.dtype)  # Make this function support all float types
     return op.IsNaN(self)
 
 
 @torch_op("aten::isneginf")
-def aten_isneginf(self: TReal) -> BOOL:
+def aten_isneginf(self: TFloatOrBFloat16) -> BOOL:
     """isneginf(Tensor self) -> Tensor"""
 
+    self = op.Cast(self, to=FLOAT.dtype)  # Make this function support all float types
     return op.And(op.Less(self, 0), op.IsInf(self))
 
 
 @torch_op("aten::isposinf")
-def aten_isposinf(self: TReal) -> BOOL:
+def aten_isposinf(self: TFloatOrBFloat16) -> BOOL:
     """isposinf(Tensor self) -> Tensor"""
 
+    self = op.Cast(self, to=FLOAT.dtype)  # Make this function support all float types
     return op.And(op.Greater(self, 0), op.IsInf(self))
 
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -3164,7 +3164,8 @@ def aten_isclose(
 def aten_isfinite(self: TFloatOrBFloat16) -> BOOL:
     """isfinite(Tensor self) -> Tensor"""
 
-    self = op.Cast(self, to=FLOAT.dtype)  # Make this function support all real types
+    # Added Cast inside the function so it can support all real dtypes naturally
+    self = op.Cast(self, to=FLOAT.dtype)
     not_inf = op.Not(op.IsInf(self))  # op.IsInf() only support FLOAT and DOUBLE
     not_nan = op.Not(op.IsNaN(self))  # TODO: The test case doesnt cover this condition
     return op.And(not_inf, not_nan)
@@ -3189,7 +3190,8 @@ def aten_isnan(self: TFloatOrBFloat16) -> BOOL:
 def aten_isneginf(self: TFloatOrBFloat16) -> BOOL:
     """isneginf(Tensor self) -> Tensor"""
 
-    self = op.Cast(self, to=FLOAT.dtype)  # Make this function support all float types
+    # Added Cast inside the function so it can support all real dtypes naturally
+    self = op.Cast(self, to=FLOAT.dtype)
     return op.And(op.Less(self, 0), op.IsInf(self))
 
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -3182,7 +3182,6 @@ def aten_isinf(self: TFloatOrBFloat16) -> BOOL:
 def aten_isnan(self: TFloatOrBFloat16) -> BOOL:
     """isnan(Tensor self) -> Tensor"""
 
-    self = op.Cast(self, to=FLOAT.dtype)  # Make this function support all float types
     return op.IsNaN(self)
 
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -3175,7 +3175,8 @@ def aten_isfinite(self: TFloatOrBFloat16) -> BOOL:
 def aten_isinf(self: TFloatOrBFloat16) -> BOOL:
     """isinf(Tensor self) -> Tensor"""
 
-    self = op.Cast(self, to=FLOAT.dtype)  # Make this function support all float types
+    # Added Cast inside the function so it can support all real dtypes naturally
+    self = op.Cast(self, to=FLOAT.dtype)
     return op.IsInf(self)
 
 
@@ -3199,7 +3200,8 @@ def aten_isneginf(self: TFloatOrBFloat16) -> BOOL:
 def aten_isposinf(self: TFloatOrBFloat16) -> BOOL:
     """isposinf(Tensor self) -> Tensor"""
 
-    self = op.Cast(self, to=FLOAT.dtype)  # Make this function support all float types
+    # Added Cast inside the function so it can support all real dtypes naturally
+    self = op.Cast(self, to=FLOAT.dtype)
     return op.And(op.Greater(self, 0), op.IsInf(self))
 
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -3154,7 +3154,8 @@ def aten_isclose(
 def aten_isfinite(self: TFloatOrBFloat16) -> BOOL:
     """isfinite(Tensor self) -> Tensor"""
 
-    not_inf = op.Not(op.IsInf(self))
+    self = op.Cast(self, to=FLOAT.dtype)  # Make this function support all real types
+    not_inf = op.Not(op.IsInf(self))  # op.IsInf() only support FLOAT and DOUBLE
     not_nan = op.Not(op.IsNaN(self))  # TODO: The test case doesnt cover this condition
     return op.And(not_inf, not_nan)
 

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1658,7 +1658,7 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     "log10": (
         torch.float32,
         # windows-latest, py310-torch-nightly
-        # torch.float16,  # FIXME: op_tupe: Div, node name: n3) B has inconsistent type tensor(float)
+        torch.float16,
     ),
     "log1p": (
         torch.float32,
@@ -1671,7 +1671,7 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     "log2": (
         torch.float32,
         # windows-latest, py310-torch-nightly
-        # torch.float16,  # FIXME: op_tupe: Div, node name: n3) B has inconsistent type tensor(float)
+        torch.float16,
     ),
     "logaddexp": (
         torch.float32,
@@ -1759,7 +1759,7 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "native_layer_norm": (
         torch.float32,
-        # torch.float16,
+        torch.float16,
     ),
     # "native_dropout": core_ops.aten_native_dropout,  # native_dropout is not in OPS_DB
     "ne": (
@@ -1882,7 +1882,7 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     "nn.functional.logsigmoid": (
         torch.float32,
         # windows-latest, py310-torch-nightly
-        # torch.float16,  # FIXME: Tensor-likes are not close
+        torch.float16,
     ),
     "nn.functional.max_pool2d": (
         torch.float32,
@@ -1915,11 +1915,11 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     "nn.functional.relu": (
         torch.float32,
         # ubuntu-latest, py310-torch-nightly
-        # torch.float16,  # FIXME: Unable to create ort InferenceSession for .Div op
+        torch.float16,
     ),
     "nn.functional.relu6": (
         torch.float32,
-        # torch.float16,  # FIXME: Unable to create ort InferenceSession for .Div op
+        torch.float16,
     ),
     "nn.functional.replication_pad2d": (
         torch.float32,
@@ -1967,7 +1967,7 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "ones_like": (
         torch.float32,
-        # torch.float16,  # FIXME" ORT inference failed
+        torch.float16,
     ),
     "permute": (
         torch.float32,
@@ -2061,11 +2061,11 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "split_with_sizes": (
         torch.float32,
-        # torch.float16,  # FIXME: ORT failed
+        torch.float16,  # FIXME: ORT failed
     ),
     "split": (
         torch.float32,
-        # torch.float16,  # ORT failed
+        torch.float16,  # ORT failed
     ),
     "sqrt": (
         torch.float32,
@@ -2138,15 +2138,15 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "var_mean": (
         torch.float32,
-        # torch.float16,
+        torch.float16,
     ),
     "var_mean_dim": (
         torch.float32,
-        # torch.float16,
+        torch.float16,
     ),
     "var_mean_correction": (
         torch.float32,
-        # torch.float16,
+        torch.float16,
     ),
     "view": (
         torch.float32,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1746,7 +1746,7 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "native_group_norm": (
         torch.float32,
-        torch.float16,  # ORT not implemented
+        # torch.float16,  # "GroupNormKernelImpl" not implemented for 'Half' in nightly and weekly
     ),
     "native_layer_norm": (
         torch.float32,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1658,7 +1658,7 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     "log10": (
         torch.float32,
         # py310-torch-nightly,Shape inference error(s): (op_type:Div, node name: n3): B has inconsistent type tensor(float)
-        torch.float16,
+        # torch.float16,
     ),
     "log1p": (
         torch.float32,
@@ -1915,11 +1915,12 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     "nn.functional.relu": (
         torch.float32,
         # ubuntu-latest, py310-torch-nightly
-        torch.float16,
+        # Unable to create onnxruntime InferenceSession for executing .Div op with onnx model
+        # torch.float16,
     ),
     "nn.functional.relu6": (
         torch.float32,
-        # py310-torch-nightly, FullGraph, AssertionError in ORT
+        # macos-latest, py310-torch-nightly, FullGraph, AssertionError in ORT
         # torch.float16,
     ),
     "nn.functional.replication_pad2d": (
@@ -2139,7 +2140,8 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "var_mean": (
         torch.float32,
-        torch.float16,
+        # py31--torch-nightly, Unable to create onnxruntime InferenceSession for executing .Mul op with onnx model
+        # torch.float16,
     ),
     "var_mean_dim": (
         torch.float32,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -807,12 +807,12 @@ SKIP_XFAIL_SUBTESTS: tuple[ops_test_common.DecorateMeta, ...] = (
         matcher=lambda sample: sample.args[1] == 2,
         reason="fixme: 'bicubic' mode in ORT implemented differently with Torch",
     ),
-    xfail(
+    skip(
         "index_put",
         matcher=lambda sample: not (sample.args[0][0].dtype == torch.int64),
         reason="this Aten overload only support tensor(int) as args",
     ),
-    xfail(
+    skip(
         "index_put_bool",
         matcher=lambda sample: not (sample.args[0][0].dtype == torch.bool),
         reason="this Aten overload only support tensor(bool) as args",
@@ -1556,7 +1556,11 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "full_like": (
         torch.float32,
-        # torch.float16,  # FIXME: dtype don't match.
+        torch.float16,
+    ),
+    "full_like_dtype": (
+        torch.float32,
+        torch.float16,
     ),
     "gather": (
         torch.float32,
@@ -1580,11 +1584,11 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     # "is_nonzero": core_ops.aten_is_nonzero,  # no test case in OPS_DB
     "index_put_bool": (
         torch.float32,
-        # torch.float16,  # FIXME: ORT failed.
+        torch.float16,
     ),
     "index_put": (
         torch.float32,
-        # torch.float16,  # FIXME: ORT failed.
+        torch.float16,
     ),
     "index_select": (
         torch.float32,
@@ -1596,7 +1600,7 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "isfinite": (
         torch.float32,
-        # torch.float16,  # FIXME: shape inference error
+        torch.float16,  # FIXME: shape inference error
     ),
     "isinf": (
         torch.float32,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1657,7 +1657,7 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "log10": (
         torch.float32,
-        # windows-latest, py310-torch-nightly
+        # py310-torch-nightly,Shape inference error(s): (op_type:Div, node name: n3): B has inconsistent type tensor(float)
         torch.float16,
     ),
     "log1p": (
@@ -1670,8 +1670,8 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "log2": (
         torch.float32,
-        # windows-latest, py310-torch-nightly
-        torch.float16,
+        # windows-latest, py310-torch-nightly, RuntimeError: Unable to create onnxruntime InferenceSession for executing .Div op with onnx model
+        # torch.float16,
     ),
     "logaddexp": (
         torch.float32,
@@ -1881,8 +1881,8 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "nn.functional.logsigmoid": (
         torch.float32,
-        # windows-latest, py310-torch-nightly
-        torch.float16,
+        # windows-latest, py310-torch-nightly, AssetionError in ORT: Tensor-likes are not close
+        # torch.float16,
     ),
     "nn.functional.max_pool2d": (
         torch.float32,
@@ -1919,7 +1919,8 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "nn.functional.relu6": (
         torch.float32,
-        torch.float16,
+        # py310-torch-nightly, FullGraph, AssertionError in ORT
+        # torch.float16,
     ),
     "nn.functional.replication_pad2d": (
         torch.float32,
@@ -2142,11 +2143,13 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "var_mean_dim": (
         torch.float32,
-        torch.float16,
+        # py310-torch-nightly, FullGraph, AssertionError in ORT
+        # torch.float16,
     ),
     "var_mean_correction": (
         torch.float32,
-        torch.float16,
+        # py310-onnx-weekly, FullGraph, AssertionError in ORT
+        # torch.float16,
     ),
     "view": (
         torch.float32,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -2061,11 +2061,11 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "split_with_sizes": (
         torch.float32,
-        torch.float16,  # FIXME: ORT failed
+        # torch.float16,  # FIXME: ORT failed
     ),
     "split": (
         torch.float32,
-        torch.float16,  # ORT failed
+        # torch.float16,  # ORT failed
     ),
     "sqrt": (
         torch.float32,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1616,7 +1616,7 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "isfinite": (
         torch.float32,
-        torch.float16,  # FIXME: shape inference error
+        torch.float16,
     ),
     "isinf": (
         torch.float32,
@@ -1628,15 +1628,15 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "isneginf": (
         torch.float32,
-        # torch.float16,  # FIXME: shape inference error
+        torch.float16,
     ),
     "isposinf": (
         torch.float32,
-        # torch.float16,  # FIXME: shape inference error
+        torch.float16,
     ),
     "layer_norm": (
         torch.float32,
-        # torch.float16,  # FIXME: skipped, check reason
+        torch.float16,
     ),
     "log": (
         torch.float32,
@@ -1746,11 +1746,11 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "native_group_norm": (
         torch.float32,
-        # torch.float16,  # ORT not implemented
+        torch.float16,  # ORT not implemented
     ),
     "native_layer_norm": (
         torch.float32,
-        torch.float16,
+        # torch.float16,
     ),
     # "native_dropout": core_ops.aten_native_dropout,  # native_dropout is not in OPS_DB
     "ne": (

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1331,6 +1331,12 @@ assert NONDETERMINISTIC_OPS.issubset(
 ), f"{NONDETERMINISTIC_OPS - TESTED_OPS} not in TESTED_OPS"
 
 # List for different input dtype testing flag
+# Added Cast inside below functions so they can support all real dtypes naturally
+# -- isfinite, isinf, isneginf, isposinf
+# Note:
+# Converter fp32 to fp16 model is a significant feature for end users,
+# another approach is to add cast before/after the function call,
+# that way we also need a list to remember which function need cast
 OPINFO_FUNCTION_TARGET_DTYPE: dict[
     str,
     tuple[Any, ...],
@@ -1616,6 +1622,7 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "isfinite": (
         torch.float32,
+        # Added Cast inside the function so it can support all real dtypes naturally
         torch.float16,
     ),
     "isinf": (
@@ -1628,10 +1635,12 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "isneginf": (
         torch.float32,
+        # Added Cast inside the function so it can support all real dtypes naturally
         torch.float16,
     ),
     "isposinf": (
         torch.float32,
+        # Added Cast inside the function so it can support all real dtypes naturally
         torch.float16,
     ),
     "layer_norm": (


### PR DESCRIPTION
Refine aten_isfinite by adding cast at beginning, so it can support all float dtypes.
The original implementation 'self: Union[FLOAT, DOUBLE]' is only for skip the testcase. When used with FP16, it will failed.

I wrote some Notes in ops_test_data.py, just like:
```python
# List for different input dtype testing flag
# Added Cast inside below functions so they can support all real dtypes naturally
# -- isfinite, isinf, isneginf, isposinf
# Note:
# Converter fp32 to fp16 model is a significant feature for end users,
# another approach is to add cast before/after the function call,
# that way we also need a list to remember which function need cast
OPINFO_FUNCTION_TARGET_DTYPE: dict[
    str,
    tuple[Any, ...],
] = {
...
```
We have a list, so we can know the functions those we made this kind of change.
If we have some other better solutions that can support this scenario, we can also revert this change.