### PR TITLE
Preserve correct params order in FunctionIR

### DIFF
--- a/onnxscript/_internal/param_manipulation.py
+++ b/onnxscript/_internal/param_manipulation.py
@@ -67,9 +67,65 @@ def separate_input_attributes_from_arguments(
             # User did not provide the attribute
             if fill_defaults:
                 onnx_attributes[param.name] = param.default
-            else:
-                continue
         elif param.required:
             raise TypeError(f"Required input '{param}' was not provided")
 
     return onnx_inputs, onnx_attributes
+
+
+def tag_arguments_with_param_schemas(
+    param_schemas: Sequence[values.ParamSchema],
+    args,
+    kwargs,
+    fill_defaults: bool = True,
+    allow_extra_kwargs: bool = False,
+) -> tuple[list[tuple[Any, values.ParamSchema]], dict[str, tuple[Any, values.ParamSchema]]]:
+    """Tag Python args and kwargs with matching ONNX ParamSchema.
+
+    Args:
+        param_schemas: The parameter schemas of an Op or a OnnxFunction.
+        args: The Python positional arguments supplied by the caller.
+        kwargs: The Python keyword arguments supplied by the caller.
+        fill_defaults: Whether to fill the default values for attributes.
+        allow_extra_kwargs: Whether to allow extra keyword arguments.
+            When set to True, extra/unknown arguments will be ignored.
+
+    Returns:
+        A tuple of two elements:
+        - A list of tuple of Python positional argument and ParamSchema.
+        - An ordered dictionary of Python keyword argument names and tuple of argument
+            value and ParamSchema.
+
+    Raises:
+        TypeError: When allow_extra_kwargs is False and there are unknown kwargs.
+        TypeError: When a required input is not provided.
+    """
+    # args, kwargs and param_schemas should be all in order
+    # user may not specify all inputs or attributes
+
+    all_param_names = {param.name for param in param_schemas}
+    extra_kwargs = set(kwargs).difference(all_param_names)
+    if extra_kwargs and not allow_extra_kwargs:
+        raise TypeError(f"Unexpected keyword arguments '{extra_kwargs}'")
+
+    tagged_args: list[tuple[Any, values.ParamSchema]] = []
+    tagged_kwargs: dict[str, tuple[Any, values.ParamSchema]] = {}
+
+    for i, param in enumerate(param_schemas):
+        if param.is_variadic_input:
+            # Exhaust all remaining args
+            tagged_args.extend((arg, param) for arg in args[i:])
+            args = []
+            continue
+        if i < len(args):
+            tagged_args.append((args[i], param))
+        elif param.name in kwargs:
+            tagged_kwargs[param.name] = (kwargs[param.name], param)
+        elif param.default is not values._EmptyDefault:  # pylint: disable=protected-access
+            # User did not provide the input/attribute
+            if fill_defaults:
+                tagged_kwargs[param.name] = (param.default, param)
+        elif param.required:
+            raise TypeError(f"Required input/attribute '{param}' was not provided")
+
+    return tagged_args, tagged_kwargs

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -3042,16 +3042,8 @@ def aten_index_reduce(
     raise NotImplementedError()
 
 
-# FIXME(#277): Script when attributes can come before inputs
-@torch_op("aten::index_select", trace_only=True)
+@torch_op("aten::index_select")
 def aten_index_select(self: TTensor, dim: int, index: IntType) -> TTensor:
-    """index_select(Tensor self, int dim, Tensor index) -> Tensor"""
-
-    return _aten_index_select_onnx(self, index, dim=dim)
-
-
-@torch_op("aten::index_select", private=True)
-def _aten_index_select_onnx(self: TTensor, index: IntType, dim: int) -> TTensor:
     """index_select(Tensor self, int dim, Tensor index) -> Tensor"""
 
     self_is_scalar = op.Size(op.Shape(self)) == 0

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -391,6 +391,7 @@ OPINFO_FUNCTION_MAPPING_SCRIPTED: dict[
     # "is_nonzero": core_ops.aten_is_nonzero,  # no test case in OPS_DB
     "index_put_bool": core_ops.aten_index_put_bool,
     "index_put": core_ops.aten_index_put,
+    "index_select": core_ops.aten_index_select,
     "isclose": core_ops.aten_isclose,
     "isfinite": core_ops.aten_isfinite,
     "isinf": core_ops.aten_isinf,
@@ -535,7 +536,6 @@ OPINFO_FUNCTION_MAPPING_TRACE_ONLY: dict[
     "grid_sampler_2d": core_ops.aten_grid_sampler_2d,
     "hstack": core_ops.aten_hstack,
     "nn.functional.grid_sample": (core_ops.aten_grid_sampler, _grid_sample_input_wrangler),
-    "index_select": core_ops.aten_index_select,
     "layer_norm": core_ops.aten_layer_norm,
     "logit": core_ops.aten_logit,
     "max": core_ops.aten_max,

--- a/onnxscript/values_test.py
+++ b/onnxscript/values_test.py
@@ -1,5 +1,6 @@
 import unittest
 
+import onnxscript
 from onnxscript import values
 
 
@@ -13,3 +14,23 @@ class TracedOnnxFunctionTest(unittest.TestCase):
         self.assertEqual(traced_function.opset, opset)
         self.assertEqual(traced_function.name, function.__name__)
         self.assertEqual(traced_function.func, function)
+
+    def test_param_schemas_in_correct_order_with_mixed_inputs_and_attrs(self):
+        opset = values.Opset("test", 1)
+
+        @onnxscript.script(default_opset=opset)
+        def function(input1, input2, attr1: int, attr2: float, input3, attr3: str = "default"):
+            return opset.CustomOp(input1 + input2, input3, attr1, attr2, attr3)
+
+        param_schemas = function.param_schemas()
+        expected_ordered_param_names = [
+            "input1",
+            "input2",
+            "attr1",
+            "attr2",
+            "input3",
+            "attr3",
+        ]
+        self.assertEqual(len(param_schemas), len(expected_ordered_param_names))
+        for i, param_schema in enumerate(param_schemas):
+            self.assertEqual(param_schema.name, expected_ordered_param_names[i])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #759
* __->__ #758

Preserves original arguments order for param_schemas, including when OnnxFunction 
is defined with intersecting inputs and attrs. E.g. `def function(self, input1, attr1, input2, attr2)`.

`eval_function` for `TorchScriptTracingEvaluator` is left unchanged, i.e., splits arguments into inputs
and attributes. Because that is the format expected by TorchScript graph building.

Fixes #277 Fixes #305 