### PR TITLE
Refine op for fp16(3)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5229,7 +5229,9 @@ def aten_refine_names(self: TensorType, names: Sequence[str]) -> TensorType:
 def aten_remainder(self: TFloatOrBFloat16, other: TFloatOrBFloat16) -> TFloatOrBFloat16:
     """remainder.Tensor(Tensor self, Tensor other) -> Tensor"""
 
+    # a - a.div(b, rounding_mode="floor") * b
     rounded_quotient = op.Floor(op.Div(self, other))
+
     return op.Sub(self, op.Mul(rounded_quotient, other))
 
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5404,12 +5404,12 @@ def aten_scalar_tensor(s: float, dtype: int = FLOAT.dtype) -> TTensor:  # type: 
     return op.Cast(s, to=dtype)
 
 
-@torch_op("aten::scatter_add")
+@torch_op("aten::scatter_add", trace_only=True)
 def aten_scatter_add(
     self: TReal,
+    dim: int,  # we have to use int here because ScatterElements() will use this attribute
     index: TInt,
     src: TReal,
-    dim: int,
 ) -> TReal:
     """scatter_add(Tensor self, int dim, Tensor index, Tensor src) -> Tensor"""
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5199,19 +5199,8 @@ def aten_refine_names(self: TensorType, names: Sequence[str]) -> TensorType:
 def aten_remainder(self: TFloatOrBFloat16, other: TFloatOrBFloat16) -> TFloatOrBFloat16:
     """remainder.Tensor(Tensor self, Tensor other) -> Tensor"""
 
-    # Have to cast to float32 at very beinging to avoid accuracy loss
-    # e.g. self=7.7500, other=0.1582
-    # in float32 mode: result = 0.1562
-    # in float16 mode: result = 0.0
-    # The difference is too big to use larger atol and rtol to tolerate
-    self_float = op.Cast(self, to=FLOAT.dtype)
-    other_float = op.Cast(other, to=FLOAT.dtype)
-
-    # a - a.div(b, rounding_mode="floor") * b
-    rounded_quotient = op.Floor(op.Div(self_float, other_float))
-
-    result = op.Sub(self_float, op.Mul(rounded_quotient, other_float))
-    return op.CastLike(result, self)
+    rounded_quotient = op.Floor(op.Div(self, other))
+    return op.Sub(self, op.Mul(rounded_quotient, other))
 
 
 @torch_op("aten::remainder")

--- a/onnxscript/tests/function_libs/torch_lib/ops_test.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test.py
@@ -239,7 +239,6 @@ def run_test_output_match(
             ),
             kwargs=repr(cpu_sample.kwargs),
         ):
-            if i != 0: continue
             test_behavior, reason = _should_skip_xfail_test_sample(op.name, cpu_sample)
 
             with ops_test_common.normal_xfail_skip_test_behaviors(test_behavior, reason):

--- a/onnxscript/tests/function_libs/torch_lib/ops_test.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test.py
@@ -92,10 +92,11 @@ def _split_function_and_wrangler(
 
 # according to https://pytorch.org/docs/stable/testing.html
 OPINFO_PRECISION_TABLE = {
-    # Relax atol and rtol for float32 based on empirical results
+    # Tolerance value (rtol, atol)
     # The current most relaxed values are for aten::matmul
     torch.float32: (3.7e-5, 1.8e-4),  # default is 1.3e-6, 1e-5
-    torch.float16: (1e-3, 1e-5),
+    # This value is for aten::log_sigmoid
+    torch.float16: (5e-3, 3e-4),  # default is 1e-3, 1e-5
 }
 
 
@@ -238,6 +239,7 @@ def run_test_output_match(
             ),
             kwargs=repr(cpu_sample.kwargs),
         ):
+            if i != 0: continue
             test_behavior, reason = _should_skip_xfail_test_sample(op.name, cpu_sample)
 
             with ops_test_common.normal_xfail_skip_test_behaviors(test_behavior, reason):

--- a/onnxscript/tests/function_libs/torch_lib/ops_test.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test.py
@@ -95,8 +95,7 @@ OPINFO_PRECISION_TABLE = {
     # Tolerance value (rtol, atol)
     # The current most relaxed values are for aten::matmul
     torch.float32: (3.7e-5, 1.8e-4),  # default is 1.3e-6, 1e-5
-    # This value is for aten::remainder
-    torch.float16: (8e-3, 7e-4),  # default is 1e-3, 1e-5
+    torch.float16: (1e-3, 1e-5),  # default is 1e-3, 1e-5
 }
 
 

