### PR TITLE
Fix 'attr_proto' with latest onnx, bump onnx-weekly | chore(deps), fix(irbuilder)

### DIFF
--- a/onnxscript/irbuilder.py
+++ b/onnxscript/irbuilder.py
@@ -17,6 +17,7 @@ from onnx.defs import onnx_opset_version
 import onnxscript
 from onnxscript import type_annotation as ta
 from onnxscript import values
+from onnxscript._internal import version_utils
 from onnxscript.onnx_types import ONNXType
 from onnxscript.sourceinfo import SourceInfo
 
@@ -172,7 +173,12 @@ class IRAttributeParameter:
                 "Attribute has no default value. Only attributes with default "
                 "values can be converted to AttributeProto."
             )
-        return helper.make_attribute(self.name, self.default_value)
+        if version_utils.onnx_older_than("1.14.1"):
+            # Argument 'attr_type' was added after version 1.14.0.
+            return helper.make_attribute(self.name, self.default_value)
+        # pylint: disable=unexpected-keyword-arg
+        return helper.make_attribute(self.name, self.default_value, attr_type=self.type)  # type: ignore[call-arg]
+        # pylint: enable=unexpected-keyword-arg
 
 
 class IRStmt:

--- a/requirements/ci/requirements-onnx-weekly.txt
+++ b/requirements/ci/requirements-onnx-weekly.txt
@@ -1,1 +1,1 @@
-onnx-weekly==1.15.0.dev20230501
+onnx-weekly==1.15.0.dev20230529


### PR DESCRIPTION
Replaces #750, resolves CI issues.

Needed by https://github.com/pytorch/pytorch/pull/101029 in order for onnxscript to work with latest onnx.
The PyTorch PR needs bugfix https://github.com/onnx/onnx/commit/213b525a51ead28961d9b4f2764b08c7e336bf2c in ONNX.

Preferrably waits for onnx 1.15 or 1.14.1.