--- a/onnxscript/tests/function_libs/torch_lib/ops_test.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test.py
@@ -95,8 +95,8 @@ OPINFO_PRECISION_TABLE = {
     # Tolerance value (rtol, atol)
     # The current most relaxed values are for aten::matmul
     torch.float32: (3.7e-5, 1.8e-4),  # default is 1.3e-6, 1e-5
-    # This value is for aten::log_sigmoid
-    torch.float16: (5e-3, 3e-4),  # default is 1e-3, 1e-5
+    # This value is for aten::remainder
+    torch.float16: (8e-3, 7e-4),  # default is 1e-3, 1e-5
 }
 
 

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -246,17 +246,10 @@ def _replication_pad3d_input_wrangler(
     return args, kwargs
 
 
-def _scatter_add_input_wrangler(
-    args: list[Any], kwargs: dict[str, Any]
-) -> tuple[list[Any], dict[str, Any]]:
-    kwargs["dim"] = args.pop(1)
-    return args, kwargs
-
-
 def _scatter_reduce_input_wrangler(
     args: list[Any], kwargs: dict[str, Any]
 ) -> tuple[list[Any], dict[str, Any]]:
-    # Put the string into kwargs, otherwise FullGraph mode will cannot find get 'reduce' argument
+    # Put the string into kwargs, otherwise FullGraph mode could not find get 'reduce' argument
     kwargs["reduce"] = args.pop(4)
     return args, kwargs
 
@@ -476,7 +469,6 @@ OPINFO_FUNCTION_MAPPING_SCRIPTED: dict[
     "rsub": core_ops.aten_rsub,
     "select": core_ops.aten_select,
     # "scalar_tensor": core_ops.aten_scalar_tensor,  # no test case in OPS_DB
-    "scatter_add": (core_ops.aten_scatter_add, _scatter_add_input_wrangler),
     "sigmoid": core_ops.aten_sigmoid,
     "sign": core_ops.aten_sign,
     "sin": core_ops.aten_sin,
@@ -560,6 +552,7 @@ OPINFO_FUNCTION_MAPPING_TRACE_ONLY: dict[
         _upsample_input_wrangler,
     ),
     "ones_like": core_ops.aten_ones_like,
+    "scatter_add": core_ops.aten_scatter_add,
     "scatter_reduce": (core_ops.aten_scatter_reduce, _scatter_reduce_input_wrangler),
     "slice_scatter": core_ops.aten_slice_scatter,
     "slice": core_ops.aten_slice,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -687,6 +687,12 @@ EXPECTED_SKIPS_OR_FAILS = (
         test_class_name="TestOutputConsistencyFullGraph",
     ),
     xfail(
+        "remainder",
+        dtypes=[torch.float16],
+        reason="Eager mode failed on case(self=7.75,other=0.1582) due to precision loss",
+        test_class_name="TestOutputConsistencyEager",
+    ),
+    xfail(
         "repeat",
         reason="Shape inference error. Remove after ONNX 1.14 release",
         test_class_name="TestOutputConsistencyFullGraph",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -591,11 +591,6 @@ OPINFO_FUNCTION_MAPPING: dict[
 TESTED_OPS = frozenset(OPINFO_FUNCTION_MAPPING)
 
 EXPECTED_SKIPS_OR_FAILS = (
-    xfail(
-        "as_strided",
-        variant_name="partial_views",
-        reason="ONNX doesn't have partial view for tensor",
-    ),
     xfail("logcumsumexp", reason="naive implementation not numerically stable"),
     xfail(
         "max",
@@ -613,12 +608,6 @@ EXPECTED_SKIPS_OR_FAILS = (
         "max_pool3d",
         variant_name="empty_strides",
         reason="fixme: 'shape' do not match: torch.Size([2, 3, 4, 3]) != torch.Size([2, 3, 4, 2])",
-    ),
-    xfail(
-        "min_dim",
-        variant_name="reduction_with_dim",
-        reason="ORT Graph attribute inferencing failed https://github.com/onnx/onnx/issues/4986",
-        test_class_name="TestOutputConsistencyFullGraph",
     ),
     xfail(
         "new_empty_dtype",
@@ -707,11 +696,11 @@ EXPECTED_SKIPS_OR_FAILS = (
         variant_name="mean",
         reason="ONNX doesn't support reduce='mean' option",
     ),
-    xfail(
-        "t",
-        reason="ORT Graph attribute inferencing failed on rank-1 input",
-        test_class_name="TestOutputConsistencyFullGraph",
-    ),
+    # xfail(
+    #     "t",
+    #     reason="ORT Graph attribute inferencing failed on rank-1 input",
+    #     test_class_name="TestOutputConsistencyFullGraph",
+    # ),
     xfail(
         "tile",
         reason="Shape inference error. Remove after ONNX 1.14 release",
@@ -824,13 +813,13 @@ SKIP_XFAIL_SUBTESTS: tuple[ops_test_common.DecorateMeta, ...] = (
         matcher=lambda sample: len(sample.args) > 0,
         reason="this ATen overload only supports one tensor as input by design",
     ),
-    xfail(
+    skip(
         "min_other",  # aten_min_other(self, other)
         matcher=lambda sample: len(sample.args) == 0
         or (len(sample.args) > 0 and isinstance(sample.args[0], int)),
         reason="this ATen overload only support one tensor as input and another tensor as args",
     ),
-    xfail(
+    skip(
         "min_dim",  # aten_min_dim(self, dim)
         matcher=lambda sample: len(sample.args) == 0
         or (len(sample.args) > 0 and not isinstance(sample.args[0], int)),

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -605,11 +605,6 @@ EXPECTED_SKIPS_OR_FAILS = (
         test_class_name="TestOutputConsistencyFullGraph",
     ),
     xfail(
-        "max_pool3d",
-        variant_name="empty_strides",
-        reason="fixme: 'shape' do not match: torch.Size([2, 3, 4, 3]) != torch.Size([2, 3, 4, 2])",
-    ),
-    xfail(
         "new_empty_dtype",
         reason="fixme: ORT fails with invalid model: 'ONNX Schema aten_new_empty_dtype: failed validating the check: !(it.GetName().empty())'",
         test_class_name="TestOutputConsistencyFullGraph",
@@ -696,11 +691,6 @@ EXPECTED_SKIPS_OR_FAILS = (
         variant_name="mean",
         reason="ONNX doesn't support reduce='mean' option",
     ),
-    # xfail(
-    #     "t",
-    #     reason="ORT Graph attribute inferencing failed on rank-1 input",
-    #     test_class_name="TestOutputConsistencyFullGraph",
-    # ),
     xfail(
         "tile",
         reason="Shape inference error. Remove after ONNX 1.14 release",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1894,7 +1894,7 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "nn.functional.elu": (
         torch.float32,
-        torch.float16,
+        # torch.float16,  # ONNX Runtime aborted, ubuntu, py310 torch-nightly
     ),
     "nn.functional.embedding": (
         torch.float32,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -591,6 +591,11 @@ OPINFO_FUNCTION_MAPPING: dict[
 TESTED_OPS = frozenset(OPINFO_FUNCTION_MAPPING)
 
 EXPECTED_SKIPS_OR_FAILS = (
+    xfail(
+        "as_strided",
+        variant_name="partial_views",
+        reason="ONNX doesn't have partial view for tensor",
+    ),
     xfail("logcumsumexp", reason="naive implementation not numerically stable"),
     xfail(
         "max",
@@ -602,6 +607,17 @@ EXPECTED_SKIPS_OR_FAILS = (
         "max",
         variant_name="reduction_with_dim",
         reason="fixme: current implementation gets shape inference error",
+        test_class_name="TestOutputConsistencyFullGraph",
+    ),
+    xfail(
+        "max_pool3d",
+        variant_name="empty_strides",
+        reason="fixme: 'shape' do not match: torch.Size([2, 3, 4, 3]) != torch.Size([2, 3, 4, 2])",
+    ),
+    xfail(
+        "min_dim",
+        variant_name="reduction_with_dim",
+        reason="ORT Graph attribute inferencing failed https://github.com/onnx/onnx/issues/4986",
         test_class_name="TestOutputConsistencyFullGraph",
     ),
     xfail(
@@ -690,6 +706,11 @@ EXPECTED_SKIPS_OR_FAILS = (
         "scatter_reduce",
         variant_name="mean",
         reason="ONNX doesn't support reduce='mean' option",
+    ),
+    xfail(
+        "t",
+        reason="ORT Graph attribute inferencing failed on rank-1 input",
+        test_class_name="TestOutputConsistencyFullGraph",
     ),
     xfail(
         "tile",
@@ -803,13 +824,13 @@ SKIP_XFAIL_SUBTESTS: tuple[ops_test_common.DecorateMeta, ...] = (
         matcher=lambda sample: len(sample.args) > 0,
         reason="this ATen overload only supports one tensor as input by design",
     ),
-    skip(
+    xfail(
         "min_other",  # aten_min_other(self, other)
         matcher=lambda sample: len(sample.args) == 0
         or (len(sample.args) > 0 and isinstance(sample.args[0], int)),
         reason="this ATen overload only support one tensor as input and another tensor as args",
     ),
-    skip(
+    xfail(
         "min_dim",  # aten_min_dim(self, dim)
         matcher=lambda sample: len(sample.args) == 0
         or (len(sample.args) > 0 and not isinstance(sample.args[0], int)),

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1874,8 +1874,8 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "nn.functional.logsigmoid": (
         torch.float32,
-        # windows-latest, py310-torch-nightly, AssetionError in ORT: Tensor-likes are not close
-        # torch.float16,
+        # Only for torch-nightly, the tolarance is (rtol=5e-3, atol=3e-4)
+        torch.float16,
     ),
     "nn.functional.max_pool2d": (
         torch.float32,
@@ -1984,7 +1984,7 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "remainder": (
         torch.float32,
-        # torch.float16,  # tensor-like are not close
+        torch.float16,
     ),
     "repeat": (
         torch.float32,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1902,7 +1902,7 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "nn.functional.gelu": (
         torch.float32,
-        torch.float16,
+        # torch.float16,  # ubuntu py310 torch-nightly failed, ONNX Runtime aborted
     ),
     "nn.functional.grid_sample": (
         torch.float32,
@@ -1974,15 +1974,15 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "nn.functional.scaled_dot_product_attention": (
         torch.float32,
-        torch.float16,  # OpSchema is not writable before ONNX 1.15
+        torch.float16,
     ),
     "nn.functional.scaled_dot_product_attention_bool_mask": (
         torch.float32,
-        torch.float16,  # OpSchema is not writable before ONNX 1.15
+        torch.float16,
     ),
     "nn.functional.selu": (
         torch.float32,
-        torch.float16,
+        # torch.float16,  # ubuntu py310 torch-nightly failed, ONNX Runtime aborted
     ),
     "nn.functional.mse_loss": (
         torch.float32,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1907,13 +1907,14 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "nn.functional.relu": (
         torch.float32,
-        # ubuntu-latest, py310-torch-nightly
-        # Unable to create onnxruntime InferenceSession for executing .Div op with onnx model
+        # Cannot support relu in float16
+        # file issue: https://github.com/microsoft/onnxruntime/issues/16069
         # torch.float16,
     ),
     "nn.functional.relu6": (
         torch.float32,
-        # macos-latest, py310-torch-nightly, FullGraph, AssertionError in ORT
+        # Cannot support relu in float16
+        # file issue: https://github.com/microsoft/onnxruntime/issues/16069
         # torch.float16,
     ),
     "nn.functional.replication_pad2d": (

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1907,13 +1907,13 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "nn.functional.relu": (
         torch.float32,
-        # Cannot support relu in float16
+        # ORT cannot support relu in float16
         # file issue: https://github.com/microsoft/onnxruntime/issues/16069
         # torch.float16,
     ),
     "nn.functional.relu6": (
         torch.float32,
-        # Cannot support relu in float16
+        # ORT cannot support relu in float16
         # file issue: https://github.com/microsoft/onnxruntime/issues/16069
         # torch.float16,
     ),
@@ -1927,11 +1927,11 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "nn.functional.scaled_dot_product_attention": (
         torch.float32,
-        # torch.float16,  # OpSchema is not writable before ONNX 1.15
+        torch.float16,  # OpSchema is not writable before ONNX 1.15
     ),
     "nn.functional.scaled_dot_product_attention_bool_mask": (
         torch.float32,
-        # torch.float16,  # OpSchema is not writable before ONNX 1.15
+        torch.float16,  # OpSchema is not writable before ONNX 1.15
     ),
     "nn.functional.selu": (
         torch.float32,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1922,7 +1922,6 @@ OPINFO_FUNCTION_TARGET_DTYPE: dict[
     ),
     "nn.functional.logsigmoid": (
         torch.float32,
-        # Only for torch-nightly, the tolarance is (rtol=5e-3, atol=3e-4)
         torch.float16,
     ),
     "nn.functional.max_pool2d": (

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -680,6 +680,12 @@ EXPECTED_SKIPS_OR_FAILS = (
         test_class_name="TestOutputConsistencyFullGraph",
         enabled_if=version_utils.onnxruntime_older_than("1.15"),
     ),
+    xfail(
+        "nn.functional.logsigmoid",
+        dtypes=[torch.float16],
+        reason="Eager mode failed on case(0,2) at location(0,6) due to precision loss",
+        test_class_name="TestOutputConsistencyEager",
+    ),
     skip(
         "nn.functional.scaled_dot_product_attention",
         reason="fixme: ORT crashes on Windows, segfaults randomly on Linux",


### PR DESCRIPTION
Below 2 Ops works well on FullGraph mode, but have precision loss on Eager mode.
1. op(log_sigmoid), using (5e-3, 3e-4) as rtol and atol. Becuase numpy also give same result as ORT on float16.
    for example: x=3.8242, y=np.log(1/(1+np.exp(x))=?
    with float32: y = -0.0216
    with float16: y = -0.02122
2. op(remainder), the difference is too big between float32 and float16, so we have to cast to fp32 at very beginning to avoid accuracy loss.
   e.g. self=7.7500, other=0.1582
   in float32 mode: result = 0.1562
   in float16 mode: result = 0.0
Numpy has same behaviour.