### PR TITLE
opgen: translate type constraints in an OpSchema to typing.TypeVars in the static API

### DIFF
--- a/onnxscript/onnx_opset/_impl/opset1.py
+++ b/onnxscript/onnx_opset/_impl/opset1.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Tuple, TypeVar
 
 from onnx import GraphProto, TensorProto
 from onnx.defs import get_schema
@@ -42,9 +42,9 @@ class Opset1(Opset):
     def __init__(self):
         super().__init__()
 
-    def Abs(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], consumed_inputs: Optional[Sequence[int]] = None
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Abs(self, X: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Abs(1)](https://onnx.ai/onnx/operators/onnx__Abs.html#abs-1 "Online Documentation")
 
 
@@ -60,17 +60,19 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Abs", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Abs", schema)
+        op = Op(self, "Abs", schema)
         return op(*self._prepare_inputs(schema, X), consumed_inputs=consumed_inputs)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def Add(
         self,
-        A: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Union[DOUBLE, FLOAT, FLOAT16],
+        A: T,
+        B: T,
         axis: Optional[int] = None,
         broadcast: int = 0,
         consumed_inputs: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 Add(1)](https://onnx.ai/onnx/operators/onnx__Add.html#add-1 "Online Documentation")
 
 
@@ -110,7 +112,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Add", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Add", schema)
+        op = Op(self, "Add", schema)
         return op(
             *self._prepare_inputs(schema, A, B),
             axis=axis,
@@ -118,7 +120,11 @@ class Opset1(Opset):
             consumed_inputs=consumed_inputs,
         )
 
-    def And(self, A: BOOL, B: BOOL, axis: Optional[int] = None, broadcast: int = 0) -> BOOL:
+    T = TypeVar("T", bound=BOOL)
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def And(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T1:
         r"""[🌐 And(1)](https://onnx.ai/onnx/operators/onnx__And.html#and-1 "Online Documentation")
 
 
@@ -141,17 +147,14 @@ class Opset1(Opset):
         """
 
         schema = get_schema("And", 1, "")
-        op: Callable[..., BOOL] = Op(self, "And", schema)
+        op = Op(self, "And", schema)
         return op(*self._prepare_inputs(schema, A, B), axis=axis, broadcast=broadcast)
 
-    def ArgMax(
-        self,
-        data: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        axis: int = 0,
-        keepdims: int = 1,
-    ) -> INT64:
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    def ArgMax(self, data: T, axis: int = 0, keepdims: int = 1) -> INT64:
         r"""[🌐 ArgMax(1)](https://onnx.ai/onnx/operators/onnx__ArgMax.html#argmax-1 "Online Documentation")
 
 
@@ -170,17 +173,14 @@ class Opset1(Opset):
         """
 
         schema = get_schema("ArgMax", 1, "")
-        op: Callable[..., INT64] = Op(self, "ArgMax", schema)
+        op = Op(self, "ArgMax", schema)
         return op(*self._prepare_inputs(schema, data), axis=axis, keepdims=keepdims)
 
-    def ArgMin(
-        self,
-        data: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        axis: int = 0,
-        keepdims: int = 1,
-    ) -> INT64:
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    def ArgMin(self, data: T, axis: int = 0, keepdims: int = 1) -> INT64:
         r"""[🌐 ArgMin(1)](https://onnx.ai/onnx/operators/onnx__ArgMin.html#argmin-1 "Online Documentation")
 
 
@@ -199,17 +199,19 @@ class Opset1(Opset):
         """
 
         schema = get_schema("ArgMin", 1, "")
-        op: Callable[..., INT64] = Op(self, "ArgMin", schema)
+        op = Op(self, "ArgMin", schema)
         return op(*self._prepare_inputs(schema, data), axis=axis, keepdims=keepdims)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def AveragePool(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
         auto_pad: str = "NOTSET",
         kernel_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 AveragePool(1)](https://onnx.ai/onnx/operators/onnx__AveragePool.html#averagepool-1 "Online Documentation")
 
 
@@ -269,7 +271,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("AveragePool", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "AveragePool", schema)
+        op = Op(self, "AveragePool", schema)
         return op(
             *self._prepare_inputs(schema, X),
             auto_pad=auto_pad,
@@ -278,25 +280,21 @@ class Opset1(Opset):
             strides=strides,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def BatchNormalization(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        scale: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Union[DOUBLE, FLOAT, FLOAT16],
-        mean: Union[DOUBLE, FLOAT, FLOAT16],
-        var: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
+        scale: T,
+        B: T,
+        mean: T,
+        var: T,
         consumed_inputs: Optional[Sequence[int]] = None,
         epsilon: float = 9.999999747378752e-06,
         is_test: int = 0,
         momentum: float = 0.8999999761581421,
         spatial: int = 1,
-    ) -> Tuple[
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-    ]:
+    ) -> Tuple[T, T, T, T, T]:
         r"""[🌐 BatchNormalization(1)](https://onnx.ai/onnx/operators/onnx__BatchNormalization.html#batchnormalization-1 "Online Documentation")
 
 
@@ -339,16 +337,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("BatchNormalization", 1, "")
-        op: Callable[
-            ...,
-            Tuple[
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-            ],
-        ] = Op(self, "BatchNormalization", schema)
+        op = Op(self, "BatchNormalization", schema)
         return op(
             *self._prepare_inputs(schema, X, scale, B, mean, var),
             consumed_inputs=consumed_inputs,
@@ -358,26 +347,39 @@ class Opset1(Opset):
             spatial=spatial,
         )
 
-    def Cast(
-        self,
-        input: Union[
-            BOOL,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        to: Optional[str] = None,
-    ) -> Union[
-        BOOL, DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-    ]:
+    T1 = TypeVar(
+        "T1",
+        BOOL,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    T2 = TypeVar(
+        "T2",
+        BOOL,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    def Cast(self, input: T1, to: Optional[str] = None) -> T2:
         r"""[🌐 Cast(1)](https://onnx.ai/onnx/operators/onnx__Cast.html#cast-1 "Online Documentation")
 
 
@@ -396,28 +398,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Cast", 1, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Cast", schema)
+        op = Op(self, "Cast", schema)
         return op(*self._prepare_inputs(schema, input), to=to)
 
-    def Ceil(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], consumed_inputs: Optional[Sequence[int]] = None
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Ceil(self, X: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Ceil(1)](https://onnx.ai/onnx/operators/onnx__Ceil.html#ceil-1 "Online Documentation")
 
 
@@ -433,16 +419,18 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Ceil", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Ceil", schema)
+        op = Op(self, "Ceil", schema)
         return op(*self._prepare_inputs(schema, X), consumed_inputs=consumed_inputs)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def Clip(
         self,
-        input: Union[DOUBLE, FLOAT, FLOAT16],
+        input: T,
         consumed_inputs: Optional[Sequence[int]] = None,
         max: Optional[float] = None,
         min: Optional[float] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 Clip(1)](https://onnx.ai/onnx/operators/onnx__Clip.html#clip-1 "Online Documentation")
 
 
@@ -462,7 +450,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Clip", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Clip", schema)
+        op = Op(self, "Clip", schema)
         return op(
             *self._prepare_inputs(schema, input),
             consumed_inputs=consumed_inputs,
@@ -470,9 +458,9 @@ class Opset1(Opset):
             min=min,
         )
 
-    def Concat(
-        self, *inputs: Union[DOUBLE, FLOAT, FLOAT16], axis: Optional[int] = None
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Concat(self, *inputs: T, axis: Optional[int] = None) -> T:
         r"""[🌐 Concat(1)](https://onnx.ai/onnx/operators/onnx__Concat.html#concat-1 "Online Documentation")
 
         Concatenate a list of tensors into a single tensor
@@ -484,10 +472,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Concat", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Concat", schema)
+        op = Op(self, "Concat", schema)
         return op(*self._prepare_inputs(schema, *inputs), axis=axis)
 
-    def Constant(self, value: Optional[TensorProto] = None) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Constant(self, value: Optional[TensorProto] = None) -> T:
         r"""[🌐 Constant(1)](https://onnx.ai/onnx/operators/onnx__Constant.html#constant-1 "Online Documentation")
 
         A constant tensor.
@@ -497,21 +487,23 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Constant", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Constant", schema)
+        op = Op(self, "Constant", schema)
         return op(value=value)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def Conv(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        W: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
+        X: T,
+        W: T,
+        B: Optional[T] = None,
         auto_pad: str = "NOTSET",
         dilations: Optional[Sequence[int]] = None,
         group: int = 1,
         kernel_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 Conv(1)](https://onnx.ai/onnx/operators/onnx__Conv.html#conv-1 "Online Documentation")
 
 
@@ -570,7 +562,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Conv", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Conv", schema)
+        op = Op(self, "Conv", schema)
         return op(
             *self._prepare_inputs(schema, X, W, B),
             auto_pad=auto_pad,
@@ -581,11 +573,13 @@ class Opset1(Opset):
             strides=strides,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def ConvTranspose(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        W: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
+        X: T,
+        W: T,
+        B: Optional[T] = None,
         auto_pad: str = "NOTSET",
         dilations: Optional[Sequence[int]] = None,
         group: int = 1,
@@ -594,7 +588,7 @@ class Opset1(Opset):
         output_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 ConvTranspose(1)](https://onnx.ai/onnx/operators/onnx__ConvTranspose.html#convtranspose-1 "Online Documentation")
 
 
@@ -665,7 +659,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("ConvTranspose", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "ConvTranspose", schema)
+        op = Op(self, "ConvTranspose", schema)
         return op(
             *self._prepare_inputs(schema, X, W, B),
             auto_pad=auto_pad,
@@ -678,27 +672,8 @@ class Opset1(Opset):
             strides=strides,
         )
 
-    def DepthToSpace(
-        self,
-        input: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        blocksize: Optional[int] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -714,7 +689,9 @@ class Opset1(Opset):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def DepthToSpace(self, input: T, blocksize: Optional[int] = None) -> T:
         r"""[🌐 DepthToSpace(1)](https://onnx.ai/onnx/operators/onnx__DepthToSpace.html#depthtospace-1 "Online Documentation")
 
         DepthToSpace rearranges (permutes) data from depth into blocks of spatial data.
@@ -731,36 +708,19 @@ class Opset1(Opset):
         """
 
         schema = get_schema("DepthToSpace", 1, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "DepthToSpace", schema)
+        op = Op(self, "DepthToSpace", schema)
         return op(*self._prepare_inputs(schema, input), blocksize=blocksize)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def Div(
         self,
-        A: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Union[DOUBLE, FLOAT, FLOAT16],
+        A: T,
+        B: T,
         axis: Optional[int] = None,
         broadcast: int = 0,
         consumed_inputs: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 Div(1)](https://onnx.ai/onnx/operators/onnx__Div.html#div-1 "Online Documentation")
 
 
@@ -800,7 +760,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Div", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Div", schema)
+        op = Op(self, "Div", schema)
         return op(
             *self._prepare_inputs(schema, A, B),
             axis=axis,
@@ -808,13 +768,15 @@ class Opset1(Opset):
             consumed_inputs=consumed_inputs,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def Dropout(
         self,
-        data: Union[DOUBLE, FLOAT, FLOAT16],
+        data: T,
         consumed_inputs: Optional[Sequence[int]] = None,
         is_test: int = 0,
         ratio: float = 0.5,
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]:
+    ) -> Tuple[T, T]:
         r"""[🌐 Dropout(1)](https://onnx.ai/onnx/operators/onnx__Dropout.html#dropout-1 "Online Documentation")
 
 
@@ -837,9 +799,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Dropout", 1, "")
-        op: Callable[
-            ..., Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]
-        ] = Op(self, "Dropout", schema)
+        op = Op(self, "Dropout", schema)
         return op(
             *self._prepare_inputs(schema, data),
             consumed_inputs=consumed_inputs,
@@ -847,12 +807,11 @@ class Opset1(Opset):
             ratio=ratio,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def Elu(
-        self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        alpha: float = 1.0,
-        consumed_inputs: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+        self, X: T, alpha: float = 1.0, consumed_inputs: Optional[Sequence[int]] = None
+    ) -> T:
         r"""[🌐 Elu(1)](https://onnx.ai/onnx/operators/onnx__Elu.html#elu-1 "Online Documentation")
 
 
@@ -871,18 +830,16 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Elu", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Elu", schema)
+        op = Op(self, "Elu", schema)
         return op(
             *self._prepare_inputs(schema, X), alpha=alpha, consumed_inputs=consumed_inputs
         )
 
-    def Equal(
-        self,
-        A: Union[BOOL, INT32, INT64],
-        B: Union[BOOL, INT32, INT64],
-        axis: Optional[int] = None,
-        broadcast: int = 0,
-    ) -> BOOL:
+    T = TypeVar("T", BOOL, INT32, INT64)
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Equal(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T1:
         r"""[🌐 Equal(1)](https://onnx.ai/onnx/operators/onnx__Equal.html#equal-1 "Online Documentation")
 
 
@@ -905,14 +862,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Equal", 1, "")
-        op: Callable[..., BOOL] = Op(self, "Equal", schema)
+        op = Op(self, "Equal", schema)
         return op(*self._prepare_inputs(schema, A, B), axis=axis, broadcast=broadcast)
 
-    def Exp(
-        self,
-        input: Union[DOUBLE, FLOAT, FLOAT16],
-        consumed_inputs: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Exp(self, input: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Exp(1)](https://onnx.ai/onnx/operators/onnx__Exp.html#exp-1 "Online Documentation")
 
 
@@ -926,12 +881,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Exp", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Exp", schema)
+        op = Op(self, "Exp", schema)
         return op(*self._prepare_inputs(schema, input), consumed_inputs=consumed_inputs)
 
-    def Flatten(
-        self, input: Union[DOUBLE, FLOAT, FLOAT16], axis: int = 1
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Flatten(self, input: T, axis: int = 1) -> T:
         r"""[🌐 Flatten(1)](https://onnx.ai/onnx/operators/onnx__Flatten.html#flatten-1 "Online Documentation")
 
 
@@ -951,12 +906,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Flatten", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Flatten", schema)
+        op = Op(self, "Flatten", schema)
         return op(*self._prepare_inputs(schema, input), axis=axis)
 
-    def Floor(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], consumed_inputs: Optional[Sequence[int]] = None
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Floor(self, X: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Floor(1)](https://onnx.ai/onnx/operators/onnx__Floor.html#floor-1 "Online Documentation")
 
 
@@ -972,17 +927,21 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Floor", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Floor", schema)
+        op = Op(self, "Floor", schema)
         return op(*self._prepare_inputs(schema, X), consumed_inputs=consumed_inputs)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    T1 = TypeVar("T1", bound=INT32)
 
     def GRU(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        W: Union[DOUBLE, FLOAT, FLOAT16],
-        R: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        sequence_lens: Optional[INT32] = None,
-        initial_h: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
+        X: T,
+        W: T,
+        R: T,
+        B: Optional[T] = None,
+        sequence_lens: Optional[T1] = None,
+        initial_h: Optional[T] = None,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Optional[Sequence[str]] = None,
@@ -990,7 +949,7 @@ class Opset1(Opset):
         direction: str = "foward",
         hidden_size: Optional[int] = None,
         output_sequence: int = 0,
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]:
+    ) -> Tuple[T, T]:
         r"""[🌐 GRU(1)](https://onnx.ai/onnx/operators/onnx__GRU.html#gru-1 "Online Documentation")
 
 
@@ -1120,9 +1079,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("GRU", 1, "")
-        op: Callable[
-            ..., Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]
-        ] = Op(self, "GRU", schema)
+        op = Op(self, "GRU", schema)
         return op(
             *self._prepare_inputs(schema, X, W, R, B, sequence_lens, initial_h),
             activation_alpha=activation_alpha,
@@ -1134,28 +1091,8 @@ class Opset1(Opset):
             output_sequence=output_sequence,
         )
 
-    def Gather(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        indices: Union[INT32, INT64],
-        axis: int = 0,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -1171,7 +1108,11 @@ class Opset1(Opset):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    Tind = TypeVar("Tind", INT32, INT64)
+
+    def Gather(self, data: T, indices: Tind, axis: int = 0) -> T:
         r"""[🌐 Gather(1)](https://onnx.ai/onnx/operators/onnx__Gather.html#gather-1 "Online Documentation")
 
 
@@ -1235,39 +1176,22 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Gather", 1, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Gather", schema)
+        op = Op(self, "Gather", schema)
         return op(*self._prepare_inputs(schema, data, indices), axis=axis)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def Gemm(
         self,
-        A: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Union[DOUBLE, FLOAT, FLOAT16],
-        C: Union[DOUBLE, FLOAT, FLOAT16],
+        A: T,
+        B: T,
+        C: T,
         alpha: float = 1.0,
         beta: float = 1.0,
         broadcast: int = 0,
         transA: int = 0,
         transB: int = 0,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 Gemm(1)](https://onnx.ai/onnx/operators/onnx__Gemm.html#gemm-1 "Online Documentation")
 
         General Matrix multiplication:
@@ -1300,7 +1224,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Gemm", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Gemm", schema)
+        op = Op(self, "Gemm", schema)
         return op(
             *self._prepare_inputs(schema, A, B, C),
             alpha=alpha,
@@ -1310,9 +1234,9 @@ class Opset1(Opset):
             transB=transB,
         )
 
-    def GlobalAveragePool(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16]
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def GlobalAveragePool(self, X: T) -> T:
         r"""[🌐 GlobalAveragePool(1)](https://onnx.ai/onnx/operators/onnx__GlobalAveragePool.html#globalaveragepool-1 "Online Documentation")
 
 
@@ -1329,14 +1253,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("GlobalAveragePool", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(
-            self, "GlobalAveragePool", schema
-        )
+        op = Op(self, "GlobalAveragePool", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def GlobalLpPool(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], p: float = 2.0
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def GlobalLpPool(self, X: T, p: float = 2.0) -> T:
         r"""[🌐 GlobalLpPool(1)](https://onnx.ai/onnx/operators/onnx__GlobalLpPool.html#globallppool-1 "Online Documentation")
 
 
@@ -1355,10 +1277,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("GlobalLpPool", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "GlobalLpPool", schema)
+        op = Op(self, "GlobalLpPool", schema)
         return op(*self._prepare_inputs(schema, X), p=p)
 
-    def GlobalMaxPool(self, X: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def GlobalMaxPool(self, X: T) -> T:
         r"""[🌐 GlobalMaxPool(1)](https://onnx.ai/onnx/operators/onnx__GlobalMaxPool.html#globalmaxpool-1 "Online Documentation")
 
 
@@ -1375,16 +1299,14 @@ class Opset1(Opset):
         """
 
         schema = get_schema("GlobalMaxPool", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "GlobalMaxPool", schema)
+        op = Op(self, "GlobalMaxPool", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def Greater(
-        self,
-        A: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Union[DOUBLE, FLOAT, FLOAT16],
-        axis: Optional[int] = None,
-        broadcast: int = 0,
-    ) -> BOOL:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Greater(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T1:
         r"""[🌐 Greater(1)](https://onnx.ai/onnx/operators/onnx__Greater.html#greater-1 "Online Documentation")
 
 
@@ -1407,16 +1329,18 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Greater", 1, "")
-        op: Callable[..., BOOL] = Op(self, "Greater", schema)
+        op = Op(self, "Greater", schema)
         return op(*self._prepare_inputs(schema, A, B), axis=axis, broadcast=broadcast)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def HardSigmoid(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
         alpha: float = 0.20000000298023224,
         beta: float = 0.5,
         consumed_inputs: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 HardSigmoid(1)](https://onnx.ai/onnx/operators/onnx__HardSigmoid.html#hardsigmoid-1 "Online Documentation")
 
 
@@ -1436,7 +1360,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("HardSigmoid", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "HardSigmoid", schema)
+        op = Op(self, "HardSigmoid", schema)
         return op(
             *self._prepare_inputs(schema, X),
             alpha=alpha,
@@ -1444,9 +1368,9 @@ class Opset1(Opset):
             consumed_inputs=consumed_inputs,
         )
 
-    def Hardmax(
-        self, input: Union[DOUBLE, FLOAT, FLOAT16], axis: int = 1
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Hardmax(self, input: T, axis: int = 1) -> T:
         r"""[🌐 Hardmax(1)](https://onnx.ai/onnx/operators/onnx__Hardmax.html#hardmax-1 "Online Documentation")
 
 
@@ -1476,29 +1400,11 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Hardmax", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Hardmax", schema)
+        op = Op(self, "Hardmax", schema)
         return op(*self._prepare_inputs(schema, input), axis=axis)
 
-    def Identity(
-        self,
-        input: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -1514,7 +1420,9 @@ class Opset1(Opset):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Identity(self, input: T) -> T:
         r"""[🌐 Identity(1)](https://onnx.ai/onnx/operators/onnx__Identity.html#identity-1 "Online Documentation")
 
         Identity operator
@@ -1524,34 +1432,13 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Identity", 1, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Identity", schema)
+        op = Op(self, "Identity", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def If(
-        self,
-        cond: BOOL,
-        else_branch: Optional[GraphProto] = None,
-        then_branch: Optional[GraphProto] = None,
-    ) -> Union[
+    B = TypeVar("B", bound=BOOL)
+
+    V = TypeVar(
+        "V",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -1567,7 +1454,14 @@ class Opset1(Opset):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def If(
+        self,
+        cond: B,
+        else_branch: Optional[GraphProto] = None,
+        then_branch: Optional[GraphProto] = None,
+    ) -> V:
         r"""[🌐 If(1)](https://onnx.ai/onnx/operators/onnx__If.html#if-1 "Online Documentation")
 
         If conditional
@@ -1585,40 +1479,23 @@ class Opset1(Opset):
         """
 
         schema = get_schema("If", 1, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "If", schema)
+        op = Op(self, "If", schema)
         return op(
             *self._prepare_inputs(schema, cond),
             else_branch=else_branch,
             then_branch=then_branch,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def InstanceNormalization(
         self,
-        input: Union[DOUBLE, FLOAT, FLOAT16],
-        scale: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Union[DOUBLE, FLOAT, FLOAT16],
+        input: T,
+        scale: T,
+        B: T,
         consumed_inputs: Optional[Sequence[int]] = None,
         epsilon: float = 9.999999747378752e-06,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 InstanceNormalization(1)](https://onnx.ai/onnx/operators/onnx__InstanceNormalization.html#instancenormalization-1 "Online Documentation")
 
 
@@ -1644,23 +1521,23 @@ class Opset1(Opset):
         """
 
         schema = get_schema("InstanceNormalization", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(
-            self, "InstanceNormalization", schema
-        )
+        op = Op(self, "InstanceNormalization", schema)
         return op(
             *self._prepare_inputs(schema, input, scale, B),
             consumed_inputs=consumed_inputs,
             epsilon=epsilon,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def LRN(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
         alpha: float = 9.999999747378752e-05,
         beta: float = 0.75,
         bias: float = 1.0,
         size: Optional[int] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 LRN(1)](https://onnx.ai/onnx/operators/onnx__LRN.html#lrn-1 "Online Documentation")
 
 
@@ -1694,21 +1571,25 @@ class Opset1(Opset):
         """
 
         schema = get_schema("LRN", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "LRN", schema)
+        op = Op(self, "LRN", schema)
         return op(
             *self._prepare_inputs(schema, X), alpha=alpha, beta=beta, bias=bias, size=size
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    T1 = TypeVar("T1", bound=INT32)
+
     def LSTM(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        W: Union[DOUBLE, FLOAT, FLOAT16],
-        R: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        sequence_lens: Optional[INT32] = None,
-        initial_h: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        initial_c: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        P: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
+        X: T,
+        W: T,
+        R: T,
+        B: Optional[T] = None,
+        sequence_lens: Optional[T1] = None,
+        initial_h: Optional[T] = None,
+        initial_c: Optional[T] = None,
+        P: Optional[T] = None,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Optional[Sequence[str]] = None,
@@ -1717,11 +1598,7 @@ class Opset1(Opset):
         hidden_size: Optional[int] = None,
         input_forget: int = 0,
         output_sequence: int = 0,
-    ) -> Tuple[
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-    ]:
+    ) -> Tuple[T, T, T]:
         r"""[🌐 LSTM(1)](https://onnx.ai/onnx/operators/onnx__LSTM.html#lstm-1 "Online Documentation")
 
 
@@ -1873,14 +1750,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("LSTM", 1, "")
-        op: Callable[
-            ...,
-            Tuple[
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-            ],
-        ] = Op(self, "LSTM", schema)
+        op = Op(self, "LSTM", schema)
         return op(
             *self._prepare_inputs(schema, X, W, R, B, sequence_lens, initial_h, initial_c, P),
             activation_alpha=activation_alpha,
@@ -1893,12 +1763,14 @@ class Opset1(Opset):
             output_sequence=output_sequence,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def LeakyRelu(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
         alpha: float = 0.009999999776482582,
         consumed_inputs: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 LeakyRelu(1)](https://onnx.ai/onnx/operators/onnx__LeakyRelu.html#leakyrelu-1 "Online Documentation")
 
 
@@ -1916,18 +1788,16 @@ class Opset1(Opset):
         """
 
         schema = get_schema("LeakyRelu", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "LeakyRelu", schema)
+        op = Op(self, "LeakyRelu", schema)
         return op(
             *self._prepare_inputs(schema, X), alpha=alpha, consumed_inputs=consumed_inputs
         )
 
-    def Less(
-        self,
-        A: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Union[DOUBLE, FLOAT, FLOAT16],
-        axis: Optional[int] = None,
-        broadcast: int = 0,
-    ) -> BOOL:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Less(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T1:
         r"""[🌐 Less(1)](https://onnx.ai/onnx/operators/onnx__Less.html#less-1 "Online Documentation")
 
 
@@ -1950,14 +1820,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Less", 1, "")
-        op: Callable[..., BOOL] = Op(self, "Less", schema)
+        op = Op(self, "Less", schema)
         return op(*self._prepare_inputs(schema, A, B), axis=axis, broadcast=broadcast)
 
-    def Log(
-        self,
-        input: Union[DOUBLE, FLOAT, FLOAT16],
-        consumed_inputs: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Log(self, input: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Log(1)](https://onnx.ai/onnx/operators/onnx__Log.html#log-1 "Online Documentation")
 
 
@@ -1971,12 +1839,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Log", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Log", schema)
+        op = Op(self, "Log", schema)
         return op(*self._prepare_inputs(schema, input), consumed_inputs=consumed_inputs)
 
-    def LogSoftmax(
-        self, input: Union[DOUBLE, FLOAT, FLOAT16], axis: int = 1
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def LogSoftmax(self, input: T, axis: int = 1) -> T:
         r"""[🌐 LogSoftmax(1)](https://onnx.ai/onnx/operators/onnx__LogSoftmax.html#logsoftmax-1 "Online Documentation")
 
 
@@ -2006,32 +1874,15 @@ class Opset1(Opset):
         """
 
         schema = get_schema("LogSoftmax", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "LogSoftmax", schema)
+        op = Op(self, "LogSoftmax", schema)
         return op(*self._prepare_inputs(schema, input), axis=axis)
 
-    def Loop(
-        self,
-        M: Optional[INT64],
-        cond: Optional[BOOL],
-        *v_initial: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        body: Optional[GraphProto] = None,
-    ) -> Union[
+    I = TypeVar("I", bound=INT64)
+
+    B = TypeVar("B", bound=BOOL)
+
+    V = TypeVar(
+        "V",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -2047,7 +1898,15 @@ class Opset1(Opset):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Loop(
+        self,
+        M: Optional[I],
+        cond: Optional[B],
+        *v_initial: V,
+        body: Optional[GraphProto] = None,
+    ) -> V:
         r"""[🌐 Loop(1)](https://onnx.ai/onnx/operators/onnx__Loop.html#loop-1 "Online Documentation")
 
 
@@ -2186,31 +2045,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Loop", 1, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Loop", schema)
+        op = Op(self, "Loop", schema)
         return op(*self._prepare_inputs(schema, M, cond, *v_initial), body=body)
 
-    def LpNormalization(
-        self, input: Union[DOUBLE, FLOAT, FLOAT16], axis: int = -1, p: int = 2
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def LpNormalization(self, input: T, axis: int = -1, p: int = 2) -> T:
         r"""[🌐 LpNormalization(1)](https://onnx.ai/onnx/operators/onnx__LpNormalization.html#lpnormalization-1 "Online Documentation")
 
 
@@ -2226,18 +2066,20 @@ class Opset1(Opset):
         """
 
         schema = get_schema("LpNormalization", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "LpNormalization", schema)
+        op = Op(self, "LpNormalization", schema)
         return op(*self._prepare_inputs(schema, input), axis=axis, p=p)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def LpPool(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
         auto_pad: str = "NOTSET",
         kernel_shape: Optional[Sequence[int]] = None,
         p: float = 2.0,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 LpPool(1)](https://onnx.ai/onnx/operators/onnx__LpPool.html#lppool-1 "Online Documentation")
 
 
@@ -2280,7 +2122,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("LpPool", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "LpPool", schema)
+        op = Op(self, "LpPool", schema)
         return op(
             *self._prepare_inputs(schema, X),
             auto_pad=auto_pad,
@@ -2290,9 +2132,9 @@ class Opset1(Opset):
             strides=strides,
         )
 
-    def MatMul(
-        self, A: Union[DOUBLE, FLOAT, FLOAT16], B: Union[DOUBLE, FLOAT, FLOAT16]
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def MatMul(self, A: T, B: T) -> T:
         r"""[🌐 MatMul(1)](https://onnx.ai/onnx/operators/onnx__MatMul.html#matmul-1 "Online Documentation")
 
 
@@ -2306,14 +2148,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("MatMul", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "MatMul", schema)
+        op = Op(self, "MatMul", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def Max(
-        self,
-        *data_0: Union[DOUBLE, FLOAT, FLOAT16],
-        consumed_inputs: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Max(self, *data_0: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Max(1)](https://onnx.ai/onnx/operators/onnx__Max.html#max-1 "Online Documentation")
 
 
@@ -2328,17 +2168,19 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Max", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Max", schema)
+        op = Op(self, "Max", schema)
         return op(*self._prepare_inputs(schema, *data_0), consumed_inputs=consumed_inputs)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def MaxPool(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
         auto_pad: str = "NOTSET",
         kernel_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 MaxPool(1)](https://onnx.ai/onnx/operators/onnx__MaxPool.html#maxpool-1 "Online Documentation")
 
 
@@ -2398,7 +2240,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("MaxPool", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "MaxPool", schema)
+        op = Op(self, "MaxPool", schema)
         return op(
             *self._prepare_inputs(schema, X),
             auto_pad=auto_pad,
@@ -2407,13 +2249,15 @@ class Opset1(Opset):
             strides=strides,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def MaxRoiPool(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        rois: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
+        rois: T,
         pooled_shape: Optional[Sequence[int]] = None,
         spatial_scale: float = 1.0,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 MaxRoiPool(1)](https://onnx.ai/onnx/operators/onnx__MaxRoiPool.html#maxroipool-1 "Online Documentation")
 
 
@@ -2438,18 +2282,16 @@ class Opset1(Opset):
         """
 
         schema = get_schema("MaxRoiPool", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "MaxRoiPool", schema)
+        op = Op(self, "MaxRoiPool", schema)
         return op(
             *self._prepare_inputs(schema, X, rois),
             pooled_shape=pooled_shape,
             spatial_scale=spatial_scale,
         )
 
-    def Mean(
-        self,
-        *data_0: Union[DOUBLE, FLOAT, FLOAT16],
-        consumed_inputs: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Mean(self, *data_0: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Mean(1)](https://onnx.ai/onnx/operators/onnx__Mean.html#mean-1 "Online Documentation")
 
 
@@ -2464,14 +2306,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Mean", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Mean", schema)
+        op = Op(self, "Mean", schema)
         return op(*self._prepare_inputs(schema, *data_0), consumed_inputs=consumed_inputs)
 
-    def Min(
-        self,
-        *data_0: Union[DOUBLE, FLOAT, FLOAT16],
-        consumed_inputs: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Min(self, *data_0: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Min(1)](https://onnx.ai/onnx/operators/onnx__Min.html#min-1 "Online Documentation")
 
 
@@ -2486,17 +2326,19 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Min", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Min", schema)
+        op = Op(self, "Min", schema)
         return op(*self._prepare_inputs(schema, *data_0), consumed_inputs=consumed_inputs)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def Mul(
         self,
-        A: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Union[DOUBLE, FLOAT, FLOAT16],
+        A: T,
+        B: T,
         axis: Optional[int] = None,
         broadcast: int = 0,
         consumed_inputs: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 Mul(1)](https://onnx.ai/onnx/operators/onnx__Mul.html#mul-1 "Online Documentation")
 
 
@@ -2536,7 +2378,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Mul", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Mul", schema)
+        op = Op(self, "Mul", schema)
         return op(
             *self._prepare_inputs(schema, A, B),
             axis=axis,
@@ -2544,9 +2386,9 @@ class Opset1(Opset):
             consumed_inputs=consumed_inputs,
         )
 
-    def Neg(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], consumed_inputs: Optional[Sequence[int]] = None
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Neg(self, X: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Neg(1)](https://onnx.ai/onnx/operators/onnx__Neg.html#neg-1 "Online Documentation")
 
 
@@ -2562,10 +2404,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Neg", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Neg", schema)
+        op = Op(self, "Neg", schema)
         return op(*self._prepare_inputs(schema, X), consumed_inputs=consumed_inputs)
 
-    def Not(self, X: BOOL) -> BOOL:
+    T = TypeVar("T", bound=BOOL)
+
+    def Not(self, X: T) -> T:
         r"""[🌐 Not(1)](https://onnx.ai/onnx/operators/onnx__Not.html#not-1 "Online Documentation")
 
 
@@ -2577,10 +2421,14 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Not", 1, "")
-        op: Callable[..., BOOL] = Op(self, "Not", schema)
+        op = Op(self, "Not", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def Or(self, A: BOOL, B: BOOL, axis: Optional[int] = None, broadcast: int = 0) -> BOOL:
+    T = TypeVar("T", bound=BOOL)
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Or(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T1:
         r"""[🌐 Or(1)](https://onnx.ai/onnx/operators/onnx__Or.html#or-1 "Online Documentation")
 
 
@@ -2603,15 +2451,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Or", 1, "")
-        op: Callable[..., BOOL] = Op(self, "Or", schema)
+        op = Op(self, "Or", schema)
         return op(*self._prepare_inputs(schema, A, B), axis=axis, broadcast=broadcast)
 
-    def PRelu(
-        self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        slope: Union[DOUBLE, FLOAT, FLOAT16],
-        consumed_inputs: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def PRelu(self, X: T, slope: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 PRelu(1)](https://onnx.ai/onnx/operators/onnx__PRelu.html#prelu-1 "Online Documentation")
 
 
@@ -2632,16 +2477,18 @@ class Opset1(Opset):
         """
 
         schema = get_schema("PRelu", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "PRelu", schema)
+        op = Op(self, "PRelu", schema)
         return op(*self._prepare_inputs(schema, X, slope), consumed_inputs=consumed_inputs)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def Pad(
         self,
-        data: Union[DOUBLE, FLOAT, FLOAT16],
+        data: T,
         mode: str = "constant",
         paddings: Optional[Sequence[int]] = None,
         value: float = 0.0,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 Pad(1)](https://onnx.ai/onnx/operators/onnx__Pad.html#pad-1 "Online Documentation")
 
 
@@ -2679,18 +2526,14 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Pad", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Pad", schema)
+        op = Op(self, "Pad", schema)
         return op(
             *self._prepare_inputs(schema, data), mode=mode, paddings=paddings, value=value
         )
 
-    def Pow(
-        self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        Y: Union[DOUBLE, FLOAT, FLOAT16],
-        axis: Optional[int] = None,
-        broadcast: int = 0,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Pow(self, X: T, Y: T, axis: Optional[int] = None, broadcast: int = 0) -> T:
         r"""[🌐 Pow(1)](https://onnx.ai/onnx/operators/onnx__Pow.html#pow-1 "Online Documentation")
 
 
@@ -2730,17 +2573,21 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Pow", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Pow", schema)
+        op = Op(self, "Pow", schema)
         return op(*self._prepare_inputs(schema, X, Y), axis=axis, broadcast=broadcast)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    T1 = TypeVar("T1", bound=INT32)
 
     def RNN(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        W: Union[DOUBLE, FLOAT, FLOAT16],
-        R: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        sequence_lens: Optional[INT32] = None,
-        initial_h: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
+        X: T,
+        W: T,
+        R: T,
+        B: Optional[T] = None,
+        sequence_lens: Optional[T1] = None,
+        initial_h: Optional[T] = None,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Sequence[str] = ("Tanh", "Tanh"),
@@ -2748,7 +2595,7 @@ class Opset1(Opset):
         direction: str = "forward",
         hidden_size: Optional[int] = None,
         output_sequence: int = 0,
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]:
+    ) -> Tuple[T, T]:
         r"""[🌐 RNN(1)](https://onnx.ai/onnx/operators/onnx__RNN.html#rnn-1 "Online Documentation")
 
 
@@ -2868,9 +2715,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("RNN", 1, "")
-        op: Callable[
-            ..., Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]
-        ] = Op(self, "RNN", schema)
+        op = Op(self, "RNN", schema)
         return op(
             *self._prepare_inputs(schema, X, W, R, B, sequence_lens, initial_h),
             activation_alpha=activation_alpha,
@@ -2882,6 +2727,8 @@ class Opset1(Opset):
             output_sequence=output_sequence,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def RandomNormal(
         self,
         dtype: int = 1,
@@ -2889,7 +2736,7 @@ class Opset1(Opset):
         scale: float = 1.0,
         seed: Optional[float] = None,
         shape: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 RandomNormal(1)](https://onnx.ai/onnx/operators/onnx__RandomNormal.html#randomnormal-1 "Online Documentation")
 
 
@@ -2917,33 +2764,38 @@ class Opset1(Opset):
         """
 
         schema = get_schema("RandomNormal", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "RandomNormal", schema)
+        op = Op(self, "RandomNormal", schema)
         return op(dtype=dtype, mean=mean, scale=scale, seed=seed, shape=shape)
+
+    T1 = TypeVar(
+        "T1",
+        BOOL,
+        COMPLEX128,
+        COMPLEX64,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    T2 = TypeVar("T2", DOUBLE, FLOAT, FLOAT16)
 
     def RandomNormalLike(
         self,
-        input: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
+        input: T1,
         dtype: Optional[int] = None,
         mean: float = 0.0,
         scale: float = 1.0,
         seed: Optional[float] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T2:
         r"""[🌐 RandomNormalLike(1)](https://onnx.ai/onnx/operators/onnx__RandomNormalLike.html#randomnormallike-1 "Online Documentation")
 
 
@@ -2971,7 +2823,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("RandomNormalLike", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "RandomNormalLike", schema)
+        op = Op(self, "RandomNormalLike", schema)
         return op(
             *self._prepare_inputs(schema, input),
             dtype=dtype,
@@ -2980,6 +2832,8 @@ class Opset1(Opset):
             seed=seed,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def RandomUniform(
         self,
         dtype: int = 1,
@@ -2987,7 +2841,7 @@ class Opset1(Opset):
         low: float = 0.0,
         seed: Optional[float] = None,
         shape: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 RandomUniform(1)](https://onnx.ai/onnx/operators/onnx__RandomUniform.html#randomuniform-1 "Online Documentation")
 
 
@@ -3014,33 +2868,38 @@ class Opset1(Opset):
         """
 
         schema = get_schema("RandomUniform", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "RandomUniform", schema)
+        op = Op(self, "RandomUniform", schema)
         return op(dtype=dtype, high=high, low=low, seed=seed, shape=shape)
+
+    T1 = TypeVar(
+        "T1",
+        BOOL,
+        COMPLEX128,
+        COMPLEX64,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    T2 = TypeVar("T2", DOUBLE, FLOAT, FLOAT16)
 
     def RandomUniformLike(
         self,
-        input: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
+        input: T1,
         dtype: Optional[int] = None,
         high: float = 1.0,
         low: float = 0.0,
         seed: Optional[float] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T2:
         r"""[🌐 RandomUniformLike(1)](https://onnx.ai/onnx/operators/onnx__RandomUniformLike.html#randomuniformlike-1 "Online Documentation")
 
 
@@ -3068,16 +2927,14 @@ class Opset1(Opset):
         """
 
         schema = get_schema("RandomUniformLike", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(
-            self, "RandomUniformLike", schema
-        )
+        op = Op(self, "RandomUniformLike", schema)
         return op(
             *self._prepare_inputs(schema, input), dtype=dtype, high=high, low=low, seed=seed
         )
 
-    def Reciprocal(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], consumed_inputs: Optional[Sequence[int]] = None
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Reciprocal(self, X: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Reciprocal(1)](https://onnx.ai/onnx/operators/onnx__Reciprocal.html#reciprocal-1 "Online Documentation")
 
 
@@ -3093,15 +2950,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Reciprocal", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Reciprocal", schema)
+        op = Op(self, "Reciprocal", schema)
         return op(*self._prepare_inputs(schema, X), consumed_inputs=consumed_inputs)
 
-    def ReduceL1(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def ReduceL1(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
         r"""[🌐 ReduceL1(1)](https://onnx.ai/onnx/operators/onnx__ReduceL1.html#reducel1-1 "Online Documentation")
 
 
@@ -3123,17 +2977,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("ReduceL1", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceL1", schema
-        )
+        op = Op(self, "ReduceL1", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
-    def ReduceL2(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def ReduceL2(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
         r"""[🌐 ReduceL2(1)](https://onnx.ai/onnx/operators/onnx__ReduceL2.html#reducel2-1 "Online Documentation")
 
 
@@ -3155,17 +3004,14 @@ class Opset1(Opset):
         """
 
         schema = get_schema("ReduceL2", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceL2", schema
-        )
+        op = Op(self, "ReduceL2", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceLogSum(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceLogSum(1)](https://onnx.ai/onnx/operators/onnx__ReduceLogSum.html#reducelogsum-1 "Online Documentation")
 
 
@@ -3187,17 +3033,14 @@ class Opset1(Opset):
         """
 
         schema = get_schema("ReduceLogSum", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceLogSum", schema
-        )
+        op = Op(self, "ReduceLogSum", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceLogSumExp(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceLogSumExp(1)](https://onnx.ai/onnx/operators/onnx__ReduceLogSumExp.html#reducelogsumexp-1 "Online Documentation")
 
 
@@ -3219,17 +3062,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("ReduceLogSumExp", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceLogSumExp", schema
-        )
+        op = Op(self, "ReduceLogSumExp", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
-    def ReduceMax(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def ReduceMax(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
         r"""[🌐 ReduceMax(1)](https://onnx.ai/onnx/operators/onnx__ReduceMax.html#reducemax-1 "Online Documentation")
 
 
@@ -3251,17 +3089,14 @@ class Opset1(Opset):
         """
 
         schema = get_schema("ReduceMax", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceMax", schema
-        )
+        op = Op(self, "ReduceMax", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceMean(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceMean(1)](https://onnx.ai/onnx/operators/onnx__ReduceMean.html#reducemean-1 "Online Documentation")
 
 
@@ -3283,17 +3118,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("ReduceMean", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceMean", schema
-        )
+        op = Op(self, "ReduceMean", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
-    def ReduceMin(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def ReduceMin(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
         r"""[🌐 ReduceMin(1)](https://onnx.ai/onnx/operators/onnx__ReduceMin.html#reducemin-1 "Online Documentation")
 
 
@@ -3315,17 +3145,14 @@ class Opset1(Opset):
         """
 
         schema = get_schema("ReduceMin", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceMin", schema
-        )
+        op = Op(self, "ReduceMin", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceProd(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceProd(1)](https://onnx.ai/onnx/operators/onnx__ReduceProd.html#reduceprod-1 "Online Documentation")
 
 
@@ -3347,17 +3174,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("ReduceProd", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceProd", schema
-        )
+        op = Op(self, "ReduceProd", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
-    def ReduceSum(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def ReduceSum(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
         r"""[🌐 ReduceSum(1)](https://onnx.ai/onnx/operators/onnx__ReduceSum.html#reducesum-1 "Online Documentation")
 
 
@@ -3379,17 +3201,14 @@ class Opset1(Opset):
         """
 
         schema = get_schema("ReduceSum", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceSum", schema
-        )
+        op = Op(self, "ReduceSum", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceSumSquare(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceSumSquare(1)](https://onnx.ai/onnx/operators/onnx__ReduceSumSquare.html#reducesumsquare-1 "Online Documentation")
 
 
@@ -3411,14 +3230,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("ReduceSumSquare", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceSumSquare", schema
-        )
+        op = Op(self, "ReduceSumSquare", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
-    def Relu(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], consumed_inputs: Optional[Sequence[int]] = None
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Relu(self, X: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Relu(1)](https://onnx.ai/onnx/operators/onnx__Relu.html#relu-1 "Online Documentation")
 
 
@@ -3434,15 +3251,17 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Relu", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Relu", schema)
+        op = Op(self, "Relu", schema)
         return op(*self._prepare_inputs(schema, X), consumed_inputs=consumed_inputs)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def Reshape(
         self,
-        data: Union[DOUBLE, FLOAT, FLOAT16],
+        data: T,
         consumed_inputs: Optional[Sequence[int]] = None,
         shape: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 Reshape(1)](https://onnx.ai/onnx/operators/onnx__Reshape.html#reshape-1 "Online Documentation")
 
 
@@ -3463,18 +3282,20 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Reshape", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Reshape", schema)
+        op = Op(self, "Reshape", schema)
         return op(
             *self._prepare_inputs(schema, data), consumed_inputs=consumed_inputs, shape=shape
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def Selu(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
         alpha: float = 1.673200011253357,
         consumed_inputs: Optional[Sequence[int]] = None,
         gamma: float = 1.0506999492645264,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 Selu(1)](https://onnx.ai/onnx/operators/onnx__Selu.html#selu-1 "Online Documentation")
 
 
@@ -3495,7 +3316,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Selu", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Selu", schema)
+        op = Op(self, "Selu", schema)
         return op(
             *self._prepare_inputs(schema, X),
             alpha=alpha,
@@ -3503,118 +3324,8 @@ class Opset1(Opset):
             gamma=gamma,
         )
 
-    def Shape(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> INT64:
-        r"""[🌐 Shape(1)](https://onnx.ai/onnx/operators/onnx__Shape.html#shape-1 "Online Documentation")
-
-
-        Takes a tensor as input and outputs an 1D int64 tensor containing the shape of the input tensor.
-
-
-        Args:
-            data: An input tensor.
-        """
-
-        schema = get_schema("Shape", 1, "")
-        op: Callable[..., INT64] = Op(self, "Shape", schema)
-        return op(*self._prepare_inputs(schema, data))
-
-    def Sigmoid(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], consumed_inputs: Optional[Sequence[int]] = None
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
-        r"""[🌐 Sigmoid(1)](https://onnx.ai/onnx/operators/onnx__Sigmoid.html#sigmoid-1 "Online Documentation")
-
-
-        Sigmoid takes one input data (Tensor<T>) and produces one output data
-        (Tensor<T>) where the sigmoid function, y = 1 / (1 + exp(-x)), is applied to the
-        tensor elementwise.
-
-
-        Args:
-            X: Input tensor
-
-            consumed_inputs: legacy optimization attribute.
-        """
-
-        schema = get_schema("Sigmoid", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Sigmoid", schema)
-        return op(*self._prepare_inputs(schema, X), consumed_inputs=consumed_inputs)
-
-    def Size(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> INT64:
-        r"""[🌐 Size(1)](https://onnx.ai/onnx/operators/onnx__Size.html#size-1 "Online Documentation")
-
-
-        Takes a tensor as input and outputs a int64 scalar that equals to the total number of elements of the input tensor.
-
-
-        Args:
-            data: An input tensor.
-        """
-
-        schema = get_schema("Size", 1, "")
-        op: Callable[..., INT64] = Op(self, "Size", schema)
-        return op(*self._prepare_inputs(schema, data))
-
-    def Slice(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axes: Optional[Sequence[int]] = None,
-        ends: Optional[Sequence[int]] = None,
-        starts: Optional[Sequence[int]] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -3630,7 +3341,108 @@ class Opset1(Opset):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    T1 = TypeVar("T1", bound=INT64)
+
+    def Shape(self, data: T) -> T1:
+        r"""[🌐 Shape(1)](https://onnx.ai/onnx/operators/onnx__Shape.html#shape-1 "Online Documentation")
+
+
+        Takes a tensor as input and outputs an 1D int64 tensor containing the shape of the input tensor.
+
+
+        Args:
+            data: An input tensor.
+        """
+
+        schema = get_schema("Shape", 1, "")
+        op = Op(self, "Shape", schema)
+        return op(*self._prepare_inputs(schema, data))
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Sigmoid(self, X: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
+        r"""[🌐 Sigmoid(1)](https://onnx.ai/onnx/operators/onnx__Sigmoid.html#sigmoid-1 "Online Documentation")
+
+
+        Sigmoid takes one input data (Tensor<T>) and produces one output data
+        (Tensor<T>) where the sigmoid function, y = 1 / (1 + exp(-x)), is applied to the
+        tensor elementwise.
+
+
+        Args:
+            X: Input tensor
+
+            consumed_inputs: legacy optimization attribute.
+        """
+
+        schema = get_schema("Sigmoid", 1, "")
+        op = Op(self, "Sigmoid", schema)
+        return op(*self._prepare_inputs(schema, X), consumed_inputs=consumed_inputs)
+
+    T = TypeVar(
+        "T",
+        BOOL,
+        COMPLEX128,
+        COMPLEX64,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    T1 = TypeVar("T1", bound=INT64)
+
+    def Size(self, data: T) -> T1:
+        r"""[🌐 Size(1)](https://onnx.ai/onnx/operators/onnx__Size.html#size-1 "Online Documentation")
+
+
+        Takes a tensor as input and outputs a int64 scalar that equals to the total number of elements of the input tensor.
+
+
+        Args:
+            data: An input tensor.
+        """
+
+        schema = get_schema("Size", 1, "")
+        op = Op(self, "Size", schema)
+        return op(*self._prepare_inputs(schema, data))
+
+    T = TypeVar(
+        "T",
+        BOOL,
+        COMPLEX128,
+        COMPLEX64,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    def Slice(
+        self,
+        data: T,
+        axes: Optional[Sequence[int]] = None,
+        ends: Optional[Sequence[int]] = None,
+        starts: Optional[Sequence[int]] = None,
+    ) -> T:
         r"""[🌐 Slice(1)](https://onnx.ai/onnx/operators/onnx__Slice.html#slice-1 "Online Documentation")
 
 
@@ -3679,31 +3491,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Slice", 1, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Slice", schema)
+        op = Op(self, "Slice", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, ends=ends, starts=starts)
 
-    def Softmax(
-        self, input: Union[DOUBLE, FLOAT, FLOAT16], axis: int = 1
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Softmax(self, input: T, axis: int = 1) -> T:
         r"""[🌐 Softmax(1)](https://onnx.ai/onnx/operators/onnx__Softmax.html#softmax-1 "Online Documentation")
 
 
@@ -3733,10 +3526,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Softmax", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Softmax", schema)
+        op = Op(self, "Softmax", schema)
         return op(*self._prepare_inputs(schema, input), axis=axis)
 
-    def Softplus(self, X: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Softplus(self, X: T) -> T:
         r"""[🌐 Softplus(1)](https://onnx.ai/onnx/operators/onnx__Softplus.html#softplus-1 "Online Documentation")
 
 
@@ -3750,10 +3545,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Softplus", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Softplus", schema)
+        op = Op(self, "Softplus", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def Softsign(self, input: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Softsign(self, input: T) -> T:
         r"""[🌐 Softsign(1)](https://onnx.ai/onnx/operators/onnx__Softsign.html#softsign-1 "Online Documentation")
 
 
@@ -3765,30 +3562,11 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Softsign", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Softsign", schema)
+        op = Op(self, "Softsign", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def SpaceToDepth(
-        self,
-        input: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        blocksize: Optional[int] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -3804,7 +3582,9 @@ class Opset1(Opset):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def SpaceToDepth(self, input: T, blocksize: Optional[int] = None) -> T:
         r"""[🌐 SpaceToDepth(1)](https://onnx.ai/onnx/operators/onnx__SpaceToDepth.html#spacetodepth-1 "Online Documentation")
 
         SpaceToDepth rearranges blocks of spatial data into depth. More specifically,
@@ -3820,35 +3600,18 @@ class Opset1(Opset):
         """
 
         schema = get_schema("SpaceToDepth", 1, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "SpaceToDepth", schema)
+        op = Op(self, "SpaceToDepth", schema)
         return op(*self._prepare_inputs(schema, input), blocksize=blocksize)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def Split(
         self,
-        input: Union[DOUBLE, FLOAT, FLOAT16],
-        split_: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
+        input: T,
+        split_: Optional[T] = None,
         axis: Optional[int] = None,
         split: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 Split(1)](https://onnx.ai/onnx/operators/onnx__Split.html#split-1 "Online Documentation")
 
         Split a tensor into a list of tensors, along the specified
@@ -3868,12 +3631,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Split", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Split", schema)
+        op = Op(self, "Split", schema)
         return op(*self._prepare_inputs(schema, input, split_), axis=axis, split=split)
 
-    def Sqrt(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], consumed_inputs: Optional[Sequence[int]] = None
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Sqrt(self, X: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Sqrt(1)](https://onnx.ai/onnx/operators/onnx__Sqrt.html#sqrt-1 "Online Documentation")
 
 
@@ -3889,30 +3652,11 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Sqrt", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Sqrt", schema)
+        op = Op(self, "Sqrt", schema)
         return op(*self._prepare_inputs(schema, X), consumed_inputs=consumed_inputs)
 
-    def Squeeze(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axes: Optional[Sequence[int]] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -3928,7 +3672,9 @@ class Opset1(Opset):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Squeeze(self, data: T, axes: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Squeeze(1)](https://onnx.ai/onnx/operators/onnx__Squeeze.html#squeeze-1 "Online Documentation")
 
 
@@ -3945,36 +3691,19 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Squeeze", 1, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Squeeze", schema)
+        op = Op(self, "Squeeze", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def Sub(
         self,
-        A: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Union[DOUBLE, FLOAT, FLOAT16],
+        A: T,
+        B: T,
         axis: Optional[int] = None,
         broadcast: int = 0,
         consumed_inputs: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 Sub(1)](https://onnx.ai/onnx/operators/onnx__Sub.html#sub-1 "Online Documentation")
 
 
@@ -4014,7 +3743,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Sub", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Sub", schema)
+        op = Op(self, "Sub", schema)
         return op(
             *self._prepare_inputs(schema, A, B),
             axis=axis,
@@ -4022,11 +3751,9 @@ class Opset1(Opset):
             consumed_inputs=consumed_inputs,
         )
 
-    def Sum(
-        self,
-        *data_0: Union[DOUBLE, FLOAT, FLOAT16],
-        consumed_inputs: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Sum(self, *data_0: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Sum(1)](https://onnx.ai/onnx/operators/onnx__Sum.html#sum-1 "Online Documentation")
 
 
@@ -4041,14 +3768,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Sum", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Sum", schema)
+        op = Op(self, "Sum", schema)
         return op(*self._prepare_inputs(schema, *data_0), consumed_inputs=consumed_inputs)
 
-    def Tanh(
-        self,
-        input: Union[DOUBLE, FLOAT, FLOAT16],
-        consumed_inputs: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Tanh(self, input: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Tanh(1)](https://onnx.ai/onnx/operators/onnx__Tanh.html#tanh-1 "Online Documentation")
 
 
@@ -4062,15 +3787,12 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Tanh", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Tanh", schema)
+        op = Op(self, "Tanh", schema)
         return op(*self._prepare_inputs(schema, input), consumed_inputs=consumed_inputs)
 
-    def Tile(
-        self,
-        input: Union[DOUBLE, FLOAT, FLOAT16],
-        tiles: Union[DOUBLE, FLOAT, FLOAT16],
-        axis: Union[DOUBLE, FLOAT, FLOAT16],
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Tile(self, input: T, tiles: T, axis: T) -> T:
         r"""[🌐 Tile(1)](https://onnx.ai/onnx/operators/onnx__Tile.html#tile-1 "Online Documentation")
 
         Repeat the elements of a tensor along an axis.
@@ -4084,12 +3806,14 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Tile", 1, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Tile", schema)
+        op = Op(self, "Tile", schema)
         return op(*self._prepare_inputs(schema, input, tiles, axis))
 
-    def TopK(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], axis: int = -1, k: Optional[int] = None
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16], INT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    I = TypeVar("I", bound=INT64)
+
+    def TopK(self, X: T, axis: int = -1, k: Optional[int] = None) -> Tuple[T, I]:
         r"""[🌐 TopK(1)](https://onnx.ai/onnx/operators/onnx__TopK.html#topk-1 "Online Documentation")
 
 
@@ -4113,32 +3837,11 @@ class Opset1(Opset):
         """
 
         schema = get_schema("TopK", 1, "")
-        op: Callable[..., Tuple[Union[DOUBLE, FLOAT, FLOAT16], INT64]] = Op(
-            self, "TopK", schema
-        )
+        op = Op(self, "TopK", schema)
         return op(*self._prepare_inputs(schema, X), axis=axis, k=k)
 
-    def Transpose(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        perm: Optional[Sequence[int]] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -4154,7 +3857,9 @@ class Opset1(Opset):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Transpose(self, data: T, perm: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Transpose(1)](https://onnx.ai/onnx/operators/onnx__Transpose.html#transpose-1 "Online Documentation")
 
 
@@ -4171,49 +3876,11 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Transpose", 1, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Transpose", schema)
+        op = Op(self, "Transpose", schema)
         return op(*self._prepare_inputs(schema, data), perm=perm)
 
-    def Unsqueeze(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axes: Optional[Sequence[int]] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -4229,7 +3896,9 @@ class Opset1(Opset):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Unsqueeze(self, data: T, axes: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Unsqueeze(1)](https://onnx.ai/onnx/operators/onnx__Unsqueeze.html#unsqueeze-1 "Online Documentation")
 
 
@@ -4247,35 +3916,18 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Unsqueeze", 1, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Unsqueeze", schema)
+        op = Op(self, "Unsqueeze", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes)
+
+    T = TypeVar("T", BOOL, DOUBLE, FLOAT, FLOAT16, INT32, INT64)
 
     def Upsample(
         self,
-        X: Union[BOOL, DOUBLE, FLOAT, FLOAT16, INT32, INT64],
+        X: T,
         height_scale: Optional[float] = None,
         mode: str = "nearest",
         width_scale: Optional[float] = None,
-    ) -> Union[BOOL, DOUBLE, FLOAT, FLOAT16, INT32, INT64]:
+    ) -> T:
         r"""[🌐 Upsample(1)](https://onnx.ai/onnx/operators/onnx__Upsample.html#upsample-1 "Online Documentation")
 
 
@@ -4314,9 +3966,7 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Upsample", 1, "")
-        op: Callable[..., Union[BOOL, DOUBLE, FLOAT, FLOAT16, INT32, INT64]] = Op(
-            self, "Upsample", schema
-        )
+        op = Op(self, "Upsample", schema)
         return op(
             *self._prepare_inputs(schema, X),
             height_scale=height_scale,
@@ -4324,7 +3974,11 @@ class Opset1(Opset):
             width_scale=width_scale,
         )
 
-    def Xor(self, A: BOOL, B: BOOL, axis: Optional[int] = None, broadcast: int = 0) -> BOOL:
+    T = TypeVar("T", bound=BOOL)
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Xor(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T1:
         r"""[🌐 Xor(1)](https://onnx.ai/onnx/operators/onnx__Xor.html#xor-1 "Online Documentation")
 
 
@@ -4347,5 +4001,5 @@ class Opset1(Opset):
         """
 
         schema = get_schema("Xor", 1, "")
-        op: Callable[..., BOOL] = Op(self, "Xor", schema)
+        op = Op(self, "Xor", schema)
         return op(*self._prepare_inputs(schema, A, B), axis=axis, broadcast=broadcast)

--- a/onnxscript/onnx_opset/_impl/opset10.py
+++ b/onnxscript/onnx_opset/_impl/opset10.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Tuple, TypeVar
 
 from onnx.defs import get_schema
 
@@ -42,16 +42,18 @@ class Opset10(Opset9):
     def __init__(self):
         super().__init__()
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def AveragePool(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         count_include_pad: int = 0,
         kernel_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 AveragePool(10)](https://onnx.ai/onnx/operators/onnx__AveragePool.html#averagepool-10 "Online Documentation")
 
 
@@ -124,7 +126,7 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("AveragePool", 10, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "AveragePool", schema)
+        op = Op(self, "AveragePool", schema)
         return op(
             *self._prepare_inputs(schema, X),
             auto_pad=auto_pad,
@@ -135,19 +137,25 @@ class Opset10(Opset9):
             strides=strides,
         )
 
+    T1 = TypeVar("T1", INT8, UINT8)
+
+    T2 = TypeVar("T2", INT8, UINT8)
+
+    T3 = TypeVar("T3", bound=INT32)
+
     def ConvInteger(
         self,
-        x: Union[INT8, UINT8],
-        w: Union[INT8, UINT8],
-        x_zero_point: Optional[Union[INT8, UINT8]] = None,
-        w_zero_point: Optional[Union[INT8, UINT8]] = None,
+        x: T1,
+        w: T2,
+        x_zero_point: Optional[T1] = None,
+        w_zero_point: Optional[T2] = None,
         auto_pad: str = "NOTSET",
         dilations: Optional[Sequence[int]] = None,
         group: int = 1,
         kernel_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
-    ) -> INT32:
+    ) -> T3:
         r"""[🌐 ConvInteger(10)](https://onnx.ai/onnx/operators/onnx__ConvInteger.html#convinteger-10 "Online Documentation")
 
 
@@ -219,7 +227,7 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("ConvInteger", 10, "")
-        op: Callable[..., INT32] = Op(self, "ConvInteger", schema)
+        op = Op(self, "ConvInteger", schema)
         return op(
             *self._prepare_inputs(schema, x, w, x_zero_point, w_zero_point),
             auto_pad=auto_pad,
@@ -230,11 +238,10 @@ class Opset10(Opset9):
             strides=strides,
         )
 
+    T = TypeVar("T", INT32, INT8, UINT8)
+
     def DequantizeLinear(
-        self,
-        x: Union[INT32, INT8, UINT8],
-        x_scale: FLOAT,
-        x_zero_point: Optional[Union[INT32, INT8, UINT8]] = None,
+        self, x: T, x_scale: FLOAT, x_zero_point: Optional[T] = None
     ) -> FLOAT:
         r"""[🌐 DequantizeLinear(10)](https://onnx.ai/onnx/operators/onnx__DequantizeLinear.html#dequantizelinear-10 "Online Documentation")
 
@@ -257,12 +264,14 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("DequantizeLinear", 10, "")
-        op: Callable[..., FLOAT] = Op(self, "DequantizeLinear", schema)
+        op = Op(self, "DequantizeLinear", schema)
         return op(*self._prepare_inputs(schema, x, x_scale, x_zero_point))
 
-    def Dropout(
-        self, data: Union[DOUBLE, FLOAT, FLOAT16], ratio: float = 0.5
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16], BOOL]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Dropout(self, data: T, ratio: float = 0.5) -> Tuple[T, T1]:
         r"""[🌐 Dropout(10)](https://onnx.ai/onnx/operators/onnx__Dropout.html#dropout-10 "Online Documentation")
 
 
@@ -281,14 +290,14 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("Dropout", 10, "")
-        op: Callable[..., Tuple[Union[DOUBLE, FLOAT, FLOAT16], BOOL]] = Op(
-            self, "Dropout", schema
-        )
+        op = Op(self, "Dropout", schema)
         return op(*self._prepare_inputs(schema, data), ratio=ratio)
 
-    def IsInf(
-        self, X: Union[DOUBLE, FLOAT], detect_negative: int = 1, detect_positive: int = 1
-    ) -> BOOL:
+    T1 = TypeVar("T1", DOUBLE, FLOAT)
+
+    T2 = TypeVar("T2", bound=BOOL)
+
+    def IsInf(self, X: T1, detect_negative: int = 1, detect_positive: int = 1) -> T2:
         r"""[🌐 IsInf(10)](https://onnx.ai/onnx/operators/onnx__IsInf.html#isinf-10 "Online Documentation")
 
         Map infinity to true and other values to false.
@@ -306,20 +315,26 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("IsInf", 10, "")
-        op: Callable[..., BOOL] = Op(self, "IsInf", schema)
+        op = Op(self, "IsInf", schema)
         return op(
             *self._prepare_inputs(schema, X),
             detect_negative=detect_negative,
             detect_positive=detect_positive,
         )
 
+    T1 = TypeVar("T1", INT8, UINT8)
+
+    T2 = TypeVar("T2", INT8, UINT8)
+
+    T3 = TypeVar("T3", bound=INT32)
+
     def MatMulInteger(
         self,
-        A: Union[INT8, UINT8],
-        B: Union[INT8, UINT8],
-        a_zero_point: Optional[Union[INT8, UINT8]] = None,
-        b_zero_point: Optional[Union[INT8, UINT8]] = None,
-    ) -> INT32:
+        A: T1,
+        B: T2,
+        a_zero_point: Optional[T1] = None,
+        b_zero_point: Optional[T2] = None,
+    ) -> T3:
         r"""[🌐 MatMulInteger(10)](https://onnx.ai/onnx/operators/onnx__MatMulInteger.html#matmulinteger-10 "Online Documentation")
 
 
@@ -350,12 +365,16 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("MatMulInteger", 10, "")
-        op: Callable[..., INT32] = Op(self, "MatMulInteger", schema)
+        op = Op(self, "MatMulInteger", schema)
         return op(*self._prepare_inputs(schema, A, B, a_zero_point, b_zero_point))
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    I = TypeVar("I", bound=INT64)
 
     def MaxPool(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         dilations: Optional[Sequence[int]] = None,
@@ -363,7 +382,7 @@ class Opset10(Opset9):
         pads: Optional[Sequence[int]] = None,
         storage_order: int = 0,
         strides: Optional[Sequence[int]] = None,
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16], INT64]:
+    ) -> Tuple[T, I]:
         r"""[🌐 MaxPool(10)](https://onnx.ai/onnx/operators/onnx__MaxPool.html#maxpool-10 "Online Documentation")
 
 
@@ -438,9 +457,7 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("MaxPool", 10, "")
-        op: Callable[..., Tuple[Union[DOUBLE, FLOAT, FLOAT16], INT64]] = Op(
-            self, "MaxPool", schema
-        )
+        op = Op(self, "MaxPool", schema)
         return op(
             *self._prepare_inputs(schema, X),
             auto_pad=auto_pad,
@@ -452,18 +469,11 @@ class Opset10(Opset9):
             strides=strides,
         )
 
-    def Mod(
-        self,
-        A: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        B: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        fmod: int = 0,
-    ) -> Union[
-        DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-    ]:
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    def Mod(self, A: T, B: T, fmod: int = 0) -> T:
         r"""[🌐 Mod(10)](https://onnx.ai/onnx/operators/onnx__Mod.html#mod-10 "Online Documentation")
 
 
@@ -492,22 +502,7 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("Mod", 10, "")
-        op: Callable[
-            ...,
-            Union[
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Mod", schema)
+        op = Op(self, "Mod", schema)
         return op(*self._prepare_inputs(schema, A, B), fmod=fmod)
 
     def NonMaxSuppression(
@@ -559,7 +554,7 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("NonMaxSuppression", 10, "")
-        op: Callable[..., INT64] = Op(self, "NonMaxSuppression", schema)
+        op = Op(self, "NonMaxSuppression", schema)
         return op(
             *self._prepare_inputs(
                 schema,
@@ -572,24 +567,32 @@ class Opset10(Opset9):
             center_point_box=center_point_box,
         )
 
+    T1 = TypeVar("T1", INT8, UINT8)
+
+    T2 = TypeVar("T2", INT8, UINT8)
+
+    T3 = TypeVar("T3", INT8, UINT8)
+
+    T4 = TypeVar("T4", bound=INT32)
+
     def QLinearConv(
         self,
-        x: Union[INT8, UINT8],
+        x: T1,
         x_scale: FLOAT,
-        x_zero_point: Union[INT8, UINT8],
-        w: Union[INT8, UINT8],
+        x_zero_point: T1,
+        w: T2,
         w_scale: FLOAT,
-        w_zero_point: Union[INT8, UINT8],
+        w_zero_point: T2,
         y_scale: FLOAT,
-        y_zero_point: Union[INT8, UINT8],
-        B: Optional[INT32] = None,
+        y_zero_point: T3,
+        B: Optional[T4] = None,
         auto_pad: str = "NOTSET",
         dilations: Optional[Sequence[int]] = None,
         group: int = 1,
         kernel_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
-    ) -> Union[INT8, UINT8]:
+    ) -> T3:
         r"""[🌐 QLinearConv(10)](https://onnx.ai/onnx/operators/onnx__QLinearConv.html#qlinearconv-10 "Online Documentation")
 
 
@@ -682,7 +685,7 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("QLinearConv", 10, "")
-        op: Callable[..., Union[INT8, UINT8]] = Op(self, "QLinearConv", schema)
+        op = Op(self, "QLinearConv", schema)
         return op(
             *self._prepare_inputs(
                 schema,
@@ -704,17 +707,23 @@ class Opset10(Opset9):
             strides=strides,
         )
 
+    T1 = TypeVar("T1", INT8, UINT8)
+
+    T2 = TypeVar("T2", INT8, UINT8)
+
+    T3 = TypeVar("T3", INT8, UINT8)
+
     def QLinearMatMul(
         self,
-        a: Union[INT8, UINT8],
+        a: T1,
         a_scale: FLOAT,
-        a_zero_point: Union[INT8, UINT8],
-        b: Union[INT8, UINT8],
+        a_zero_point: T1,
+        b: T2,
         b_scale: FLOAT,
-        b_zero_point: Union[INT8, UINT8],
+        b_zero_point: T2,
         y_scale: FLOAT,
-        y_zero_point: Union[INT8, UINT8],
-    ) -> Union[INT8, UINT8]:
+        y_zero_point: T3,
+    ) -> T3:
         r"""[🌐 QLinearMatMul(10)](https://onnx.ai/onnx/operators/onnx__QLinearMatMul.html#qlinearmatmul-10 "Online Documentation")
 
 
@@ -750,7 +759,7 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("QLinearMatMul", 10, "")
-        op: Callable[..., Union[INT8, UINT8]] = Op(self, "QLinearMatMul", schema)
+        op = Op(self, "QLinearMatMul", schema)
         return op(
             *self._prepare_inputs(
                 schema,
@@ -765,12 +774,11 @@ class Opset10(Opset9):
             )
         )
 
-    def QuantizeLinear(
-        self,
-        x: Union[FLOAT, INT32],
-        y_scale: FLOAT,
-        y_zero_point: Optional[Union[INT8, UINT8]] = None,
-    ) -> Union[INT8, UINT8]:
+    T1 = TypeVar("T1", FLOAT, INT32)
+
+    T2 = TypeVar("T2", INT8, UINT8)
+
+    def QuantizeLinear(self, x: T1, y_scale: FLOAT, y_zero_point: Optional[T2] = None) -> T2:
         r"""[🌐 QuantizeLinear(10)](https://onnx.ai/onnx/operators/onnx__QuantizeLinear.html#quantizelinear-10 "Online Documentation")
 
 
@@ -791,31 +799,11 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("QuantizeLinear", 10, "")
-        op: Callable[..., Union[INT8, UINT8]] = Op(self, "QuantizeLinear", schema)
+        op = Op(self, "QuantizeLinear", schema)
         return op(*self._prepare_inputs(schema, x, y_scale, y_zero_point))
 
-    def Resize(
-        self,
-        X: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        scales: FLOAT,
-        mode: str = "nearest",
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -831,7 +819,9 @@ class Opset10(Opset9):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Resize(self, X: T, scales: FLOAT, mode: str = "nearest") -> T:
         r"""[🌐 Resize(10)](https://onnx.ai/onnx/operators/onnx__Resize.html#resize-10 "Online Documentation")
 
 
@@ -853,51 +843,11 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("Resize", 10, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Resize", schema)
+        op = Op(self, "Resize", schema)
         return op(*self._prepare_inputs(schema, X, scales), mode=mode)
 
-    def ReverseSequence(
-        self,
-        input: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        sequence_lens: INT64,
-        batch_axis: int = 1,
-        time_axis: int = 0,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -913,7 +863,11 @@ class Opset10(Opset9):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def ReverseSequence(
+        self, input: T, sequence_lens: INT64, batch_axis: int = 1, time_axis: int = 0
+    ) -> T:
         r"""[🌐 ReverseSequence(10)](https://onnx.ai/onnx/operators/onnx__ReverseSequence.html#reversesequence-10 "Online Documentation")
 
 
@@ -966,43 +920,28 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("ReverseSequence", 10, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "ReverseSequence", schema)
+        op = Op(self, "ReverseSequence", schema)
         return op(
             *self._prepare_inputs(schema, input, sequence_lens),
             batch_axis=batch_axis,
             time_axis=time_axis,
         )
 
+    T1 = TypeVar("T1", DOUBLE, FLOAT, FLOAT16)
+
+    T2 = TypeVar("T2", bound=INT64)
+
     def RoiAlign(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        rois: Union[DOUBLE, FLOAT, FLOAT16],
-        batch_indices: INT64,
+        X: T1,
+        rois: T1,
+        batch_indices: T2,
         mode: str = "avg",
         output_height: int = 1,
         output_width: int = 1,
         sampling_ratio: int = 0,
         spatial_scale: float = 1.0,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T1:
         r"""[🌐 RoiAlign(10)](https://onnx.ai/onnx/operators/onnx__RoiAlign.html#roialign-10 "Online Documentation")
 
 
@@ -1052,7 +991,7 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("RoiAlign", 10, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "RoiAlign", schema)
+        op = Op(self, "RoiAlign", schema)
         return op(
             *self._prepare_inputs(schema, X, rois, batch_indices),
             mode=mode,
@@ -1062,30 +1001,8 @@ class Opset10(Opset9):
             spatial_scale=spatial_scale,
         )
 
-    def Slice(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        starts: Union[INT32, INT64],
-        ends: Union[INT32, INT64],
-        axes: Optional[Union[INT32, INT64]] = None,
-        steps: Optional[Union[INT32, INT64]] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -1101,7 +1018,18 @@ class Opset10(Opset9):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    Tind = TypeVar("Tind", INT32, INT64)
+
+    def Slice(
+        self,
+        data: T,
+        starts: Tind,
+        ends: Tind,
+        axes: Optional[Tind] = None,
+        steps: Optional[Tind] = None,
+    ) -> T:
         r"""[🌐 Slice(10)](https://onnx.ai/onnx/operators/onnx__Slice.html#slice-10 "Online Documentation")
 
 
@@ -1156,26 +1084,7 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("Slice", 10, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Slice", schema)
+        op = Op(self, "Slice", schema)
         return op(*self._prepare_inputs(schema, data, starts, ends, axes, steps))
 
     def StringNormalizer(
@@ -1218,7 +1127,7 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("StringNormalizer", 10, "")
-        op: Callable[..., STRING] = Op(self, "StringNormalizer", schema)
+        op = Op(self, "StringNormalizer", schema)
         return op(
             *self._prepare_inputs(schema, X),
             case_change_action=case_change_action,
@@ -1227,9 +1136,9 @@ class Opset10(Opset9):
             stopwords=stopwords,
         )
 
-    def ThresholdedRelu(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], alpha: float = 1.0
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def ThresholdedRelu(self, X: T, alpha: float = 1.0) -> T:
         r"""[🌐 ThresholdedRelu(10)](https://onnx.ai/onnx/operators/onnx__ThresholdedRelu.html#thresholdedrelu-10 "Online Documentation")
 
 
@@ -1245,12 +1154,14 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("ThresholdedRelu", 10, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "ThresholdedRelu", schema)
+        op = Op(self, "ThresholdedRelu", schema)
         return op(*self._prepare_inputs(schema, X), alpha=alpha)
 
-    def TopK(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], K: INT64, axis: int = -1
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16], INT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    I = TypeVar("I", bound=INT64)
+
+    def TopK(self, X: T, K: INT64, axis: int = -1) -> Tuple[T, I]:
         r"""[🌐 TopK(10)](https://onnx.ai/onnx/operators/onnx__TopK.html#topk-10 "Online Documentation")
 
 
@@ -1276,7 +1187,5 @@ class Opset10(Opset9):
         """
 
         schema = get_schema("TopK", 10, "")
-        op: Callable[..., Tuple[Union[DOUBLE, FLOAT, FLOAT16], INT64]] = Op(
-            self, "TopK", schema
-        )
+        op = Op(self, "TopK", schema)
         return op(*self._prepare_inputs(schema, X, K), axis=axis)

--- a/onnxscript/onnx_opset/_impl/opset11.py
+++ b/onnxscript/onnx_opset/_impl/opset11.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Tuple, TypeVar
 
 from onnx import GraphProto, SparseTensorProto, TensorProto
 from onnx.defs import get_schema
@@ -43,14 +43,11 @@ class Opset11(Opset10):
     def __init__(self):
         super().__init__()
 
-    def ArgMax(
-        self,
-        data: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        axis: int = 0,
-        keepdims: int = 1,
-    ) -> INT64:
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    def ArgMax(self, data: T, axis: int = 0, keepdims: int = 1) -> INT64:
         r"""[🌐 ArgMax(11)](https://onnx.ai/onnx/operators/onnx__ArgMax.html#argmax-11 "Online Documentation")
 
 
@@ -70,17 +67,14 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("ArgMax", 11, "")
-        op: Callable[..., INT64] = Op(self, "ArgMax", schema)
+        op = Op(self, "ArgMax", schema)
         return op(*self._prepare_inputs(schema, data), axis=axis, keepdims=keepdims)
 
-    def ArgMin(
-        self,
-        data: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        axis: int = 0,
-        keepdims: int = 1,
-    ) -> INT64:
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    def ArgMin(self, data: T, axis: int = 0, keepdims: int = 1) -> INT64:
         r"""[🌐 ArgMin(11)](https://onnx.ai/onnx/operators/onnx__ArgMin.html#argmin-11 "Online Documentation")
 
 
@@ -100,19 +94,21 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("ArgMin", 11, "")
-        op: Callable[..., INT64] = Op(self, "ArgMin", schema)
+        op = Op(self, "ArgMin", schema)
         return op(*self._prepare_inputs(schema, data), axis=axis, keepdims=keepdims)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def AveragePool(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         count_include_pad: int = 0,
         kernel_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 AveragePool(11)](https://onnx.ai/onnx/operators/onnx__AveragePool.html#averagepool-11 "Online Documentation")
 
 
@@ -188,7 +184,7 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("AveragePool", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "AveragePool", schema)
+        op = Op(self, "AveragePool", schema)
         return op(
             *self._prepare_inputs(schema, X),
             auto_pad=auto_pad,
@@ -199,12 +195,9 @@ class Opset11(Opset10):
             strides=strides,
         )
 
-    def BitShift(
-        self,
-        X: Union[UINT16, UINT32, UINT64, UINT8],
-        Y: Union[UINT16, UINT32, UINT64, UINT8],
-        direction: Optional[str] = None,
-    ) -> Union[UINT16, UINT32, UINT64, UINT8]:
+    T = TypeVar("T", UINT16, UINT32, UINT64, UINT8)
+
+    def BitShift(self, X: T, Y: T, direction: Optional[str] = None) -> T:
         r"""[🌐 BitShift(11)](https://onnx.ai/onnx/operators/onnx__BitShift.html#bitshift-11 "Online Documentation")
 
 
@@ -231,15 +224,12 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("BitShift", 11, "")
-        op: Callable[..., Union[UINT16, UINT32, UINT64, UINT8]] = Op(self, "BitShift", schema)
+        op = Op(self, "BitShift", schema)
         return op(*self._prepare_inputs(schema, X, Y), direction=direction)
 
-    def Clip(
-        self,
-        input: Union[DOUBLE, FLOAT, FLOAT16],
-        min: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        max: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Clip(self, input: T, min: Optional[T] = None, max: Optional[T] = None) -> T:
         r"""[🌐 Clip(11)](https://onnx.ai/onnx/operators/onnx__Clip.html#clip-11 "Online Documentation")
 
 
@@ -259,31 +249,11 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Clip", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Clip", schema)
+        op = Op(self, "Clip", schema)
         return op(*self._prepare_inputs(schema, input, min, max))
 
-    def Compress(
-        self,
-        input: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        condition: BOOL,
-        axis: Optional[int] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -299,7 +269,11 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Compress(self, input: T, condition: T1, axis: Optional[int] = None) -> T:
         r"""[🌐 Compress(11)](https://onnx.ai/onnx/operators/onnx__Compress.html#compress-11 "Online Documentation")
 
 
@@ -324,49 +298,11 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Compress", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Compress", schema)
+        op = Op(self, "Compress", schema)
         return op(*self._prepare_inputs(schema, input, condition), axis=axis)
 
-    def Concat(
-        self,
-        *inputs: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axis: Optional[int] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -382,7 +318,9 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Concat(self, *inputs: T, axis: Optional[int] = None) -> T:
         r"""[🌐 Concat(11)](https://onnx.ai/onnx/operators/onnx__Concat.html#concat-11 "Online Documentation")
 
         Concatenate a list of tensors into a single tensor. All input tensors must have the same shape, except for the dimension size of the axis to concatenate on.
@@ -395,50 +333,30 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Concat", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Concat", schema)
+        op = Op(self, "Concat", schema)
         return op(*self._prepare_inputs(schema, *inputs), axis=axis)
 
-    def ConcatFromSequence(
-        self,
-        input_sequence: Union[
-            Sequence[BOOL],
-            Sequence[COMPLEX128],
-            Sequence[COMPLEX64],
-            Sequence[DOUBLE],
-            Sequence[FLOAT],
-            Sequence[FLOAT16],
-            Sequence[INT16],
-            Sequence[INT32],
-            Sequence[INT64],
-            Sequence[INT8],
-            Sequence[STRING],
-            Sequence[UINT16],
-            Sequence[UINT32],
-            Sequence[UINT64],
-            Sequence[UINT8],
-        ],
-        axis: Optional[int] = None,
-        new_axis: int = 0,
-    ) -> Union[
+    S = TypeVar(
+        "S",
+        Sequence[BOOL],
+        Sequence[COMPLEX128],
+        Sequence[COMPLEX64],
+        Sequence[DOUBLE],
+        Sequence[FLOAT],
+        Sequence[FLOAT16],
+        Sequence[INT16],
+        Sequence[INT32],
+        Sequence[INT64],
+        Sequence[INT8],
+        Sequence[STRING],
+        Sequence[UINT16],
+        Sequence[UINT32],
+        Sequence[UINT64],
+        Sequence[UINT8],
+    )
+
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -454,7 +372,11 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def ConcatFromSequence(
+        self, input_sequence: S, axis: Optional[int] = None, new_axis: int = 0
+    ) -> T:
         r"""[🌐 ConcatFromSequence(11)](https://onnx.ai/onnx/operators/onnx__ConcatFromSequence.html#concatfromsequence-11 "Online Documentation")
 
 
@@ -476,33 +398,11 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("ConcatFromSequence", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "ConcatFromSequence", schema)
+        op = Op(self, "ConcatFromSequence", schema)
         return op(*self._prepare_inputs(schema, input_sequence), axis=axis, new_axis=new_axis)
 
-    def Constant(
-        self,
-        sparse_value: Optional[SparseTensorProto] = None,
-        value: Optional[TensorProto] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -518,7 +418,13 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Constant(
+        self,
+        sparse_value: Optional[SparseTensorProto] = None,
+        value: Optional[TensorProto] = None,
+    ) -> T:
         r"""[🌐 Constant(11)](https://onnx.ai/onnx/operators/onnx__Constant.html#constant-11 "Online Documentation")
 
 
@@ -534,40 +440,23 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Constant", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Constant", schema)
+        op = Op(self, "Constant", schema)
         return op(sparse_value=sparse_value, value=value)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def Conv(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        W: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
+        X: T,
+        W: T,
+        B: Optional[T] = None,
         auto_pad: str = "NOTSET",
         dilations: Optional[Sequence[int]] = None,
         group: int = 1,
         kernel_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 Conv(11)](https://onnx.ai/onnx/operators/onnx__Conv.html#conv-11 "Online Documentation")
 
 
@@ -632,7 +521,7 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Conv", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Conv", schema)
+        op = Op(self, "Conv", schema)
         return op(
             *self._prepare_inputs(schema, X, W, B),
             auto_pad=auto_pad,
@@ -643,11 +532,13 @@ class Opset11(Opset10):
             strides=strides,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def ConvTranspose(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        W: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
+        X: T,
+        W: T,
+        B: Optional[T] = None,
         auto_pad: str = "NOTSET",
         dilations: Optional[Sequence[int]] = None,
         group: int = 1,
@@ -656,7 +547,7 @@ class Opset11(Opset10):
         output_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 ConvTranspose(11)](https://onnx.ai/onnx/operators/onnx__ConvTranspose.html#convtranspose-11 "Online Documentation")
 
 
@@ -739,7 +630,7 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("ConvTranspose", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "ConvTranspose", schema)
+        op = Op(self, "ConvTranspose", schema)
         return op(
             *self._prepare_inputs(schema, X, W, B),
             auto_pad=auto_pad,
@@ -752,13 +643,11 @@ class Opset11(Opset10):
             strides=strides,
         )
 
-    def CumSum(
-        self,
-        x: Union[DOUBLE, FLOAT, INT32, INT64, UINT32, UINT64],
-        axis: Union[INT32, INT64],
-        exclusive: int = 0,
-        reverse: int = 0,
-    ) -> Union[DOUBLE, FLOAT, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, INT32, INT64, UINT32, UINT64)
+
+    T2 = TypeVar("T2", INT32, INT64)
+
+    def CumSum(self, x: T, axis: T2, exclusive: int = 0, reverse: int = 0) -> T:
         r"""[🌐 CumSum(11)](https://onnx.ai/onnx/operators/onnx__CumSum.html#cumsum-11 "Online Documentation")
 
 
@@ -800,33 +689,11 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("CumSum", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "CumSum", schema
-        )
+        op = Op(self, "CumSum", schema)
         return op(*self._prepare_inputs(schema, x, axis), exclusive=exclusive, reverse=reverse)
 
-    def DepthToSpace(
-        self,
-        input: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        blocksize: Optional[int] = None,
-        mode: str = "DCR",
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -842,7 +709,9 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def DepthToSpace(self, input: T, blocksize: Optional[int] = None, mode: str = "DCR") -> T:
         r"""[🌐 DepthToSpace(11)](https://onnx.ai/onnx/operators/onnx__DepthToSpace.html#depthtospace-11 "Online Documentation")
 
         DepthToSpace rearranges (permutes) data from depth into blocks of spatial data.
@@ -885,29 +754,12 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("DepthToSpace", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "DepthToSpace", schema)
+        op = Op(self, "DepthToSpace", schema)
         return op(*self._prepare_inputs(schema, input), blocksize=blocksize, mode=mode)
 
-    def Det(self, X: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Det(self, X: T) -> T:
         r"""[🌐 Det(11)](https://onnx.ai/onnx/operators/onnx__Det.html#det-11 "Online Documentation")
 
 
@@ -923,10 +775,14 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Det", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Det", schema)
+        op = Op(self, "Det", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def DynamicQuantizeLinear(self, x: FLOAT) -> Tuple[UINT8, FLOAT, UINT8]:
+    T1 = TypeVar("T1", bound=FLOAT)
+
+    T2 = TypeVar("T2", bound=UINT8)
+
+    def DynamicQuantizeLinear(self, x: T1) -> Tuple[T2, FLOAT, T2]:
         r"""[🌐 DynamicQuantizeLinear(11)](https://onnx.ai/onnx/operators/onnx__DynamicQuantizeLinear.html#dynamicquantizelinear-11 "Online Documentation")
 
 
@@ -970,42 +826,28 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("DynamicQuantizeLinear", 11, "")
-        op: Callable[..., Tuple[UINT8, FLOAT, UINT8]] = Op(
-            self, "DynamicQuantizeLinear", schema
-        )
+        op = Op(self, "DynamicQuantizeLinear", schema)
         return op(*self._prepare_inputs(schema, x))
 
-    def Equal(
-        self,
-        A: Union[
-            BOOL,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        B: Union[
-            BOOL,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> BOOL:
+    T = TypeVar(
+        "T",
+        BOOL,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Equal(self, A: T, B: T) -> T1:
         r"""[🌐 Equal(11)](https://onnx.ai/onnx/operators/onnx__Equal.html#equal-11 "Online Documentation")
 
 
@@ -1022,30 +864,11 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Equal", 11, "")
-        op: Callable[..., BOOL] = Op(self, "Equal", schema)
+        op = Op(self, "Equal", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def Flatten(
-        self,
-        input: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axis: int = 1,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -1061,7 +884,9 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Flatten(self, input: T, axis: int = 1) -> T:
         r"""[🌐 Flatten(11)](https://onnx.ai/onnx/operators/onnx__Flatten.html#flatten-11 "Online Documentation")
 
 
@@ -1082,50 +907,11 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Flatten", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Flatten", schema)
+        op = Op(self, "Flatten", schema)
         return op(*self._prepare_inputs(schema, input), axis=axis)
 
-    def Gather(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        indices: Union[INT32, INT64],
-        axis: int = 0,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -1141,7 +927,11 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    Tind = TypeVar("Tind", INT32, INT64)
+
+    def Gather(self, data: T, indices: Tind, axis: int = 0) -> T:
         r"""[🌐 Gather(11)](https://onnx.ai/onnx/operators/onnx__Gather.html#gather-11 "Online Documentation")
 
 
@@ -1218,50 +1008,11 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Gather", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Gather", schema)
+        op = Op(self, "Gather", schema)
         return op(*self._prepare_inputs(schema, data, indices), axis=axis)
 
-    def GatherElements(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        indices: Union[INT32, INT64],
-        axis: int = 0,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -1277,7 +1028,11 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    Tind = TypeVar("Tind", INT32, INT64)
+
+    def GatherElements(self, data: T, indices: Tind, axis: int = 0) -> T:
         r"""[🌐 GatherElements(11)](https://onnx.ai/onnx/operators/onnx__GatherElements.html#gatherelements-11 "Online Documentation")
 
 
@@ -1357,49 +1112,11 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("GatherElements", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "GatherElements", schema)
+        op = Op(self, "GatherElements", schema)
         return op(*self._prepare_inputs(schema, data, indices), axis=axis)
 
-    def GatherND(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        indices: INT64,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -1415,7 +1132,9 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def GatherND(self, data: T, indices: INT64) -> T:
         r"""[🌐 GatherND(11)](https://onnx.ai/onnx/operators/onnx__GatherND.html#gathernd-11 "Online Documentation")
 
 
@@ -1495,38 +1214,21 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("GatherND", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "GatherND", schema)
+        op = Op(self, "GatherND", schema)
         return op(*self._prepare_inputs(schema, data, indices))
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def Gemm(
         self,
-        A: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        B: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        C: Optional[Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = None,
+        A: T,
+        B: T,
+        C: Optional[T] = None,
         alpha: float = 1.0,
         beta: float = 1.0,
         transA: int = 0,
         transB: int = 0,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    ) -> T:
         r"""[🌐 Gemm(11)](https://onnx.ai/onnx/operators/onnx__Gemm.html#gemm-11 "Online Documentation")
 
         General Matrix multiplication:
@@ -1565,9 +1267,7 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Gemm", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "Gemm", schema
-        )
+        op = Op(self, "Gemm", schema)
         return op(
             *self._prepare_inputs(schema, A, B, C),
             alpha=alpha,
@@ -1576,9 +1276,9 @@ class Opset11(Opset10):
             transB=transB,
         )
 
-    def Hardmax(
-        self, input: Union[DOUBLE, FLOAT, FLOAT16], axis: int = 1
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Hardmax(self, input: T, axis: int = 1) -> T:
         r"""[🌐 Hardmax(11)](https://onnx.ai/onnx/operators/onnx__Hardmax.html#hardmax-11 "Online Documentation")
 
 
@@ -1609,15 +1309,13 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Hardmax", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Hardmax", schema)
+        op = Op(self, "Hardmax", schema)
         return op(*self._prepare_inputs(schema, input), axis=axis)
 
-    def If(
-        self,
-        cond: BOOL,
-        else_branch: Optional[GraphProto] = None,
-        then_branch: Optional[GraphProto] = None,
-    ) -> Union[
+    B = TypeVar("B", bound=BOOL)
+
+    V = TypeVar(
+        "V",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -1633,7 +1331,14 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def If(
+        self,
+        cond: B,
+        else_branch: Optional[GraphProto] = None,
+        then_branch: Optional[GraphProto] = None,
+    ) -> V:
         r"""[🌐 If(11)](https://onnx.ai/onnx/operators/onnx__If.html#if-11 "Online Documentation")
 
         If conditional
@@ -1651,35 +1356,16 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("If", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "If", schema)
+        op = Op(self, "If", schema)
         return op(
             *self._prepare_inputs(schema, cond),
             else_branch=else_branch,
             then_branch=then_branch,
         )
 
-    def LogSoftmax(
-        self, input: Union[DOUBLE, FLOAT, FLOAT16], axis: int = 1
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def LogSoftmax(self, input: T, axis: int = 1) -> T:
         r"""[🌐 LogSoftmax(11)](https://onnx.ai/onnx/operators/onnx__LogSoftmax.html#logsoftmax-11 "Online Documentation")
 
 
@@ -1710,32 +1396,15 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("LogSoftmax", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "LogSoftmax", schema)
+        op = Op(self, "LogSoftmax", schema)
         return op(*self._prepare_inputs(schema, input), axis=axis)
 
-    def Loop(
-        self,
-        M: Optional[INT64],
-        cond: Optional[BOOL],
-        *v_initial: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        body: Optional[GraphProto] = None,
-    ) -> Union[
+    I = TypeVar("I", bound=INT64)
+
+    B = TypeVar("B", bound=BOOL)
+
+    V = TypeVar(
+        "V",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -1751,7 +1420,15 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Loop(
+        self,
+        M: Optional[I],
+        cond: Optional[B],
+        *v_initial: V,
+        body: Optional[GraphProto] = None,
+    ) -> V:
         r"""[🌐 Loop(11)](https://onnx.ai/onnx/operators/onnx__Loop.html#loop-11 "Online Documentation")
 
 
@@ -1910,37 +1587,20 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Loop", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Loop", schema)
+        op = Op(self, "Loop", schema)
         return op(*self._prepare_inputs(schema, M, cond, *v_initial), body=body)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def LpPool(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
         auto_pad: str = "NOTSET",
         kernel_shape: Optional[Sequence[int]] = None,
         p: int = 2,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 LpPool(11)](https://onnx.ai/onnx/operators/onnx__LpPool.html#lppool-11 "Online Documentation")
 
 
@@ -1985,7 +1645,7 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("LpPool", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "LpPool", schema)
+        op = Op(self, "LpPool", schema)
         return op(
             *self._prepare_inputs(schema, X),
             auto_pad=auto_pad,
@@ -1995,9 +1655,13 @@ class Opset11(Opset10):
             strides=strides,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    I = TypeVar("I", bound=INT64)
+
     def MaxPool(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         dilations: Optional[Sequence[int]] = None,
@@ -2005,7 +1669,7 @@ class Opset11(Opset10):
         pads: Optional[Sequence[int]] = None,
         storage_order: int = 0,
         strides: Optional[Sequence[int]] = None,
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16], INT64]:
+    ) -> Tuple[T, I]:
         r"""[🌐 MaxPool(11)](https://onnx.ai/onnx/operators/onnx__MaxPool.html#maxpool-11 "Online Documentation")
 
 
@@ -2082,9 +1746,7 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("MaxPool", 11, "")
-        op: Callable[..., Tuple[Union[DOUBLE, FLOAT, FLOAT16], INT64]] = Op(
-            self, "MaxPool", schema
-        )
+        op = Op(self, "MaxPool", schema)
         return op(
             *self._prepare_inputs(schema, X),
             auto_pad=auto_pad,
@@ -2096,15 +1758,19 @@ class Opset11(Opset10):
             strides=strides,
         )
 
+    T1 = TypeVar("T1", DOUBLE, FLOAT, FLOAT16)
+
+    T2 = TypeVar("T2", bound=INT64)
+
     def MaxUnpool(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        I: INT64,
-        output_shape: Optional[INT64] = None,
+        X: T1,
+        I: T2,
+        output_shape: Optional[T2] = None,
         kernel_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T1:
         r"""[🌐 MaxUnpool(11)](https://onnx.ai/onnx/operators/onnx__MaxUnpool.html#maxunpool-11 "Online Documentation")
 
 
@@ -2168,7 +1834,7 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("MaxUnpool", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "MaxUnpool", schema)
+        op = Op(self, "MaxUnpool", schema)
         return op(
             *self._prepare_inputs(schema, X, I, output_shape),
             kernel_shape=kernel_shape,
@@ -2225,7 +1891,7 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("NonMaxSuppression", 11, "")
-        op: Callable[..., INT64] = Op(self, "NonMaxSuppression", schema)
+        op = Op(self, "NonMaxSuppression", schema)
         return op(
             *self._prepare_inputs(
                 schema,
@@ -2238,33 +1904,16 @@ class Opset11(Opset10):
             center_point_box=center_point_box,
         )
 
-    def OneHot(
-        self,
-        indices: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        depth: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        values: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axis: int = -1,
-    ) -> Union[
+    T1 = TypeVar(
+        "T1", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    T2 = TypeVar(
+        "T2", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    T3 = TypeVar(
+        "T3",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -2280,7 +1929,9 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def OneHot(self, indices: T1, depth: T2, values: T3, axis: int = -1) -> T3:
         r"""[🌐 OneHot(11)](https://onnx.ai/onnx/operators/onnx__OneHot.html#onehot-11 "Online Documentation")
 
 
@@ -2333,53 +1984,16 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("OneHot", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "OneHot", schema)
+        op = Op(self, "OneHot", schema)
         return op(*self._prepare_inputs(schema, indices, depth, values), axis=axis)
 
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
     def Pad(
-        self,
-        data: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        pads: INT64,
-        constant_value: Optional[
-            Union[
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ]
-        ] = None,
-        mode: str = "constant",
-    ) -> Union[
-        DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-    ]:
+        self, data: T, pads: INT64, constant_value: Optional[T] = None, mode: str = "constant"
+    ) -> T:
         r"""[🌐 Pad(11)](https://onnx.ai/onnx/operators/onnx__Pad.html#pad-11 "Online Documentation")
 
 
@@ -2478,30 +2092,12 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Pad", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Pad", schema)
+        op = Op(self, "Pad", schema)
         return op(*self._prepare_inputs(schema, data, pads, constant_value), mode=mode)
 
-    def Range(
-        self,
-        start: Union[DOUBLE, FLOAT, INT16, INT32, INT64],
-        limit: Union[DOUBLE, FLOAT, INT16, INT32, INT64],
-        delta: Union[DOUBLE, FLOAT, INT16, INT32, INT64],
-    ) -> Union[DOUBLE, FLOAT, INT16, INT32, INT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, INT16, INT32, INT64)
+
+    def Range(self, start: T, limit: T, delta: T) -> T:
         r"""[🌐 Range(11)](https://onnx.ai/onnx/operators/onnx__Range.html#range-11 "Online Documentation")
 
 
@@ -2554,17 +2150,12 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Range", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, INT16, INT32, INT64]] = Op(
-            self, "Range", schema
-        )
+        op = Op(self, "Range", schema)
         return op(*self._prepare_inputs(schema, start, limit, delta))
 
-    def ReduceL1(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def ReduceL1(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
         r"""[🌐 ReduceL1(11)](https://onnx.ai/onnx/operators/onnx__ReduceL1.html#reducel1-11 "Online Documentation")
 
 
@@ -2587,17 +2178,12 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("ReduceL1", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceL1", schema
-        )
+        op = Op(self, "ReduceL1", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
-    def ReduceL2(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def ReduceL2(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
         r"""[🌐 ReduceL2(11)](https://onnx.ai/onnx/operators/onnx__ReduceL2.html#reducel2-11 "Online Documentation")
 
 
@@ -2620,17 +2206,14 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("ReduceL2", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceL2", schema
-        )
+        op = Op(self, "ReduceL2", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceLogSum(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceLogSum(11)](https://onnx.ai/onnx/operators/onnx__ReduceLogSum.html#reducelogsum-11 "Online Documentation")
 
 
@@ -2653,17 +2236,14 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("ReduceLogSum", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceLogSum", schema
-        )
+        op = Op(self, "ReduceLogSum", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceLogSumExp(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceLogSumExp(11)](https://onnx.ai/onnx/operators/onnx__ReduceLogSumExp.html#reducelogsumexp-11 "Online Documentation")
 
 
@@ -2686,17 +2266,12 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("ReduceLogSumExp", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceLogSumExp", schema
-        )
+        op = Op(self, "ReduceLogSumExp", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
-    def ReduceMax(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def ReduceMax(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
         r"""[🌐 ReduceMax(11)](https://onnx.ai/onnx/operators/onnx__ReduceMax.html#reducemax-11 "Online Documentation")
 
 
@@ -2719,17 +2294,14 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("ReduceMax", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceMax", schema
-        )
+        op = Op(self, "ReduceMax", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceMean(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceMean(11)](https://onnx.ai/onnx/operators/onnx__ReduceMean.html#reducemean-11 "Online Documentation")
 
 
@@ -2752,17 +2324,12 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("ReduceMean", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceMean", schema
-        )
+        op = Op(self, "ReduceMean", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
-    def ReduceMin(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def ReduceMin(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
         r"""[🌐 ReduceMin(11)](https://onnx.ai/onnx/operators/onnx__ReduceMin.html#reducemin-11 "Online Documentation")
 
 
@@ -2785,17 +2352,14 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("ReduceMin", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceMin", schema
-        )
+        op = Op(self, "ReduceMin", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceProd(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceProd(11)](https://onnx.ai/onnx/operators/onnx__ReduceProd.html#reduceprod-11 "Online Documentation")
 
 
@@ -2818,17 +2382,12 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("ReduceProd", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceProd", schema
-        )
+        op = Op(self, "ReduceProd", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
-    def ReduceSum(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def ReduceSum(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
         r"""[🌐 ReduceSum(11)](https://onnx.ai/onnx/operators/onnx__ReduceSum.html#reducesum-11 "Online Documentation")
 
 
@@ -2851,17 +2410,14 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("ReduceSum", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceSum", schema
-        )
+        op = Op(self, "ReduceSum", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceSumSquare(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceSumSquare(11)](https://onnx.ai/onnx/operators/onnx__ReduceSumSquare.html#reducesumsquare-11 "Online Documentation")
 
 
@@ -2884,40 +2440,11 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("ReduceSumSquare", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "ReduceSumSquare", schema
-        )
+        op = Op(self, "ReduceSumSquare", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
-    def Resize(
-        self,
-        X: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        roi: Union[DOUBLE, FLOAT, FLOAT16],
-        scales: FLOAT,
-        sizes: Optional[INT64] = None,
-        coordinate_transformation_mode: str = "half_pixel",
-        cubic_coeff_a: float = -0.75,
-        exclude_outside: int = 0,
-        extrapolation_value: float = 0.0,
-        mode: str = "nearest",
-        nearest_mode: str = "round_prefer_floor",
-    ) -> Union[
+    T1 = TypeVar(
+        "T1",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -2933,7 +2460,23 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    T2 = TypeVar("T2", DOUBLE, FLOAT, FLOAT16)
+
+    def Resize(
+        self,
+        X: T1,
+        roi: T2,
+        scales: FLOAT,
+        sizes: Optional[INT64] = None,
+        coordinate_transformation_mode: str = "half_pixel",
+        cubic_coeff_a: float = -0.75,
+        exclude_outside: int = 0,
+        extrapolation_value: float = 0.0,
+        mode: str = "nearest",
+        nearest_mode: str = "round_prefer_floor",
+    ) -> T1:
         r"""[🌐 Resize(11)](https://onnx.ai/onnx/operators/onnx__Resize.html#resize-11 "Online Documentation")
 
 
@@ -3030,26 +2573,7 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Resize", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Resize", schema)
+        op = Op(self, "Resize", schema)
         return op(
             *self._prepare_inputs(schema, X, roi, scales, sizes),
             coordinate_transformation_mode=coordinate_transformation_mode,
@@ -3060,7 +2584,9 @@ class Opset11(Opset10):
             nearest_mode=nearest_mode,
         )
 
-    def Round(self, X: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Round(self, X: T) -> T:
         r"""[🌐 Round(11)](https://onnx.ai/onnx/operators/onnx__Round.html#round-11 "Online Documentation")
 
 
@@ -3087,35 +2613,11 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Round", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Round", schema)
+        op = Op(self, "Round", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def Scan(
-        self,
-        *initial_state_and_scan_inputs: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        body: Optional[GraphProto] = None,
-        num_scan_inputs: Optional[int] = None,
-        scan_input_axes: Optional[Sequence[int]] = None,
-        scan_input_directions: Optional[Sequence[int]] = None,
-        scan_output_axes: Optional[Sequence[int]] = None,
-        scan_output_directions: Optional[Sequence[int]] = None,
-    ) -> Union[
+    V = TypeVar(
+        "V",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -3131,7 +2633,18 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Scan(
+        self,
+        *initial_state_and_scan_inputs: V,
+        body: Optional[GraphProto] = None,
+        num_scan_inputs: Optional[int] = None,
+        scan_input_axes: Optional[Sequence[int]] = None,
+        scan_input_directions: Optional[Sequence[int]] = None,
+        scan_output_axes: Optional[Sequence[int]] = None,
+        scan_output_directions: Optional[Sequence[int]] = None,
+    ) -> V:
         r"""[🌐 Scan(11)](https://onnx.ai/onnx/operators/onnx__Scan.html#scan-11 "Online Documentation")
 
 
@@ -3298,26 +2811,7 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Scan", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Scan", schema)
+        op = Op(self, "Scan", schema)
         return op(
             *self._prepare_inputs(schema, *initial_state_and_scan_inputs),
             body=body,
@@ -3328,45 +2822,8 @@ class Opset11(Opset10):
             scan_output_directions=scan_output_directions,
         )
 
-    def ScatterElements(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        indices: Union[INT32, INT64],
-        updates: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axis: int = 0,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -3382,7 +2839,11 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    Tind = TypeVar("Tind", INT32, INT64)
+
+    def ScatterElements(self, data: T, indices: Tind, updates: T, axis: int = 0) -> T:
         r"""[🌐 ScatterElements(11)](https://onnx.ai/onnx/operators/onnx__ScatterElements.html#scatterelements-11 "Online Documentation")
 
 
@@ -3459,66 +2920,11 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("ScatterElements", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "ScatterElements", schema)
+        op = Op(self, "ScatterElements", schema)
         return op(*self._prepare_inputs(schema, data, indices, updates), axis=axis)
 
-    def ScatterND(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        indices: INT64,
-        updates: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -3534,7 +2940,9 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def ScatterND(self, data: T, indices: INT64, updates: T) -> T:
         r"""[🌐 ScatterND(11)](https://onnx.ai/onnx/operators/onnx__ScatterND.html#scatternd-11 "Online Documentation")
 
 
@@ -3610,49 +3018,32 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("ScatterND", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "ScatterND", schema)
+        op = Op(self, "ScatterND", schema)
         return op(*self._prepare_inputs(schema, data, indices, updates))
 
-    def SequenceAt(
-        self,
-        input_sequence: Union[
-            Sequence[BOOL],
-            Sequence[COMPLEX128],
-            Sequence[COMPLEX64],
-            Sequence[DOUBLE],
-            Sequence[FLOAT],
-            Sequence[FLOAT16],
-            Sequence[INT16],
-            Sequence[INT32],
-            Sequence[INT64],
-            Sequence[INT8],
-            Sequence[STRING],
-            Sequence[UINT16],
-            Sequence[UINT32],
-            Sequence[UINT64],
-            Sequence[UINT8],
-        ],
-        position: Union[INT32, INT64],
-    ) -> Union[
+    S = TypeVar(
+        "S",
+        Sequence[BOOL],
+        Sequence[COMPLEX128],
+        Sequence[COMPLEX64],
+        Sequence[DOUBLE],
+        Sequence[FLOAT],
+        Sequence[FLOAT16],
+        Sequence[INT16],
+        Sequence[INT32],
+        Sequence[INT64],
+        Sequence[INT8],
+        Sequence[STRING],
+        Sequence[UINT16],
+        Sequence[UINT32],
+        Sequence[UINT64],
+        Sequence[UINT8],
+    )
+
+    I = TypeVar("I", INT32, INT64)
+
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -3668,7 +3059,9 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def SequenceAt(self, input_sequence: S, position: I) -> T:
         r"""[🌐 SequenceAt(11)](https://onnx.ai/onnx/operators/onnx__SequenceAt.html#sequenceat-11 "Online Documentation")
 
 
@@ -3688,48 +3081,30 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("SequenceAt", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "SequenceAt", schema)
+        op = Op(self, "SequenceAt", schema)
         return op(*self._prepare_inputs(schema, input_sequence, position))
 
-    def SequenceConstruct(
-        self,
-        *inputs: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    T = TypeVar(
+        "T",
+        BOOL,
+        COMPLEX128,
+        COMPLEX64,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    S = TypeVar(
+        "S",
         Sequence[BOOL],
         Sequence[COMPLEX128],
         Sequence[COMPLEX64],
@@ -3745,7 +3120,9 @@ class Opset11(Opset10):
         Sequence[UINT32],
         Sequence[UINT64],
         Sequence[UINT8],
-    ]:
+    )
+
+    def SequenceConstruct(self, *inputs: T) -> S:
         r"""[🌐 SequenceConstruct(11)](https://onnx.ai/onnx/operators/onnx__SequenceConstruct.html#sequenceconstruct-11 "Online Documentation")
 
 
@@ -3758,31 +3135,11 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("SequenceConstruct", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                Sequence[BOOL],
-                Sequence[COMPLEX128],
-                Sequence[COMPLEX64],
-                Sequence[DOUBLE],
-                Sequence[FLOAT],
-                Sequence[FLOAT16],
-                Sequence[INT16],
-                Sequence[INT32],
-                Sequence[INT64],
-                Sequence[INT8],
-                Sequence[STRING],
-                Sequence[UINT16],
-                Sequence[UINT32],
-                Sequence[UINT64],
-                Sequence[UINT8],
-            ],
-        ] = Op(self, "SequenceConstruct", schema)
+        op = Op(self, "SequenceConstruct", schema)
         return op(*self._prepare_inputs(schema, *inputs))
 
-    def SequenceEmpty(
-        self, dtype: Optional[int] = None
-    ) -> Union[
+    S = TypeVar(
+        "S",
         Sequence[BOOL],
         Sequence[COMPLEX128],
         Sequence[COMPLEX64],
@@ -3798,7 +3155,9 @@ class Opset11(Opset10):
         Sequence[UINT32],
         Sequence[UINT64],
         Sequence[UINT8],
-    ]:
+    )
+
+    def SequenceEmpty(self, dtype: Optional[int] = None) -> S:
         r"""[🌐 SequenceEmpty(11)](https://onnx.ai/onnx/operators/onnx__SequenceEmpty.html#sequenceempty-11 "Online Documentation")
 
 
@@ -3811,49 +3170,11 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("SequenceEmpty", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                Sequence[BOOL],
-                Sequence[COMPLEX128],
-                Sequence[COMPLEX64],
-                Sequence[DOUBLE],
-                Sequence[FLOAT],
-                Sequence[FLOAT16],
-                Sequence[INT16],
-                Sequence[INT32],
-                Sequence[INT64],
-                Sequence[INT8],
-                Sequence[STRING],
-                Sequence[UINT16],
-                Sequence[UINT32],
-                Sequence[UINT64],
-                Sequence[UINT8],
-            ],
-        ] = Op(self, "SequenceEmpty", schema)
+        op = Op(self, "SequenceEmpty", schema)
         return op(dtype=dtype)
 
-    def SequenceErase(
-        self,
-        input_sequence: Union[
-            Sequence[BOOL],
-            Sequence[COMPLEX128],
-            Sequence[COMPLEX64],
-            Sequence[DOUBLE],
-            Sequence[FLOAT],
-            Sequence[FLOAT16],
-            Sequence[INT16],
-            Sequence[INT32],
-            Sequence[INT64],
-            Sequence[INT8],
-            Sequence[STRING],
-            Sequence[UINT16],
-            Sequence[UINT32],
-            Sequence[UINT64],
-            Sequence[UINT8],
-        ],
-        position: Optional[Union[INT32, INT64]] = None,
-    ) -> Union[
+    S = TypeVar(
+        "S",
         Sequence[BOOL],
         Sequence[COMPLEX128],
         Sequence[COMPLEX64],
@@ -3869,7 +3190,11 @@ class Opset11(Opset10):
         Sequence[UINT32],
         Sequence[UINT64],
         Sequence[UINT8],
-    ]:
+    )
+
+    I = TypeVar("I", INT32, INT64)
+
+    def SequenceErase(self, input_sequence: S, position: Optional[I] = None) -> S:
         r"""[🌐 SequenceErase(11)](https://onnx.ai/onnx/operators/onnx__SequenceErase.html#sequenceerase-11 "Online Documentation")
 
 
@@ -3890,66 +3215,11 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("SequenceErase", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                Sequence[BOOL],
-                Sequence[COMPLEX128],
-                Sequence[COMPLEX64],
-                Sequence[DOUBLE],
-                Sequence[FLOAT],
-                Sequence[FLOAT16],
-                Sequence[INT16],
-                Sequence[INT32],
-                Sequence[INT64],
-                Sequence[INT8],
-                Sequence[STRING],
-                Sequence[UINT16],
-                Sequence[UINT32],
-                Sequence[UINT64],
-                Sequence[UINT8],
-            ],
-        ] = Op(self, "SequenceErase", schema)
+        op = Op(self, "SequenceErase", schema)
         return op(*self._prepare_inputs(schema, input_sequence, position))
 
-    def SequenceInsert(
-        self,
-        input_sequence: Union[
-            Sequence[BOOL],
-            Sequence[COMPLEX128],
-            Sequence[COMPLEX64],
-            Sequence[DOUBLE],
-            Sequence[FLOAT],
-            Sequence[FLOAT16],
-            Sequence[INT16],
-            Sequence[INT32],
-            Sequence[INT64],
-            Sequence[INT8],
-            Sequence[STRING],
-            Sequence[UINT16],
-            Sequence[UINT32],
-            Sequence[UINT64],
-            Sequence[UINT8],
-        ],
-        tensor: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        position: Optional[Union[INT32, INT64]] = None,
-    ) -> Union[
+    S = TypeVar(
+        "S",
         Sequence[BOOL],
         Sequence[COMPLEX128],
         Sequence[COMPLEX64],
@@ -3965,7 +3235,30 @@ class Opset11(Opset10):
         Sequence[UINT32],
         Sequence[UINT64],
         Sequence[UINT8],
-    ]:
+    )
+
+    T = TypeVar(
+        "T",
+        BOOL,
+        COMPLEX128,
+        COMPLEX64,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    I = TypeVar("I", INT32, INT64)
+
+    def SequenceInsert(self, input_sequence: S, tensor: T, position: Optional[I] = None) -> S:
         r"""[🌐 SequenceInsert(11)](https://onnx.ai/onnx/operators/onnx__SequenceInsert.html#sequenceinsert-11 "Online Documentation")
 
 
@@ -3990,48 +3283,31 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("SequenceInsert", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                Sequence[BOOL],
-                Sequence[COMPLEX128],
-                Sequence[COMPLEX64],
-                Sequence[DOUBLE],
-                Sequence[FLOAT],
-                Sequence[FLOAT16],
-                Sequence[INT16],
-                Sequence[INT32],
-                Sequence[INT64],
-                Sequence[INT8],
-                Sequence[STRING],
-                Sequence[UINT16],
-                Sequence[UINT32],
-                Sequence[UINT64],
-                Sequence[UINT8],
-            ],
-        ] = Op(self, "SequenceInsert", schema)
+        op = Op(self, "SequenceInsert", schema)
         return op(*self._prepare_inputs(schema, input_sequence, tensor, position))
 
-    def SequenceLength(
-        self,
-        input_sequence: Union[
-            Sequence[BOOL],
-            Sequence[COMPLEX128],
-            Sequence[COMPLEX64],
-            Sequence[DOUBLE],
-            Sequence[FLOAT],
-            Sequence[FLOAT16],
-            Sequence[INT16],
-            Sequence[INT32],
-            Sequence[INT64],
-            Sequence[INT8],
-            Sequence[STRING],
-            Sequence[UINT16],
-            Sequence[UINT32],
-            Sequence[UINT64],
-            Sequence[UINT8],
-        ],
-    ) -> INT64:
+    S = TypeVar(
+        "S",
+        Sequence[BOOL],
+        Sequence[COMPLEX128],
+        Sequence[COMPLEX64],
+        Sequence[DOUBLE],
+        Sequence[FLOAT],
+        Sequence[FLOAT16],
+        Sequence[INT16],
+        Sequence[INT32],
+        Sequence[INT64],
+        Sequence[INT8],
+        Sequence[STRING],
+        Sequence[UINT16],
+        Sequence[UINT32],
+        Sequence[UINT64],
+        Sequence[UINT8],
+    )
+
+    I = TypeVar("I", bound=INT64)
+
+    def SequenceLength(self, input_sequence: S) -> I:
         r"""[🌐 SequenceLength(11)](https://onnx.ai/onnx/operators/onnx__SequenceLength.html#sequencelength-11 "Online Documentation")
 
 
@@ -4043,33 +3319,11 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("SequenceLength", 11, "")
-        op: Callable[..., INT64] = Op(self, "SequenceLength", schema)
+        op = Op(self, "SequenceLength", schema)
         return op(*self._prepare_inputs(schema, input_sequence))
 
-    def Slice(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        starts: Union[INT32, INT64],
-        ends: Union[INT32, INT64],
-        axes: Optional[Union[INT32, INT64]] = None,
-        steps: Optional[Union[INT32, INT64]] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -4085,7 +3339,18 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    Tind = TypeVar("Tind", INT32, INT64)
+
+    def Slice(
+        self,
+        data: T,
+        starts: Tind,
+        ends: Tind,
+        axes: Optional[Tind] = None,
+        steps: Optional[Tind] = None,
+    ) -> T:
         r"""[🌐 Slice(11)](https://onnx.ai/onnx/operators/onnx__Slice.html#slice-11 "Online Documentation")
 
 
@@ -4145,31 +3410,12 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Slice", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Slice", schema)
+        op = Op(self, "Slice", schema)
         return op(*self._prepare_inputs(schema, data, starts, ends, axes, steps))
 
-    def Softmax(
-        self, input: Union[DOUBLE, FLOAT, FLOAT16], axis: int = 1
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Softmax(self, input: T, axis: int = 1) -> T:
         r"""[🌐 Softmax(11)](https://onnx.ai/onnx/operators/onnx__Softmax.html#softmax-11 "Online Documentation")
 
 
@@ -4200,31 +3446,11 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Softmax", 11, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Softmax", schema)
+        op = Op(self, "Softmax", schema)
         return op(*self._prepare_inputs(schema, input), axis=axis)
 
-    def Split(
-        self,
-        input: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axis: int = 0,
-        split: Optional[Sequence[int]] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -4240,7 +3466,9 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Split(self, input: T, axis: int = 0, split: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Split(11)](https://onnx.ai/onnx/operators/onnx__Split.html#split-11 "Online Documentation")
 
         Split a tensor into a list of tensors, along the specified
@@ -4258,51 +3486,32 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Split", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Split", schema)
+        op = Op(self, "Split", schema)
         return op(*self._prepare_inputs(schema, input), axis=axis, split=split)
 
-    def SplitToSequence(
-        self,
-        input: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        split: Optional[Union[INT32, INT64]] = None,
-        axis: int = 0,
-        keepdims: int = 1,
-    ) -> Union[
+    T = TypeVar(
+        "T",
+        BOOL,
+        COMPLEX128,
+        COMPLEX64,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    I = TypeVar("I", INT32, INT64)
+
+    S = TypeVar(
+        "S",
         Sequence[BOOL],
         Sequence[COMPLEX128],
         Sequence[COMPLEX64],
@@ -4318,7 +3527,11 @@ class Opset11(Opset10):
         Sequence[UINT32],
         Sequence[UINT64],
         Sequence[UINT8],
-    ]:
+    )
+
+    def SplitToSequence(
+        self, input: T, split: Optional[I] = None, axis: int = 0, keepdims: int = 1
+    ) -> S:
         r"""[🌐 SplitToSequence(11)](https://onnx.ai/onnx/operators/onnx__SplitToSequence.html#splittosequence-11 "Online Documentation")
 
 
@@ -4351,49 +3564,11 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("SplitToSequence", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                Sequence[BOOL],
-                Sequence[COMPLEX128],
-                Sequence[COMPLEX64],
-                Sequence[DOUBLE],
-                Sequence[FLOAT],
-                Sequence[FLOAT16],
-                Sequence[INT16],
-                Sequence[INT32],
-                Sequence[INT64],
-                Sequence[INT8],
-                Sequence[STRING],
-                Sequence[UINT16],
-                Sequence[UINT32],
-                Sequence[UINT64],
-                Sequence[UINT8],
-            ],
-        ] = Op(self, "SplitToSequence", schema)
+        op = Op(self, "SplitToSequence", schema)
         return op(*self._prepare_inputs(schema, input, split), axis=axis, keepdims=keepdims)
 
-    def Squeeze(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axes: Optional[Sequence[int]] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -4409,7 +3584,9 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Squeeze(self, data: T, axes: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Squeeze(11)](https://onnx.ai/onnx/operators/onnx__Squeeze.html#squeeze-11 "Online Documentation")
 
 
@@ -4428,43 +3605,18 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Squeeze", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Squeeze", schema)
+        op = Op(self, "Squeeze", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes)
 
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    I = TypeVar("I", bound=INT64)
+
     def TopK(
-        self,
-        X: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        K: INT64,
-        axis: int = -1,
-        largest: int = 1,
-        sorted: int = 1,
-    ) -> Tuple[
-        Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        INT64,
-    ]:
+        self, X: T, K: INT64, axis: int = -1, largest: int = 1, sorted: int = 1
+    ) -> Tuple[T, I]:
         r"""[🌐 TopK(11)](https://onnx.ai/onnx/operators/onnx__TopK.html#topk-11 "Online Documentation")
 
 
@@ -4501,72 +3653,33 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("TopK", 11, "")
-        op: Callable[
-            ...,
-            Tuple[
-                Union[
-                    DOUBLE,
-                    FLOAT,
-                    FLOAT16,
-                    INT16,
-                    INT32,
-                    INT64,
-                    INT8,
-                    UINT16,
-                    UINT32,
-                    UINT64,
-                    UINT8,
-                ],
-                INT64,
-            ],
-        ] = Op(self, "TopK", schema)
+        op = Op(self, "TopK", schema)
         return op(
             *self._prepare_inputs(schema, X, K), axis=axis, largest=largest, sorted=sorted
         )
 
+    T = TypeVar(
+        "T",
+        BOOL,
+        COMPLEX128,
+        COMPLEX64,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
     def Unique(
-        self,
-        X: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axis: Optional[int] = None,
-        sorted: int = 1,
-    ) -> Tuple[
-        Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        INT64,
-        INT64,
-        INT64,
-    ]:
+        self, X: T, axis: Optional[int] = None, sorted: int = 1
+    ) -> Tuple[T, INT64, INT64, INT64]:
         r"""[🌐 Unique(11)](https://onnx.ai/onnx/operators/onnx__Unique.html#unique-11 "Online Documentation")
 
 
@@ -4704,54 +3817,11 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Unique", 11, "")
-        op: Callable[
-            ...,
-            Tuple[
-                Union[
-                    BOOL,
-                    COMPLEX128,
-                    COMPLEX64,
-                    DOUBLE,
-                    FLOAT,
-                    FLOAT16,
-                    INT16,
-                    INT32,
-                    INT64,
-                    INT8,
-                    STRING,
-                    UINT16,
-                    UINT32,
-                    UINT64,
-                    UINT8,
-                ],
-                INT64,
-                INT64,
-                INT64,
-            ],
-        ] = Op(self, "Unique", schema)
+        op = Op(self, "Unique", schema)
         return op(*self._prepare_inputs(schema, X), axis=axis, sorted=sorted)
 
-    def Unsqueeze(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axes: Optional[Sequence[int]] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -4767,7 +3837,9 @@ class Opset11(Opset10):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Unsqueeze(self, data: T, axes: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Unsqueeze(11)](https://onnx.ai/onnx/operators/onnx__Unsqueeze.html#unsqueeze-11 "Online Documentation")
 
 
@@ -4794,24 +3866,5 @@ class Opset11(Opset10):
         """
 
         schema = get_schema("Unsqueeze", 11, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Unsqueeze", schema)
+        op = Op(self, "Unsqueeze", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes)

--- a/onnxscript/onnx_opset/_impl/opset12.py
+++ b/onnxscript/onnx_opset/_impl/opset12.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Tuple, TypeVar
 
 from onnx import SparseTensorProto, TensorProto
 from onnx.defs import get_schema
@@ -43,14 +43,12 @@ class Opset12(Opset11):
     def __init__(self):
         super().__init__()
 
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
     def ArgMax(
-        self,
-        data: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        axis: int = 0,
-        keepdims: int = 1,
-        select_last_index: int = 0,
+        self, data: T, axis: int = 0, keepdims: int = 1, select_last_index: int = 0
     ) -> INT64:
         r"""[🌐 ArgMax(12)](https://onnx.ai/onnx/operators/onnx__ArgMax.html#argmax-12 "Online Documentation")
 
@@ -77,7 +75,7 @@ class Opset12(Opset11):
         """
 
         schema = get_schema("ArgMax", 12, "")
-        op: Callable[..., INT64] = Op(self, "ArgMax", schema)
+        op = Op(self, "ArgMax", schema)
         return op(
             *self._prepare_inputs(schema, data),
             axis=axis,
@@ -85,14 +83,12 @@ class Opset12(Opset11):
             select_last_index=select_last_index,
         )
 
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
     def ArgMin(
-        self,
-        data: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        axis: int = 0,
-        keepdims: int = 1,
-        select_last_index: int = 0,
+        self, data: T, axis: int = 0, keepdims: int = 1, select_last_index: int = 0
     ) -> INT64:
         r"""[🌐 ArgMin(12)](https://onnx.ai/onnx/operators/onnx__ArgMin.html#argmin-12 "Online Documentation")
 
@@ -119,7 +115,7 @@ class Opset12(Opset11):
         """
 
         schema = get_schema("ArgMin", 12, "")
-        op: Callable[..., INT64] = Op(self, "ArgMin", schema)
+        op = Op(self, "ArgMin", schema)
         return op(
             *self._prepare_inputs(schema, data),
             axis=axis,
@@ -127,7 +123,9 @@ class Opset12(Opset11):
             select_last_index=select_last_index,
         )
 
-    def Celu(self, X: FLOAT, alpha: float = 1.0) -> FLOAT:
+    T = TypeVar("T", bound=FLOAT)
+
+    def Celu(self, X: T, alpha: float = 1.0) -> T:
         r"""[🌐 Celu(12)](https://onnx.ai/onnx/operators/onnx__Celu.html#celu-12 "Online Documentation")
 
 
@@ -150,47 +148,14 @@ class Opset12(Opset11):
         """
 
         schema = get_schema("Celu", 12, "")
-        op: Callable[..., FLOAT] = Op(self, "Celu", schema)
+        op = Op(self, "Celu", schema)
         return op(*self._prepare_inputs(schema, X), alpha=alpha)
 
-    def Clip(
-        self,
-        input: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        min: Optional[
-            Union[
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ]
-        ] = None,
-        max: Optional[
-            Union[
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ]
-        ] = None,
-    ) -> Union[
-        DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-    ]:
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    def Clip(self, input: T, min: Optional[T] = None, max: Optional[T] = None) -> T:
         r"""[🌐 Clip(12)](https://onnx.ai/onnx/operators/onnx__Clip.html#clip-12 "Online Documentation")
 
 
@@ -210,35 +175,11 @@ class Opset12(Opset11):
         """
 
         schema = get_schema("Clip", 12, "")
-        op: Callable[
-            ...,
-            Union[
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Clip", schema)
+        op = Op(self, "Clip", schema)
         return op(*self._prepare_inputs(schema, input, min, max))
 
-    def Constant(
-        self,
-        sparse_value: Optional[SparseTensorProto] = None,
-        value: Optional[TensorProto] = None,
-        value_float: Optional[float] = None,
-        value_floats: Optional[Sequence[float]] = None,
-        value_int: Optional[int] = None,
-        value_ints: Optional[Sequence[int]] = None,
-        value_string: Optional[str] = None,
-        value_strings: Optional[Sequence[str]] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -254,7 +195,19 @@ class Opset12(Opset11):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Constant(
+        self,
+        sparse_value: Optional[SparseTensorProto] = None,
+        value: Optional[TensorProto] = None,
+        value_float: Optional[float] = None,
+        value_floats: Optional[Sequence[float]] = None,
+        value_int: Optional[int] = None,
+        value_ints: Optional[Sequence[int]] = None,
+        value_string: Optional[str] = None,
+        value_strings: Optional[Sequence[str]] = None,
+    ) -> T:
         r"""[🌐 Constant(12)](https://onnx.ai/onnx/operators/onnx__Constant.html#constant-12 "Online Documentation")
 
 
@@ -287,26 +240,7 @@ class Opset12(Opset11):
         """
 
         schema = get_schema("Constant", 12, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Constant", schema)
+        op = Op(self, "Constant", schema)
         return op(
             sparse_value=sparse_value,
             value=value,
@@ -318,13 +252,19 @@ class Opset12(Opset11):
             value_strings=value_strings,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    T1 = TypeVar("T1", DOUBLE, FLOAT, FLOAT16)
+
+    T2 = TypeVar("T2", bound=BOOL)
+
     def Dropout(
         self,
-        data: Union[DOUBLE, FLOAT, FLOAT16],
-        ratio: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        training_mode: Optional[BOOL] = None,
+        data: T,
+        ratio: Optional[T1] = None,
+        training_mode: Optional[T2] = None,
         seed: Optional[int] = None,
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16], BOOL]:
+    ) -> Tuple[T, T2]:
         r"""[🌐 Dropout(12)](https://onnx.ai/onnx/operators/onnx__Dropout.html#dropout-12 "Online Documentation")
 
 
@@ -366,20 +306,14 @@ class Opset12(Opset11):
         """
 
         schema = get_schema("Dropout", 12, "")
-        op: Callable[..., Tuple[Union[DOUBLE, FLOAT, FLOAT16], BOOL]] = Op(
-            self, "Dropout", schema
-        )
+        op = Op(self, "Dropout", schema)
         return op(*self._prepare_inputs(schema, data, ratio, training_mode), seed=seed)
 
-    def Einsum(
-        self,
-        *Inputs: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        equation: Optional[str] = None,
-    ) -> Union[
-        DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-    ]:
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    def Einsum(self, *Inputs: T, equation: Optional[str] = None) -> T:
         r"""[🌐 Einsum(12)](https://onnx.ai/onnx/operators/onnx__Einsum.html#einsum-12 "Online Documentation")
 
 
@@ -419,46 +353,11 @@ class Opset12(Opset11):
         """
 
         schema = get_schema("Einsum", 12, "")
-        op: Callable[
-            ...,
-            Union[
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Einsum", schema)
+        op = Op(self, "Einsum", schema)
         return op(*self._prepare_inputs(schema, *Inputs), equation=equation)
 
-    def GatherND(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        indices: INT64,
-        batch_dims: int = 0,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -474,7 +373,9 @@ class Opset12(Opset11):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def GatherND(self, data: T, indices: INT64, batch_dims: int = 0) -> T:
         r"""[🌐 GatherND(12)](https://onnx.ai/onnx/operators/onnx__GatherND.html#gathernd-12 "Online Documentation")
 
 
@@ -583,37 +484,16 @@ class Opset12(Opset11):
         """
 
         schema = get_schema("GatherND", 12, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "GatherND", schema)
+        op = Op(self, "GatherND", schema)
         return op(*self._prepare_inputs(schema, data, indices), batch_dims=batch_dims)
 
-    def GreaterOrEqual(
-        self,
-        A: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        B: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-    ) -> BOOL:
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def GreaterOrEqual(self, A: T, B: T) -> T1:
         r"""[🌐 GreaterOrEqual(12)](https://onnx.ai/onnx/operators/onnx__GreaterOrEqual.html#greaterorequal-12 "Online Documentation")
 
 
@@ -630,18 +510,16 @@ class Opset12(Opset11):
         """
 
         schema = get_schema("GreaterOrEqual", 12, "")
-        op: Callable[..., BOOL] = Op(self, "GreaterOrEqual", schema)
+        op = Op(self, "GreaterOrEqual", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def LessOrEqual(
-        self,
-        A: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        B: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-    ) -> BOOL:
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def LessOrEqual(self, A: T, B: T) -> T1:
         r"""[🌐 LessOrEqual(12)](https://onnx.ai/onnx/operators/onnx__LessOrEqual.html#lessorequal-12 "Online Documentation")
 
 
@@ -658,17 +536,14 @@ class Opset12(Opset11):
         """
 
         schema = get_schema("LessOrEqual", 12, "")
-        op: Callable[..., BOOL] = Op(self, "LessOrEqual", schema)
+        op = Op(self, "LessOrEqual", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def Max(
-        self,
-        *data_0: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-    ) -> Union[
-        DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-    ]:
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    def Max(self, *data_0: T) -> T:
         r"""[🌐 Max(12)](https://onnx.ai/onnx/operators/onnx__Max.html#max-12 "Online Documentation")
 
 
@@ -682,27 +557,16 @@ class Opset12(Opset11):
         """
 
         schema = get_schema("Max", 12, "")
-        op: Callable[
-            ...,
-            Union[
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Max", schema)
+        op = Op(self, "Max", schema)
         return op(*self._prepare_inputs(schema, *data_0))
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT8, UINT8)
+
+    I = TypeVar("I", bound=INT64)
 
     def MaxPool(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16, INT8, UINT8],
+        X: T,
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         dilations: Optional[Sequence[int]] = None,
@@ -710,7 +574,7 @@ class Opset12(Opset11):
         pads: Optional[Sequence[int]] = None,
         storage_order: int = 0,
         strides: Optional[Sequence[int]] = None,
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16, INT8, UINT8], INT64]:
+    ) -> Tuple[T, I]:
         r"""[🌐 MaxPool(12)](https://onnx.ai/onnx/operators/onnx__MaxPool.html#maxpool-12 "Online Documentation")
 
 
@@ -786,9 +650,7 @@ class Opset12(Opset11):
         """
 
         schema = get_schema("MaxPool", 12, "")
-        op: Callable[..., Tuple[Union[DOUBLE, FLOAT, FLOAT16, INT8, UINT8], INT64]] = Op(
-            self, "MaxPool", schema
-        )
+        op = Op(self, "MaxPool", schema)
         return op(
             *self._prepare_inputs(schema, X),
             auto_pad=auto_pad,
@@ -800,14 +662,11 @@ class Opset12(Opset11):
             strides=strides,
         )
 
-    def Min(
-        self,
-        *data_0: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-    ) -> Union[
-        DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-    ]:
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    def Min(self, *data_0: T) -> T:
         r"""[🌐 Min(12)](https://onnx.ai/onnx/operators/onnx__Min.html#min-12 "Online Documentation")
 
 
@@ -821,32 +680,21 @@ class Opset12(Opset11):
         """
 
         schema = get_schema("Min", 12, "")
-        op: Callable[
-            ...,
-            Union[
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Min", schema)
+        op = Op(self, "Min", schema)
         return op(*self._prepare_inputs(schema, *data_0))
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    Tind = TypeVar("Tind", INT32, INT64)
 
     def NegativeLogLikelihoodLoss(
         self,
-        input: Union[DOUBLE, FLOAT, FLOAT16],
-        target: Union[INT32, INT64],
-        weight: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
+        input: T,
+        target: Tind,
+        weight: Optional[T] = None,
         ignore_index: Optional[int] = None,
         reduction: str = "mean",
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 NegativeLogLikelihoodLoss(12)](https://onnx.ai/onnx/operators/onnx__NegativeLogLikelihoodLoss.html#negativeloglikelihoodloss-12 "Online Documentation")
 
 
@@ -939,22 +787,20 @@ class Opset12(Opset11):
         """
 
         schema = get_schema("NegativeLogLikelihoodLoss", 12, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(
-            self, "NegativeLogLikelihoodLoss", schema
-        )
+        op = Op(self, "NegativeLogLikelihoodLoss", schema)
         return op(
             *self._prepare_inputs(schema, input, target, weight),
             ignore_index=ignore_index,
             reduction=reduction,
         )
 
-    def Pow(
-        self,
-        X: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64],
-        Y: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64)
+
+    T1 = TypeVar(
+        "T1", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    def Pow(self, X: T, Y: T1) -> T:
         r"""[🌐 Pow(12)](https://onnx.ai/onnx/operators/onnx__Pow.html#pow-12 "Online Documentation")
 
 
@@ -970,17 +816,12 @@ class Opset12(Opset11):
         """
 
         schema = get_schema("Pow", 12, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64]] = Op(
-            self, "Pow", schema
-        )
+        op = Op(self, "Pow", schema)
         return op(*self._prepare_inputs(schema, X, Y))
 
-    def ReduceMax(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8)
+
+    def ReduceMax(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
         r"""[🌐 ReduceMax(12)](https://onnx.ai/onnx/operators/onnx__ReduceMax.html#reducemax-12 "Online Documentation")
 
 
@@ -1003,17 +844,12 @@ class Opset12(Opset11):
         """
 
         schema = get_schema("ReduceMax", 12, "")
-        op: Callable[
-            ..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8]
-        ] = Op(self, "ReduceMax", schema)
+        op = Op(self, "ReduceMax", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
-    def ReduceMin(
-        self,
-        data: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8)
+
+    def ReduceMin(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
         r"""[🌐 ReduceMin(12)](https://onnx.ai/onnx/operators/onnx__ReduceMin.html#reducemin-12 "Online Documentation")
 
 
@@ -1036,19 +872,21 @@ class Opset12(Opset11):
         """
 
         schema = get_schema("ReduceMin", 12, "")
-        op: Callable[
-            ..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8]
-        ] = Op(self, "ReduceMin", schema)
+        op = Op(self, "ReduceMin", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    Tind = TypeVar("Tind", INT32, INT64)
 
     def SoftmaxCrossEntropyLoss(
         self,
-        scores: Union[DOUBLE, FLOAT, FLOAT16],
-        labels: Union[INT32, INT64],
-        weights: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
+        scores: T,
+        labels: Tind,
+        weights: Optional[T] = None,
         ignore_index: Optional[int] = None,
         reduction: str = "mean",
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]:
+    ) -> Tuple[T, T]:
         r"""[🌐 SoftmaxCrossEntropyLoss(12)](https://onnx.ai/onnx/operators/onnx__SoftmaxCrossEntropyLoss.html#softmaxcrossentropyloss-12 "Online Documentation")
 
         Loss function that measures the softmax cross entropy
@@ -1109,9 +947,7 @@ class Opset12(Opset11):
         """
 
         schema = get_schema("SoftmaxCrossEntropyLoss", 12, "")
-        op: Callable[
-            ..., Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]
-        ] = Op(self, "SoftmaxCrossEntropyLoss", schema)
+        op = Op(self, "SoftmaxCrossEntropyLoss", schema)
         return op(
             *self._prepare_inputs(schema, scores, labels, weights),
             ignore_index=ignore_index,

--- a/onnxscript/onnx_opset/_impl/opset13.py
+++ b/onnxscript/onnx_opset/_impl/opset13.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Tuple, TypeVar
 
 from onnx import GraphProto, SparseTensorProto, TensorProto
 from onnx.defs import get_schema
@@ -44,23 +44,8 @@ class Opset13(Opset12):
     def __init__(self):
         super().__init__()
 
-    def Abs(
-        self,
-        X: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         DOUBLE,
         FLOAT,
@@ -73,7 +58,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Abs(self, X: T) -> T:
         r"""[🌐 Abs(13)](https://onnx.ai/onnx/operators/onnx__Abs.html#abs-13 "Online Documentation")
 
 
@@ -87,30 +74,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Abs", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Abs", schema)
+        op = Op(self, "Abs", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def Add(
-        self,
-        A: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        B: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def Add(self, A: T, B: T) -> T:
         r"""[🌐 Add(13)](https://onnx.ai/onnx/operators/onnx__Add.html#add-13 "Online Documentation")
 
 
@@ -126,30 +95,27 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Add", 13, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "Add", schema)
+        op = Op(self, "Add", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
+    T = TypeVar(
+        "T",
+        BFLOAT16,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
     def ArgMax(
-        self,
-        data: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axis: int = 0,
-        keepdims: int = 1,
-        select_last_index: int = 0,
+        self, data: T, axis: int = 0, keepdims: int = 1, select_last_index: int = 0
     ) -> INT64:
         r"""[🌐 ArgMax(13)](https://onnx.ai/onnx/operators/onnx__ArgMax.html#argmax-13 "Online Documentation")
 
@@ -176,7 +142,7 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("ArgMax", 13, "")
-        op: Callable[..., INT64] = Op(self, "ArgMax", schema)
+        op = Op(self, "ArgMax", schema)
         return op(
             *self._prepare_inputs(schema, data),
             axis=axis,
@@ -184,25 +150,24 @@ class Opset13(Opset12):
             select_last_index=select_last_index,
         )
 
+    T = TypeVar(
+        "T",
+        BFLOAT16,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
     def ArgMin(
-        self,
-        data: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axis: int = 0,
-        keepdims: int = 1,
-        select_last_index: int = 0,
+        self, data: T, axis: int = 0, keepdims: int = 1, select_last_index: int = 0
     ) -> INT64:
         r"""[🌐 ArgMin(13)](https://onnx.ai/onnx/operators/onnx__ArgMin.html#argmin-13 "Online Documentation")
 
@@ -229,7 +194,7 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("ArgMin", 13, "")
-        op: Callable[..., INT64] = Op(self, "ArgMin", schema)
+        op = Op(self, "ArgMin", schema)
         return op(
             *self._prepare_inputs(schema, data),
             axis=axis,
@@ -237,26 +202,8 @@ class Opset13(Opset12):
             select_last_index=select_last_index,
         )
 
-    def Cast(
-        self,
-        input: Union[
-            BFLOAT16,
-            BOOL,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        to: Optional[int] = None,
-    ) -> Union[
+    T1 = TypeVar(
+        "T1",
         BFLOAT16,
         BOOL,
         DOUBLE,
@@ -271,7 +218,27 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    T2 = TypeVar(
+        "T2",
+        BFLOAT16,
+        BOOL,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    def Cast(self, input: T1, to: Optional[int] = None) -> T2:
         r"""[🌐 Cast(13)](https://onnx.ai/onnx/operators/onnx__Cast.html#cast-13 "Online Documentation")
 
 
@@ -320,30 +287,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Cast", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Cast", schema)
+        op = Op(self, "Cast", schema)
         return op(*self._prepare_inputs(schema, input), to=to)
 
-    def Ceil(
-        self, X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    def Ceil(self, X: T) -> T:
         r"""[🌐 Ceil(13)](https://onnx.ai/onnx/operators/onnx__Ceil.html#ceil-13 "Online Documentation")
 
 
@@ -357,58 +306,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Ceil", 13, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(self, "Ceil", schema)
+        op = Op(self, "Ceil", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def Clip(
-        self,
-        input: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        min: Optional[
-            Union[
-                BFLOAT16,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ]
-        ] = None,
-        max: Optional[
-            Union[
-                BFLOAT16,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ]
-        ] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         DOUBLE,
         FLOAT,
@@ -421,7 +323,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Clip(self, input: T, min: Optional[T] = None, max: Optional[T] = None) -> T:
         r"""[🌐 Clip(13)](https://onnx.ai/onnx/operators/onnx__Clip.html#clip-13 "Online Documentation")
 
 
@@ -441,47 +345,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Clip", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Clip", schema)
+        op = Op(self, "Clip", schema)
         return op(*self._prepare_inputs(schema, input, min, max))
 
-    def Concat(
-        self,
-        *inputs: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axis: Optional[int] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -498,7 +366,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Concat(self, *inputs: T, axis: Optional[int] = None) -> T:
         r"""[🌐 Concat(13)](https://onnx.ai/onnx/operators/onnx__Concat.html#concat-13 "Online Documentation")
 
         Concatenate a list of tensors into a single tensor. All input tensors must have the same shape, except for the dimension size of the axis to concatenate on.
@@ -511,40 +381,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Concat", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Concat", schema)
+        op = Op(self, "Concat", schema)
         return op(*self._prepare_inputs(schema, *inputs), axis=axis)
 
-    def Constant(
-        self,
-        sparse_value: Optional[SparseTensorProto] = None,
-        value: Optional[TensorProto] = None,
-        value_float: Optional[float] = None,
-        value_floats: Optional[Sequence[float]] = None,
-        value_int: Optional[int] = None,
-        value_ints: Optional[Sequence[int]] = None,
-        value_string: Optional[str] = None,
-        value_strings: Optional[Sequence[str]] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -561,7 +402,19 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Constant(
+        self,
+        sparse_value: Optional[SparseTensorProto] = None,
+        value: Optional[TensorProto] = None,
+        value_float: Optional[float] = None,
+        value_floats: Optional[Sequence[float]] = None,
+        value_int: Optional[int] = None,
+        value_ints: Optional[Sequence[int]] = None,
+        value_string: Optional[str] = None,
+        value_strings: Optional[Sequence[str]] = None,
+    ) -> T:
         r"""[🌐 Constant(13)](https://onnx.ai/onnx/operators/onnx__Constant.html#constant-13 "Online Documentation")
 
 
@@ -594,27 +447,7 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Constant", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Constant", schema)
+        op = Op(self, "Constant", schema)
         return op(
             sparse_value=sparse_value,
             value=value,
@@ -626,29 +459,8 @@ class Opset13(Opset12):
             value_strings=value_strings,
         )
 
-    def DepthToSpace(
-        self,
-        input: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        blocksize: Optional[int] = None,
-        mode: str = "DCR",
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -665,7 +477,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def DepthToSpace(self, input: T, blocksize: Optional[int] = None, mode: str = "DCR") -> T:
         r"""[🌐 DepthToSpace(13)](https://onnx.ai/onnx/operators/onnx__DepthToSpace.html#depthtospace-13 "Online Documentation")
 
         DepthToSpace rearranges (permutes) data from depth into blocks of spatial data.
@@ -708,35 +522,13 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("DepthToSpace", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "DepthToSpace", schema)
+        op = Op(self, "DepthToSpace", schema)
         return op(*self._prepare_inputs(schema, input), blocksize=blocksize, mode=mode)
 
+    T = TypeVar("T", INT32, INT8, UINT8)
+
     def DequantizeLinear(
-        self,
-        x: Union[INT32, INT8, UINT8],
-        x_scale: FLOAT,
-        x_zero_point: Optional[Union[INT32, INT8, UINT8]] = None,
-        axis: int = 1,
+        self, x: T, x_scale: FLOAT, x_zero_point: Optional[T] = None, axis: int = 1
     ) -> FLOAT:
         r"""[🌐 DequantizeLinear(13)](https://onnx.ai/onnx/operators/onnx__DequantizeLinear.html#dequantizelinear-13 "Online Documentation")
 
@@ -765,14 +557,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("DequantizeLinear", 13, "")
-        op: Callable[..., FLOAT] = Op(self, "DequantizeLinear", schema)
+        op = Op(self, "DequantizeLinear", schema)
         return op(*self._prepare_inputs(schema, x, x_scale, x_zero_point), axis=axis)
 
-    def Div(
-        self,
-        A: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        B: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def Div(self, A: T, B: T) -> T:
         r"""[🌐 Div(13)](https://onnx.ai/onnx/operators/onnx__Div.html#div-13 "Online Documentation")
 
 
@@ -788,18 +578,22 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Div", 13, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "Div", schema)
+        op = Op(self, "Div", schema)
         return op(*self._prepare_inputs(schema, A, B))
+
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    T1 = TypeVar("T1", DOUBLE, FLOAT, FLOAT16)
+
+    T2 = TypeVar("T2", bound=BOOL)
 
     def Dropout(
         self,
-        data: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        ratio: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        training_mode: Optional[BOOL] = None,
+        data: T,
+        ratio: Optional[T1] = None,
+        training_mode: Optional[T2] = None,
         seed: Optional[int] = None,
-    ) -> Tuple[Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16], BOOL]:
+    ) -> Tuple[T, T2]:
         r"""[🌐 Dropout(13)](https://onnx.ai/onnx/operators/onnx__Dropout.html#dropout-13 "Online Documentation")
 
 
@@ -843,44 +637,29 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Dropout", 13, "")
-        op: Callable[..., Tuple[Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16], BOOL]] = Op(
-            self, "Dropout", schema
-        )
+        op = Op(self, "Dropout", schema)
         return op(*self._prepare_inputs(schema, data, ratio, training_mode), seed=seed)
 
-    def Equal(
-        self,
-        A: Union[
-            BFLOAT16,
-            BOOL,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        B: Union[
-            BFLOAT16,
-            BOOL,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> BOOL:
+    T = TypeVar(
+        "T",
+        BFLOAT16,
+        BOOL,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Equal(self, A: T, B: T) -> T1:
         r"""[🌐 Equal(13)](https://onnx.ai/onnx/operators/onnx__Equal.html#equal-13 "Online Documentation")
 
 
@@ -897,26 +676,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Equal", 13, "")
-        op: Callable[..., BOOL] = Op(self, "Equal", schema)
+        op = Op(self, "Equal", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def Erf(
-        self,
-        input: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         DOUBLE,
         FLOAT,
@@ -929,7 +693,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Erf(self, input: T) -> T:
         r"""[🌐 Erf(13)](https://onnx.ai/onnx/operators/onnx__Erf.html#erf-13 "Online Documentation")
 
 
@@ -941,28 +707,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Erf", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Erf", schema)
+        op = Op(self, "Erf", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def Exp(
-        self, input: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    def Exp(self, input: T) -> T:
         r"""[🌐 Exp(13)](https://onnx.ai/onnx/operators/onnx__Exp.html#exp-13 "Online Documentation")
 
 
@@ -974,31 +724,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Exp", 13, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(self, "Exp", schema)
+        op = Op(self, "Exp", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def Expand(
-        self,
-        input: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        shape: INT64,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -1015,7 +745,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Expand(self, input: T, shape: INT64) -> T:
         r"""[🌐 Expand(13)](https://onnx.ai/onnx/operators/onnx__Expand.html#expand-13 "Online Documentation")
 
 
@@ -1037,51 +769,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Expand", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Expand", schema)
+        op = Op(self, "Expand", schema)
         return op(*self._prepare_inputs(schema, input, shape))
 
-    def Flatten(
-        self,
-        input: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axis: int = 1,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -1098,7 +790,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Flatten(self, input: T, axis: int = 1) -> T:
         r"""[🌐 Flatten(13)](https://onnx.ai/onnx/operators/onnx__Flatten.html#flatten-13 "Online Documentation")
 
 
@@ -1119,32 +813,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Flatten", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Flatten", schema)
+        op = Op(self, "Flatten", schema)
         return op(*self._prepare_inputs(schema, input), axis=axis)
 
-    def Floor(
-        self, X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    def Floor(self, X: T) -> T:
         r"""[🌐 Floor(13)](https://onnx.ai/onnx/operators/onnx__Floor.html#floor-13 "Online Documentation")
 
 
@@ -1158,32 +832,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Floor", 13, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(self, "Floor", schema)
+        op = Op(self, "Floor", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def Gather(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        indices: Union[INT32, INT64],
-        axis: int = 0,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -1200,7 +853,11 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    Tind = TypeVar("Tind", INT32, INT64)
+
+    def Gather(self, data: T, indices: Tind, axis: int = 0) -> T:
         r"""[🌐 Gather(13)](https://onnx.ai/onnx/operators/onnx__Gather.html#gather-13 "Online Documentation")
 
 
@@ -1270,52 +927,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Gather", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Gather", schema)
+        op = Op(self, "Gather", schema)
         return op(*self._prepare_inputs(schema, data, indices), axis=axis)
 
-    def GatherElements(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        indices: Union[INT32, INT64],
-        axis: int = 0,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -1332,7 +948,11 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    Tind = TypeVar("Tind", INT32, INT64)
+
+    def GatherElements(self, data: T, indices: Tind, axis: int = 0) -> T:
         r"""[🌐 GatherElements(13)](https://onnx.ai/onnx/operators/onnx__GatherElements.html#gatherelements-13 "Online Documentation")
 
 
@@ -1409,52 +1029,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("GatherElements", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "GatherElements", schema)
+        op = Op(self, "GatherElements", schema)
         return op(*self._prepare_inputs(schema, data, indices), axis=axis)
 
-    def GatherND(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        indices: INT64,
-        batch_dims: int = 0,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -1471,7 +1050,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def GatherND(self, data: T, indices: INT64, batch_dims: int = 0) -> T:
         r"""[🌐 GatherND(13)](https://onnx.ai/onnx/operators/onnx__GatherND.html#gathernd-13 "Online Documentation")
 
 
@@ -1580,41 +1161,21 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("GatherND", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "GatherND", schema)
+        op = Op(self, "GatherND", schema)
         return op(*self._prepare_inputs(schema, data, indices), batch_dims=batch_dims)
+
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def Gemm(
         self,
-        A: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        B: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        C: Optional[
-            Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = None,
+        A: T,
+        B: T,
+        C: Optional[T] = None,
         alpha: float = 1.0,
         beta: float = 1.0,
         transA: int = 0,
         transB: int = 0,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    ) -> T:
         r"""[🌐 Gemm(13)](https://onnx.ai/onnx/operators/onnx__Gemm.html#gemm-13 "Online Documentation")
 
         General Matrix multiplication:
@@ -1652,9 +1213,7 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Gemm", 13, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "Gemm", schema)
+        op = Op(self, "Gemm", schema)
         return op(
             *self._prepare_inputs(schema, A, B, C),
             alpha=alpha,
@@ -1663,37 +1222,25 @@ class Opset13(Opset12):
             transB=transB,
         )
 
-    def Greater(
-        self,
-        A: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        B: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> BOOL:
+    T = TypeVar(
+        "T",
+        BFLOAT16,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Greater(self, A: T, B: T) -> T1:
         r"""[🌐 Greater(13)](https://onnx.ai/onnx/operators/onnx__Greater.html#greater-13 "Online Documentation")
 
 
@@ -1710,12 +1257,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Greater", 13, "")
-        op: Callable[..., BOOL] = Op(self, "Greater", schema)
+        op = Op(self, "Greater", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def Hardmax(
-        self, input: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16], axis: int = -1
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    def Hardmax(self, input: T, axis: int = -1) -> T:
         r"""[🌐 Hardmax(13)](https://onnx.ai/onnx/operators/onnx__Hardmax.html#hardmax-13 "Online Documentation")
 
 
@@ -1740,32 +1287,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Hardmax", 13, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(
-            self, "Hardmax", schema
-        )
+        op = Op(self, "Hardmax", schema)
         return op(*self._prepare_inputs(schema, input), axis=axis)
 
-    def Identity(
-        self,
-        input: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -1782,7 +1308,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Identity(self, input: T) -> T:
         r"""[🌐 Identity(13)](https://onnx.ai/onnx/operators/onnx__Identity.html#identity-13 "Online Documentation")
 
         Identity operator
@@ -1792,35 +1320,13 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Identity", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Identity", schema)
+        op = Op(self, "Identity", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def If(
-        self,
-        cond: BOOL,
-        else_branch: Optional[GraphProto] = None,
-        then_branch: Optional[GraphProto] = None,
-    ) -> Union[
+    B = TypeVar("B", bound=BOOL)
+
+    V = TypeVar(
+        "V",
         Sequence[BOOL],
         Sequence[COMPLEX128],
         Sequence[COMPLEX64],
@@ -1851,7 +1357,14 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def If(
+        self,
+        cond: B,
+        else_branch: Optional[GraphProto] = None,
+        then_branch: Optional[GraphProto] = None,
+    ) -> V:
         r"""[🌐 If(13)](https://onnx.ai/onnx/operators/onnx__If.html#if-13 "Online Documentation")
 
         If conditional
@@ -1869,48 +1382,18 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("If", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                Sequence[BOOL],
-                Sequence[COMPLEX128],
-                Sequence[COMPLEX64],
-                Sequence[DOUBLE],
-                Sequence[FLOAT],
-                Sequence[FLOAT16],
-                Sequence[INT16],
-                Sequence[INT32],
-                Sequence[INT64],
-                Sequence[INT8],
-                Sequence[STRING],
-                Sequence[UINT16],
-                Sequence[UINT32],
-                Sequence[UINT64],
-                Sequence[UINT8],
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "If", schema)
+        op = Op(self, "If", schema)
         return op(
             *self._prepare_inputs(schema, cond),
             else_branch=else_branch,
             then_branch=then_branch,
         )
 
-    def IsNaN(self, X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]) -> BOOL:
+    T1 = TypeVar("T1", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    T2 = TypeVar("T2", bound=BOOL)
+
+    def IsNaN(self, X: T1) -> T2:
         r"""[🌐 IsNaN(13)](https://onnx.ai/onnx/operators/onnx__IsNaN.html#isnan-13 "Online Documentation")
 
         Returns which elements of the input are NaN.
@@ -1920,17 +1403,19 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("IsNaN", 13, "")
-        op: Callable[..., BOOL] = Op(self, "IsNaN", schema)
+        op = Op(self, "IsNaN", schema)
         return op(*self._prepare_inputs(schema, X))
+
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
 
     def LRN(
         self,
-        X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
+        X: T,
         alpha: float = 9.999999747378752e-05,
         beta: float = 0.75,
         bias: float = 1.0,
         size: Optional[int] = None,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 LRN(13)](https://onnx.ai/onnx/operators/onnx__LRN.html#lrn-13 "Online Documentation")
 
 
@@ -1964,42 +1449,30 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("LRN", 13, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(self, "LRN", schema)
+        op = Op(self, "LRN", schema)
         return op(
             *self._prepare_inputs(schema, X), alpha=alpha, beta=beta, bias=bias, size=size
         )
 
-    def Less(
-        self,
-        A: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        B: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> BOOL:
+    T = TypeVar(
+        "T",
+        BFLOAT16,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Less(self, A: T, B: T) -> T1:
         r"""[🌐 Less(13)](https://onnx.ai/onnx/operators/onnx__Less.html#less-13 "Online Documentation")
 
 
@@ -2016,12 +1489,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Less", 13, "")
-        op: Callable[..., BOOL] = Op(self, "Less", schema)
+        op = Op(self, "Less", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def Log(
-        self, input: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    def Log(self, input: T) -> T:
         r"""[🌐 Log(13)](https://onnx.ai/onnx/operators/onnx__Log.html#log-13 "Online Documentation")
 
 
@@ -2033,12 +1506,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Log", 13, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(self, "Log", schema)
+        op = Op(self, "Log", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def LogSoftmax(
-        self, input: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16], axis: int = -1
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    def LogSoftmax(self, input: T, axis: int = -1) -> T:
         r"""[🌐 LogSoftmax(13)](https://onnx.ai/onnx/operators/onnx__LogSoftmax.html#logsoftmax-13 "Online Documentation")
 
 
@@ -2063,49 +1536,15 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("LogSoftmax", 13, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(
-            self, "LogSoftmax", schema
-        )
+        op = Op(self, "LogSoftmax", schema)
         return op(*self._prepare_inputs(schema, input), axis=axis)
 
-    def Loop(
-        self,
-        M: Optional[INT64],
-        cond: Optional[BOOL],
-        *v_initial: Union[
-            Sequence[BOOL],
-            Sequence[COMPLEX128],
-            Sequence[COMPLEX64],
-            Sequence[DOUBLE],
-            Sequence[FLOAT],
-            Sequence[FLOAT16],
-            Sequence[INT16],
-            Sequence[INT32],
-            Sequence[INT64],
-            Sequence[INT8],
-            Sequence[STRING],
-            Sequence[UINT16],
-            Sequence[UINT32],
-            Sequence[UINT64],
-            Sequence[UINT8],
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        body: Optional[GraphProto] = None,
-    ) -> Union[
+    I = TypeVar("I", bound=INT64)
+
+    B = TypeVar("B", bound=BOOL)
+
+    V = TypeVar(
+        "V",
         Sequence[BOOL],
         Sequence[COMPLEX128],
         Sequence[COMPLEX64],
@@ -2136,7 +1575,15 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Loop(
+        self,
+        M: Optional[I],
+        cond: Optional[B],
+        *v_initial: V,
+        body: Optional[GraphProto] = None,
+    ) -> V:
         r"""[🌐 Loop(13)](https://onnx.ai/onnx/operators/onnx__Loop.html#loop-13 "Online Documentation")
 
 
@@ -2297,48 +1744,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Loop", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                Sequence[BOOL],
-                Sequence[COMPLEX128],
-                Sequence[COMPLEX64],
-                Sequence[DOUBLE],
-                Sequence[FLOAT],
-                Sequence[FLOAT16],
-                Sequence[INT16],
-                Sequence[INT32],
-                Sequence[INT64],
-                Sequence[INT8],
-                Sequence[STRING],
-                Sequence[UINT16],
-                Sequence[UINT32],
-                Sequence[UINT64],
-                Sequence[UINT8],
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Loop", schema)
+        op = Op(self, "Loop", schema)
         return op(*self._prepare_inputs(schema, M, cond, *v_initial), body=body)
 
-    def MatMul(
-        self,
-        A: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        B: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def MatMul(self, A: T, B: T) -> T:
         r"""[🌐 MatMul(13)](https://onnx.ai/onnx/operators/onnx__MatMul.html#matmul-13 "Online Documentation")
 
 
@@ -2352,28 +1763,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("MatMul", 13, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "MatMul", schema)
+        op = Op(self, "MatMul", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def Max(
-        self,
-        *data_0: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         DOUBLE,
         FLOAT,
@@ -2386,7 +1780,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Max(self, *data_0: T) -> T:
         r"""[🌐 Max(13)](https://onnx.ai/onnx/operators/onnx__Max.html#max-13 "Online Documentation")
 
 
@@ -2400,28 +1796,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Max", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Max", schema)
+        op = Op(self, "Max", schema)
         return op(*self._prepare_inputs(schema, *data_0))
 
-    def Mean(
-        self, *data_0: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    def Mean(self, *data_0: T) -> T:
         r"""[🌐 Mean(13)](https://onnx.ai/onnx/operators/onnx__Mean.html#mean-13 "Online Documentation")
 
 
@@ -2435,12 +1815,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Mean", 13, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(self, "Mean", schema)
+        op = Op(self, "Mean", schema)
         return op(*self._prepare_inputs(schema, *data_0))
 
-    def MeanVarianceNormalization(
-        self, X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16], axes: Sequence[int] = (0, 2, 3)
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    def MeanVarianceNormalization(self, X: T, axes: Sequence[int] = (0, 2, 3)) -> T:
         r"""[🌐 MeanVarianceNormalization(13)](https://onnx.ai/onnx/operators/onnx__MeanVarianceNormalization.html#meanvariancenormalization-13 "Online Documentation")
 
 
@@ -2458,28 +1838,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("MeanVarianceNormalization", 13, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(
-            self, "MeanVarianceNormalization", schema
-        )
+        op = Op(self, "MeanVarianceNormalization", schema)
         return op(*self._prepare_inputs(schema, X), axes=axes)
 
-    def Min(
-        self,
-        *data_0: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         DOUBLE,
         FLOAT,
@@ -2492,7 +1855,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Min(self, *data_0: T) -> T:
         r"""[🌐 Min(13)](https://onnx.ai/onnx/operators/onnx__Min.html#min-13 "Online Documentation")
 
 
@@ -2506,57 +1871,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Min", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Min", schema)
+        op = Op(self, "Min", schema)
         return op(*self._prepare_inputs(schema, *data_0))
 
-    def Mod(
-        self,
-        A: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        B: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        fmod: int = 0,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         DOUBLE,
         FLOAT,
@@ -2569,7 +1888,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Mod(self, A: T, B: T, fmod: int = 0) -> T:
         r"""[🌐 Mod(13)](https://onnx.ai/onnx/operators/onnx__Mod.html#mod-13 "Online Documentation")
 
 
@@ -2598,30 +1919,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Mod", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Mod", schema)
+        op = Op(self, "Mod", schema)
         return op(*self._prepare_inputs(schema, A, B), fmod=fmod)
 
-    def Mul(
-        self,
-        A: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        B: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def Mul(self, A: T, B: T) -> T:
         r"""[🌐 Mul(13)](https://onnx.ai/onnx/operators/onnx__Mul.html#mul-13 "Online Documentation")
 
 
@@ -2637,14 +1940,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Mul", 13, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "Mul", schema)
+        op = Op(self, "Mul", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def Neg(
-        self, X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8]
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8)
+
+    def Neg(self, X: T) -> T:
         r"""[🌐 Neg(13)](https://onnx.ai/onnx/operators/onnx__Neg.html#neg-13 "Online Documentation")
 
 
@@ -2658,19 +1959,21 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Neg", 13, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8]
-        ] = Op(self, "Neg", schema)
+        op = Op(self, "Neg", schema)
         return op(*self._prepare_inputs(schema, X))
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    Tind = TypeVar("Tind", INT32, INT64)
 
     def NegativeLogLikelihoodLoss(
         self,
-        input: Union[DOUBLE, FLOAT, FLOAT16],
-        target: Union[INT32, INT64],
-        weight: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
+        input: T,
+        target: Tind,
+        weight: Optional[T] = None,
         ignore_index: Optional[int] = None,
         reduction: str = "mean",
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 NegativeLogLikelihoodLoss(13)](https://onnx.ai/onnx/operators/onnx__NegativeLogLikelihoodLoss.html#negativeloglikelihoodloss-13 "Online Documentation")
 
 
@@ -2816,97 +2119,15 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("NegativeLogLikelihoodLoss", 13, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(
-            self, "NegativeLogLikelihoodLoss", schema
-        )
+        op = Op(self, "NegativeLogLikelihoodLoss", schema)
         return op(
             *self._prepare_inputs(schema, input, target, weight),
             ignore_index=ignore_index,
             reduction=reduction,
         )
 
-    def NonZero(
-        self,
-        X: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> INT64:
-        r"""[🌐 NonZero(13)](https://onnx.ai/onnx/operators/onnx__NonZero.html#nonzero-13 "Online Documentation")
-
-
-            Returns the indices of the elements that are non-zero
-            (in row-major order - by dimension).
-            NonZero behaves similar to numpy.nonzero:
-            https://docs.scipy.org/doc/numpy/reference/generated/numpy.nonzero.html,
-            but for scalar input, NonZero produces output shape (0, N) instead of (1, N), which is different from Numpy's behavior.
-
-
-        Args:
-            X: (non-differentiable) input
-        """
-
-        schema = get_schema("NonZero", 13, "")
-        op: Callable[..., INT64] = Op(self, "NonZero", schema)
-        return op(*self._prepare_inputs(schema, X))
-
-    def Pad(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        pads: INT64,
-        constant_value: Optional[
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ]
-        ] = None,
-        mode: str = "constant",
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -2923,7 +2144,50 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def NonZero(self, X: T) -> INT64:
+        r"""[🌐 NonZero(13)](https://onnx.ai/onnx/operators/onnx__NonZero.html#nonzero-13 "Online Documentation")
+
+
+            Returns the indices of the elements that are non-zero
+            (in row-major order - by dimension).
+            NonZero behaves similar to numpy.nonzero:
+            https://docs.scipy.org/doc/numpy/reference/generated/numpy.nonzero.html,
+            but for scalar input, NonZero produces output shape (0, N) instead of (1, N), which is different from Numpy's behavior.
+
+
+        Args:
+            X: (non-differentiable) input
+        """
+
+        schema = get_schema("NonZero", 13, "")
+        op = Op(self, "NonZero", schema)
+        return op(*self._prepare_inputs(schema, X))
+
+    T = TypeVar(
+        "T",
+        BFLOAT16,
+        BOOL,
+        COMPLEX128,
+        COMPLEX64,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    def Pad(
+        self, data: T, pads: INT64, constant_value: Optional[T] = None, mode: str = "constant"
+    ) -> T:
         r"""[🌐 Pad(13)](https://onnx.ai/onnx/operators/onnx__Pad.html#pad-13 "Online Documentation")
 
 
@@ -3023,36 +2287,16 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Pad", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Pad", schema)
+        op = Op(self, "Pad", schema)
         return op(*self._prepare_inputs(schema, data, pads, constant_value), mode=mode)
 
-    def Pow(
-        self,
-        X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64],
-        Y: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64)
+
+    T1 = TypeVar(
+        "T1", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    def Pow(self, X: T, Y: T1) -> T:
         r"""[🌐 Pow(13)](https://onnx.ai/onnx/operators/onnx__Pow.html#pow-13 "Online Documentation")
 
 
@@ -3068,18 +2312,16 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Pow", 13, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64]] = Op(
-            self, "Pow", schema
-        )
+        op = Op(self, "Pow", schema)
         return op(*self._prepare_inputs(schema, X, Y))
 
+    T1 = TypeVar("T1", FLOAT, INT32)
+
+    T2 = TypeVar("T2", INT8, UINT8)
+
     def QuantizeLinear(
-        self,
-        x: Union[FLOAT, INT32],
-        y_scale: FLOAT,
-        y_zero_point: Optional[Union[INT8, UINT8]] = None,
-        axis: int = 1,
-    ) -> Union[INT8, UINT8]:
+        self, x: T1, y_scale: FLOAT, y_zero_point: Optional[T2] = None, axis: int = 1
+    ) -> T2:
         r"""[🌐 QuantizeLinear(13)](https://onnx.ai/onnx/operators/onnx__QuantizeLinear.html#quantizelinear-13 "Online Documentation")
 
 
@@ -3108,12 +2350,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("QuantizeLinear", 13, "")
-        op: Callable[..., Union[INT8, UINT8]] = Op(self, "QuantizeLinear", schema)
+        op = Op(self, "QuantizeLinear", schema)
         return op(*self._prepare_inputs(schema, x, y_scale, y_zero_point), axis=axis)
 
-    def Reciprocal(
-        self, X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    def Reciprocal(self, X: T) -> T:
         r"""[🌐 Reciprocal(13)](https://onnx.ai/onnx/operators/onnx__Reciprocal.html#reciprocal-13 "Online Documentation")
 
 
@@ -3127,17 +2369,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Reciprocal", 13, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(
-            self, "Reciprocal", schema
-        )
+        op = Op(self, "Reciprocal", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def ReduceL1(
-        self,
-        data: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def ReduceL1(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
         r"""[🌐 ReduceL1(13)](https://onnx.ai/onnx/operators/onnx__ReduceL1.html#reducel1-13 "Online Documentation")
 
 
@@ -3161,17 +2398,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("ReduceL1", 13, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "ReduceL1", schema)
+        op = Op(self, "ReduceL1", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
-    def ReduceL2(
-        self,
-        data: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def ReduceL2(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
         r"""[🌐 ReduceL2(13)](https://onnx.ai/onnx/operators/onnx__ReduceL2.html#reducel2-13 "Online Documentation")
 
 
@@ -3195,17 +2427,14 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("ReduceL2", 13, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "ReduceL2", schema)
+        op = Op(self, "ReduceL2", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceLogSum(
-        self,
-        data: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceLogSum(13)](https://onnx.ai/onnx/operators/onnx__ReduceLogSum.html#reducelogsum-13 "Online Documentation")
 
 
@@ -3229,17 +2458,14 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("ReduceLogSum", 13, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "ReduceLogSum", schema)
+        op = Op(self, "ReduceLogSum", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceLogSumExp(
-        self,
-        data: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceLogSumExp(13)](https://onnx.ai/onnx/operators/onnx__ReduceLogSumExp.html#reducelogsumexp-13 "Online Documentation")
 
 
@@ -3263,19 +2489,14 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("ReduceLogSumExp", 13, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "ReduceLogSumExp", schema)
+        op = Op(self, "ReduceLogSumExp", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
-    def ReduceMax(
-        self,
-        data: Union[
-            BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8
-        ],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8]:
+    T = TypeVar(
+        "T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8
+    )
+
+    def ReduceMax(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
         r"""[🌐 ReduceMax(13)](https://onnx.ai/onnx/operators/onnx__ReduceMax.html#reducemax-13 "Online Documentation")
 
 
@@ -3299,18 +2520,14 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("ReduceMax", 13, "")
-        op: Callable[
-            ...,
-            Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8],
-        ] = Op(self, "ReduceMax", schema)
+        op = Op(self, "ReduceMax", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceMean(
-        self,
-        data: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceMean(13)](https://onnx.ai/onnx/operators/onnx__ReduceMean.html#reducemean-13 "Online Documentation")
 
 
@@ -3334,19 +2551,14 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("ReduceMean", 13, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "ReduceMean", schema)
+        op = Op(self, "ReduceMean", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
-    def ReduceMin(
-        self,
-        data: Union[
-            BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8
-        ],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8]:
+    T = TypeVar(
+        "T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8
+    )
+
+    def ReduceMin(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
         r"""[🌐 ReduceMin(13)](https://onnx.ai/onnx/operators/onnx__ReduceMin.html#reducemin-13 "Online Documentation")
 
 
@@ -3370,18 +2582,14 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("ReduceMin", 13, "")
-        op: Callable[
-            ...,
-            Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8],
-        ] = Op(self, "ReduceMin", schema)
+        op = Op(self, "ReduceMin", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceProd(
-        self,
-        data: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceProd(13)](https://onnx.ai/onnx/operators/onnx__ReduceProd.html#reduceprod-13 "Online Documentation")
 
 
@@ -3405,18 +2613,18 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("ReduceProd", 13, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "ReduceProd", schema)
+        op = Op(self, "ReduceProd", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
+
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def ReduceSum(
         self,
-        data: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
+        data: T,
         axes: Optional[INT64] = None,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    ) -> T:
         r"""[🌐 ReduceSum(13)](https://onnx.ai/onnx/operators/onnx__ReduceSum.html#reducesum-13 "Online Documentation")
 
 
@@ -3447,21 +2655,18 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("ReduceSum", 13, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "ReduceSum", schema)
+        op = Op(self, "ReduceSum", schema)
         return op(
             *self._prepare_inputs(schema, data, axes),
             keepdims=keepdims,
             noop_with_empty_axes=noop_with_empty_axes,
         )
 
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceSumSquare(
-        self,
-        data: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axes: Optional[Sequence[int]] = None,
-        keepdims: int = 1,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceSumSquare(13)](https://onnx.ai/onnx/operators/onnx__ReduceSumSquare.html#reducesumsquare-13 "Online Documentation")
 
 
@@ -3485,14 +2690,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("ReduceSumSquare", 13, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "ReduceSumSquare", schema)
+        op = Op(self, "ReduceSumSquare", schema)
         return op(*self._prepare_inputs(schema, data), axes=axes, keepdims=keepdims)
 
-    def Relu(
-        self, X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    def Relu(self, X: T) -> T:
         r"""[🌐 Relu(13)](https://onnx.ai/onnx/operators/onnx__Relu.html#relu-13 "Online Documentation")
 
 
@@ -3506,31 +2709,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Relu", 13, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(self, "Relu", schema)
+        op = Op(self, "Relu", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def Reshape(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        shape: INT64,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -3547,7 +2730,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Reshape(self, data: T, shape: INT64) -> T:
         r"""[🌐 Reshape(13)](https://onnx.ai/onnx/operators/onnx__Reshape.html#reshape-13 "Online Documentation")
 
 
@@ -3566,59 +2751,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Reshape", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Reshape", schema)
+        op = Op(self, "Reshape", schema)
         return op(*self._prepare_inputs(schema, data, shape))
 
-    def Resize(
-        self,
-        X: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        roi: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        scales: Optional[FLOAT] = None,
-        sizes: Optional[INT64] = None,
-        coordinate_transformation_mode: str = "half_pixel",
-        cubic_coeff_a: float = -0.75,
-        exclude_outside: int = 0,
-        extrapolation_value: float = 0.0,
-        mode: str = "nearest",
-        nearest_mode: str = "round_prefer_floor",
-    ) -> Union[
+    T1 = TypeVar(
+        "T1",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -3635,7 +2772,23 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    T2 = TypeVar("T2", DOUBLE, FLOAT, FLOAT16)
+
+    def Resize(
+        self,
+        X: T1,
+        roi: Optional[T2] = None,
+        scales: Optional[FLOAT] = None,
+        sizes: Optional[INT64] = None,
+        coordinate_transformation_mode: str = "half_pixel",
+        cubic_coeff_a: float = -0.75,
+        exclude_outside: int = 0,
+        extrapolation_value: float = 0.0,
+        mode: str = "nearest",
+        nearest_mode: str = "round_prefer_floor",
+    ) -> T1:
         r"""[🌐 Resize(13)](https://onnx.ai/onnx/operators/onnx__Resize.html#resize-13 "Online Documentation")
 
 
@@ -3733,27 +2886,7 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Resize", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Resize", schema)
+        op = Op(self, "Resize", schema)
         return op(
             *self._prepare_inputs(schema, X, roi, scales, sizes),
             coordinate_transformation_mode=coordinate_transformation_mode,
@@ -3764,47 +2897,8 @@ class Opset13(Opset12):
             nearest_mode=nearest_mode,
         )
 
-    def ScatterElements(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        indices: Union[INT32, INT64],
-        updates: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axis: int = 0,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -3821,7 +2915,11 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    Tind = TypeVar("Tind", INT32, INT64)
+
+    def ScatterElements(self, data: T, indices: Tind, updates: T, axis: int = 0) -> T:
         r"""[🌐 ScatterElements(13)](https://onnx.ai/onnx/operators/onnx__ScatterElements.html#scatterelements-13 "Online Documentation")
 
 
@@ -3900,69 +2998,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("ScatterElements", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "ScatterElements", schema)
+        op = Op(self, "ScatterElements", schema)
         return op(*self._prepare_inputs(schema, data, indices, updates), axis=axis)
 
-    def ScatterND(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        indices: INT64,
-        updates: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -3979,7 +3019,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def ScatterND(self, data: T, indices: INT64, updates: T) -> T:
         r"""[🌐 ScatterND(13)](https://onnx.ai/onnx/operators/onnx__ScatterND.html#scatternd-13 "Online Documentation")
 
 
@@ -4055,206 +3097,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("ScatterND", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "ScatterND", schema)
+        op = Op(self, "ScatterND", schema)
         return op(*self._prepare_inputs(schema, data, indices, updates))
 
-    def Shape(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> INT64:
-        r"""[🌐 Shape(13)](https://onnx.ai/onnx/operators/onnx__Shape.html#shape-13 "Online Documentation")
-
-
-        Takes a tensor as input and outputs an 1D int64 tensor containing the shape of the input tensor.
-
-
-        Args:
-            data: (non-differentiable) An input tensor.
-        """
-
-        schema = get_schema("Shape", 13, "")
-        op: Callable[..., INT64] = Op(self, "Shape", schema)
-        return op(*self._prepare_inputs(schema, data))
-
-    def Sigmoid(
-        self, X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
-        r"""[🌐 Sigmoid(13)](https://onnx.ai/onnx/operators/onnx__Sigmoid.html#sigmoid-13 "Online Documentation")
-
-
-        Sigmoid takes one input data (Tensor<T>) and produces one output data
-        (Tensor<T>) where the sigmoid function, y = 1 / (1 + exp(-x)), is applied to the
-        tensor elementwise.
-
-
-        Args:
-            X: (differentiable) Input tensor
-        """
-
-        schema = get_schema("Sigmoid", 13, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(
-            self, "Sigmoid", schema
-        )
-        return op(*self._prepare_inputs(schema, X))
-
-    def Sign(
-        self,
-        input: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
-        BFLOAT16,
-        DOUBLE,
-        FLOAT,
-        FLOAT16,
-        INT16,
-        INT32,
-        INT64,
-        INT8,
-        UINT16,
-        UINT32,
-        UINT64,
-        UINT8,
-    ]:
-        r"""[🌐 Sign(13)](https://onnx.ai/onnx/operators/onnx__Sign.html#sign-13 "Online Documentation")
-
-
-        Calculate the sign of the given input tensor element-wise.
-        If input > 0, output 1. if input < 0, output -1. if input == 0, output 0.
-
-
-        Args:
-            input: (non-differentiable) Input tensor
-        """
-
-        schema = get_schema("Sign", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Sign", schema)
-        return op(*self._prepare_inputs(schema, input))
-
-    def Size(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> INT64:
-        r"""[🌐 Size(13)](https://onnx.ai/onnx/operators/onnx__Size.html#size-13 "Online Documentation")
-
-
-        Takes a tensor as input and outputs a int64 scalar that equals to the total number of elements of the input tensor.
-
-
-        Args:
-            data: (non-differentiable) An input tensor.
-        """
-
-        schema = get_schema("Size", 13, "")
-        op: Callable[..., INT64] = Op(self, "Size", schema)
-        return op(*self._prepare_inputs(schema, data))
-
-    def Slice(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        starts: Union[INT32, INT64],
-        ends: Union[INT32, INT64],
-        axes: Optional[Union[INT32, INT64]] = None,
-        steps: Optional[Union[INT32, INT64]] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -4271,7 +3118,143 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    T1 = TypeVar("T1", bound=INT64)
+
+    def Shape(self, data: T) -> T1:
+        r"""[🌐 Shape(13)](https://onnx.ai/onnx/operators/onnx__Shape.html#shape-13 "Online Documentation")
+
+
+        Takes a tensor as input and outputs an 1D int64 tensor containing the shape of the input tensor.
+
+
+        Args:
+            data: (non-differentiable) An input tensor.
+        """
+
+        schema = get_schema("Shape", 13, "")
+        op = Op(self, "Shape", schema)
+        return op(*self._prepare_inputs(schema, data))
+
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    def Sigmoid(self, X: T) -> T:
+        r"""[🌐 Sigmoid(13)](https://onnx.ai/onnx/operators/onnx__Sigmoid.html#sigmoid-13 "Online Documentation")
+
+
+        Sigmoid takes one input data (Tensor<T>) and produces one output data
+        (Tensor<T>) where the sigmoid function, y = 1 / (1 + exp(-x)), is applied to the
+        tensor elementwise.
+
+
+        Args:
+            X: (differentiable) Input tensor
+        """
+
+        schema = get_schema("Sigmoid", 13, "")
+        op = Op(self, "Sigmoid", schema)
+        return op(*self._prepare_inputs(schema, X))
+
+    T = TypeVar(
+        "T",
+        BFLOAT16,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    def Sign(self, input: T) -> T:
+        r"""[🌐 Sign(13)](https://onnx.ai/onnx/operators/onnx__Sign.html#sign-13 "Online Documentation")
+
+
+        Calculate the sign of the given input tensor element-wise.
+        If input > 0, output 1. if input < 0, output -1. if input == 0, output 0.
+
+
+        Args:
+            input: (non-differentiable) Input tensor
+        """
+
+        schema = get_schema("Sign", 13, "")
+        op = Op(self, "Sign", schema)
+        return op(*self._prepare_inputs(schema, input))
+
+    T = TypeVar(
+        "T",
+        BFLOAT16,
+        BOOL,
+        COMPLEX128,
+        COMPLEX64,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    T1 = TypeVar("T1", bound=INT64)
+
+    def Size(self, data: T) -> T1:
+        r"""[🌐 Size(13)](https://onnx.ai/onnx/operators/onnx__Size.html#size-13 "Online Documentation")
+
+
+        Takes a tensor as input and outputs a int64 scalar that equals to the total number of elements of the input tensor.
+
+
+        Args:
+            data: (non-differentiable) An input tensor.
+        """
+
+        schema = get_schema("Size", 13, "")
+        op = Op(self, "Size", schema)
+        return op(*self._prepare_inputs(schema, data))
+
+    T = TypeVar(
+        "T",
+        BFLOAT16,
+        BOOL,
+        COMPLEX128,
+        COMPLEX64,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    Tind = TypeVar("Tind", INT32, INT64)
+
+    def Slice(
+        self,
+        data: T,
+        starts: Tind,
+        ends: Tind,
+        axes: Optional[Tind] = None,
+        steps: Optional[Tind] = None,
+    ) -> T:
         r"""[🌐 Slice(13)](https://onnx.ai/onnx/operators/onnx__Slice.html#slice-13 "Online Documentation")
 
 
@@ -4363,32 +3346,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Slice", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Slice", schema)
+        op = Op(self, "Slice", schema)
         return op(*self._prepare_inputs(schema, data, starts, ends, axes, steps))
 
-    def Softmax(
-        self, input: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16], axis: int = -1
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    def Softmax(self, input: T, axis: int = -1) -> T:
         r"""[🌐 Softmax(13)](https://onnx.ai/onnx/operators/onnx__Softmax.html#softmax-13 "Online Documentation")
 
 
@@ -4413,21 +3376,21 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Softmax", 13, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(
-            self, "Softmax", schema
-        )
+        op = Op(self, "Softmax", schema)
         return op(*self._prepare_inputs(schema, input), axis=axis)
+
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    Tind = TypeVar("Tind", INT32, INT64)
 
     def SoftmaxCrossEntropyLoss(
         self,
-        scores: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        labels: Union[INT32, INT64],
-        weights: Optional[Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = None,
+        scores: T,
+        labels: Tind,
+        weights: Optional[T] = None,
         ignore_index: Optional[int] = None,
         reduction: str = "mean",
-    ) -> Tuple[
-        Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16], Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]
-    ]:
+    ) -> Tuple[T, T]:
         r"""[🌐 SoftmaxCrossEntropyLoss(13)](https://onnx.ai/onnx/operators/onnx__SoftmaxCrossEntropyLoss.html#softmaxcrossentropyloss-13 "Online Documentation")
 
         Loss function that measures the softmax cross entropy
@@ -4506,41 +3469,15 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("SoftmaxCrossEntropyLoss", 13, "")
-        op: Callable[
-            ...,
-            Tuple[
-                Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-                Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-            ],
-        ] = Op(self, "SoftmaxCrossEntropyLoss", schema)
+        op = Op(self, "SoftmaxCrossEntropyLoss", schema)
         return op(
             *self._prepare_inputs(schema, scores, labels, weights),
             ignore_index=ignore_index,
             reduction=reduction,
         )
 
-    def SpaceToDepth(
-        self,
-        input: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        blocksize: Optional[int] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -4557,7 +3494,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def SpaceToDepth(self, input: T, blocksize: Optional[int] = None) -> T:
         r"""[🌐 SpaceToDepth(13)](https://onnx.ai/onnx/operators/onnx__SpaceToDepth.html#spacetodepth-13 "Online Documentation")
 
         SpaceToDepth rearranges blocks of spatial data into depth. More specifically,
@@ -4573,52 +3512,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("SpaceToDepth", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "SpaceToDepth", schema)
+        op = Op(self, "SpaceToDepth", schema)
         return op(*self._prepare_inputs(schema, input), blocksize=blocksize)
 
-    def Split(
-        self,
-        input: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        split: Optional[INT64] = None,
-        axis: int = 0,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -4635,7 +3533,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Split(self, input: T, split: Optional[INT64] = None, axis: int = 0) -> T:
         r"""[🌐 Split(13)](https://onnx.ai/onnx/operators/onnx__Split.html#split-13 "Online Documentation")
 
         Split a tensor into a list of tensors, along the specified
@@ -4655,32 +3555,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Split", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Split", schema)
+        op = Op(self, "Split", schema)
         return op(*self._prepare_inputs(schema, input, split), axis=axis)
 
-    def Sqrt(
-        self, X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    def Sqrt(self, X: T) -> T:
         r"""[🌐 Sqrt(13)](https://onnx.ai/onnx/operators/onnx__Sqrt.html#sqrt-13 "Online Documentation")
 
 
@@ -4694,31 +3574,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Sqrt", 13, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(self, "Sqrt", schema)
+        op = Op(self, "Sqrt", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def Squeeze(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axes: Optional[INT64] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -4735,7 +3595,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Squeeze(self, data: T, axes: Optional[INT64] = None) -> T:
         r"""[🌐 Squeeze(13)](https://onnx.ai/onnx/operators/onnx__Squeeze.html#squeeze-13 "Online Documentation")
 
 
@@ -4754,34 +3616,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Squeeze", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Squeeze", schema)
+        op = Op(self, "Squeeze", schema)
         return op(*self._prepare_inputs(schema, data, axes))
 
-    def Sub(
-        self,
-        A: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        B: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def Sub(self, A: T, B: T) -> T:
         r"""[🌐 Sub(13)](https://onnx.ai/onnx/operators/onnx__Sub.html#sub-13 "Online Documentation")
 
 
@@ -4797,14 +3637,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Sub", 13, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "Sub", schema)
+        op = Op(self, "Sub", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def Sum(
-        self, *data_0: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    def Sum(self, *data_0: T) -> T:
         r"""[🌐 Sum(13)](https://onnx.ai/onnx/operators/onnx__Sum.html#sum-13 "Online Documentation")
 
 
@@ -4818,12 +3656,12 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Sum", 13, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(self, "Sum", schema)
+        op = Op(self, "Sum", schema)
         return op(*self._prepare_inputs(schema, *data_0))
 
-    def Tanh(
-        self, input: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    def Tanh(self, input: T) -> T:
         r"""[🌐 Tanh(13)](https://onnx.ai/onnx/operators/onnx__Tanh.html#tanh-13 "Online Documentation")
 
 
@@ -4835,31 +3673,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Tanh", 13, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(self, "Tanh", schema)
+        op = Op(self, "Tanh", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def Tile(
-        self,
-        input: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        repeats: INT64,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -4876,7 +3694,11 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    T1 = TypeVar("T1", bound=INT64)
+
+    def Tile(self, input: T, repeats: T1) -> T:
         r"""[🌐 Tile(13)](https://onnx.ai/onnx/operators/onnx__Tile.html#tile-13 "Online Documentation")
 
         Constructs a tensor by tiling a given tensor.
@@ -4893,51 +3715,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Tile", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Tile", schema)
+        op = Op(self, "Tile", schema)
         return op(*self._prepare_inputs(schema, input, repeats))
 
-    def Transpose(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        perm: Optional[Sequence[int]] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -4954,7 +3736,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Transpose(self, data: T, perm: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Transpose(13)](https://onnx.ai/onnx/operators/onnx__Transpose.html#transpose-13 "Online Documentation")
 
 
@@ -4971,51 +3755,11 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Transpose", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Transpose", schema)
+        op = Op(self, "Transpose", schema)
         return op(*self._prepare_inputs(schema, data), perm=perm)
 
-    def Unsqueeze(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axes: INT64,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -5032,7 +3776,9 @@ class Opset13(Opset12):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Unsqueeze(self, data: T, axes: INT64) -> T:
         r"""[🌐 Unsqueeze(13)](https://onnx.ai/onnx/operators/onnx__Unsqueeze.html#unsqueeze-13 "Online Documentation")
 
 
@@ -5057,25 +3803,5 @@ class Opset13(Opset12):
         """
 
         schema = get_schema("Unsqueeze", 13, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Unsqueeze", schema)
+        op = Op(self, "Unsqueeze", schema)
         return op(*self._prepare_inputs(schema, data, axes))

--- a/onnxscript/onnx_opset/_impl/opset14.py
+++ b/onnxscript/onnx_opset/_impl/opset14.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Tuple, TypeVar
 
 from onnx.defs import get_schema
 
@@ -43,37 +43,8 @@ class Opset14(Opset13):
     def __init__(self):
         super().__init__()
 
-    def Add(
-        self,
-        A: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        B: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         DOUBLE,
         FLOAT,
@@ -86,7 +57,9 @@ class Opset14(Opset13):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Add(self, A: T, B: T) -> T:
         r"""[🌐 Add(14)](https://onnx.ai/onnx/operators/onnx__Add.html#add-14 "Online Documentation")
 
 
@@ -104,40 +77,24 @@ class Opset14(Opset13):
         """
 
         schema = get_schema("Add", 14, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Add", schema)
+        op = Op(self, "Add", schema)
         return op(*self._prepare_inputs(schema, A, B))
+
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    U = TypeVar("U", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
 
     def BatchNormalization(
         self,
-        X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        scale: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        B: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        input_mean: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        input_var: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
+        X: T,
+        scale: T,
+        B: T,
+        input_mean: U,
+        input_var: U,
         epsilon: float = 9.999999747378752e-06,
         momentum: float = 0.8999999761581421,
         training_mode: int = 0,
-    ) -> Tuple[
-        Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-    ]:
+    ) -> Tuple[T, U, U]:
         r"""[🌐 BatchNormalization(14)](https://onnx.ai/onnx/operators/onnx__BatchNormalization.html#batchnormalization-14 "Online Documentation")
 
 
@@ -214,14 +171,7 @@ class Opset14(Opset13):
         """
 
         schema = get_schema("BatchNormalization", 14, "")
-        op: Callable[
-            ...,
-            Tuple[
-                Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-                Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-                Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-            ],
-        ] = Op(self, "BatchNormalization", schema)
+        op = Op(self, "BatchNormalization", schema)
         return op(
             *self._prepare_inputs(schema, X, scale, B, input_mean, input_var),
             epsilon=epsilon,
@@ -229,13 +179,11 @@ class Opset14(Opset13):
             training_mode=training_mode,
         )
 
-    def CumSum(
-        self,
-        x: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axis: Union[INT32, INT64],
-        exclusive: int = 0,
-        reverse: int = 0,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    T2 = TypeVar("T2", INT32, INT64)
+
+    def CumSum(self, x: T, axis: T2, exclusive: int = 0, reverse: int = 0) -> T:
         r"""[🌐 CumSum(14)](https://onnx.ai/onnx/operators/onnx__CumSum.html#cumsum-14 "Online Documentation")
 
 
@@ -277,42 +225,11 @@ class Opset14(Opset13):
         """
 
         schema = get_schema("CumSum", 14, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "CumSum", schema)
+        op = Op(self, "CumSum", schema)
         return op(*self._prepare_inputs(schema, x, axis), exclusive=exclusive, reverse=reverse)
 
-    def Div(
-        self,
-        A: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        B: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         DOUBLE,
         FLOAT,
@@ -325,7 +242,9 @@ class Opset14(Opset13):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Div(self, A: T, B: T) -> T:
         r"""[🌐 Div(14)](https://onnx.ai/onnx/operators/onnx__Div.html#div-14 "Online Documentation")
 
 
@@ -343,33 +262,21 @@ class Opset14(Opset13):
         """
 
         schema = get_schema("Div", 14, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Div", schema)
+        op = Op(self, "Div", schema)
         return op(*self._prepare_inputs(schema, A, B))
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    T1 = TypeVar("T1", bound=INT32)
 
     def GRU(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        W: Union[DOUBLE, FLOAT, FLOAT16],
-        R: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        sequence_lens: Optional[INT32] = None,
-        initial_h: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
+        X: T,
+        W: T,
+        R: T,
+        B: Optional[T] = None,
+        sequence_lens: Optional[T1] = None,
+        initial_h: Optional[T] = None,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Optional[Sequence[str]] = None,
@@ -378,7 +285,7 @@ class Opset14(Opset13):
         hidden_size: Optional[int] = None,
         layout: int = 0,
         linear_before_reset: int = 0,
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]:
+    ) -> Tuple[T, T]:
         r"""[🌐 GRU(14)](https://onnx.ai/onnx/operators/onnx__GRU.html#gru-14 "Online Documentation")
 
 
@@ -497,9 +404,7 @@ class Opset14(Opset13):
         """
 
         schema = get_schema("GRU", 14, "")
-        op: Callable[
-            ..., Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]
-        ] = Op(self, "GRU", schema)
+        op = Op(self, "GRU", schema)
         return op(
             *self._prepare_inputs(schema, X, W, R, B, sequence_lens, initial_h),
             activation_alpha=activation_alpha,
@@ -512,7 +417,9 @@ class Opset14(Opset13):
             linear_before_reset=linear_before_reset,
         )
 
-    def HardSwish(self, X: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def HardSwish(self, X: T) -> T:
         r"""[🌐 HardSwish(14)](https://onnx.ai/onnx/operators/onnx__HardSwish.html#hardswish-14 "Online Documentation")
 
 
@@ -526,45 +433,11 @@ class Opset14(Opset13):
         """
 
         schema = get_schema("HardSwish", 14, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "HardSwish", schema)
+        op = Op(self, "HardSwish", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def Identity(
-        self,
-        input: Union[
-            Sequence[BOOL],
-            Sequence[COMPLEX128],
-            Sequence[COMPLEX64],
-            Sequence[DOUBLE],
-            Sequence[FLOAT],
-            Sequence[FLOAT16],
-            Sequence[INT16],
-            Sequence[INT32],
-            Sequence[INT64],
-            Sequence[INT8],
-            Sequence[STRING],
-            Sequence[UINT16],
-            Sequence[UINT32],
-            Sequence[UINT64],
-            Sequence[UINT8],
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    V = TypeVar(
+        "V",
         Sequence[BOOL],
         Sequence[COMPLEX128],
         Sequence[COMPLEX64],
@@ -596,7 +469,9 @@ class Opset14(Opset13):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Identity(self, input: V) -> V:
         r"""[🌐 Identity(14)](https://onnx.ai/onnx/operators/onnx__Identity.html#identity-14 "Online Documentation")
 
         Identity operator
@@ -606,54 +481,23 @@ class Opset14(Opset13):
         """
 
         schema = get_schema("Identity", 14, "")
-        op: Callable[
-            ...,
-            Union[
-                Sequence[BOOL],
-                Sequence[COMPLEX128],
-                Sequence[COMPLEX64],
-                Sequence[DOUBLE],
-                Sequence[FLOAT],
-                Sequence[FLOAT16],
-                Sequence[INT16],
-                Sequence[INT32],
-                Sequence[INT64],
-                Sequence[INT8],
-                Sequence[STRING],
-                Sequence[UINT16],
-                Sequence[UINT32],
-                Sequence[UINT64],
-                Sequence[UINT8],
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Identity", schema)
+        op = Op(self, "Identity", schema)
         return op(*self._prepare_inputs(schema, input))
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    T1 = TypeVar("T1", bound=INT32)
 
     def LSTM(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        W: Union[DOUBLE, FLOAT, FLOAT16],
-        R: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        sequence_lens: Optional[INT32] = None,
-        initial_h: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        initial_c: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        P: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
+        X: T,
+        W: T,
+        R: T,
+        B: Optional[T] = None,
+        sequence_lens: Optional[T1] = None,
+        initial_h: Optional[T] = None,
+        initial_c: Optional[T] = None,
+        P: Optional[T] = None,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Optional[Sequence[str]] = None,
@@ -662,11 +506,7 @@ class Opset14(Opset13):
         hidden_size: Optional[int] = None,
         input_forget: int = 0,
         layout: int = 0,
-    ) -> Tuple[
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-    ]:
+    ) -> Tuple[T, T, T]:
         r"""[🌐 LSTM(14)](https://onnx.ai/onnx/operators/onnx__LSTM.html#lstm-14 "Online Documentation")
 
 
@@ -797,14 +637,7 @@ class Opset14(Opset13):
         """
 
         schema = get_schema("LSTM", 14, "")
-        op: Callable[
-            ...,
-            Tuple[
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-            ],
-        ] = Op(self, "LSTM", schema)
+        op = Op(self, "LSTM", schema)
         return op(
             *self._prepare_inputs(schema, X, W, R, B, sequence_lens, initial_h, initial_c, P),
             activation_alpha=activation_alpha,
@@ -817,37 +650,8 @@ class Opset14(Opset13):
             layout=layout,
         )
 
-    def Mul(
-        self,
-        A: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        B: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         DOUBLE,
         FLOAT,
@@ -860,7 +664,9 @@ class Opset14(Opset13):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Mul(self, A: T, B: T) -> T:
         r"""[🌐 Mul(14)](https://onnx.ai/onnx/operators/onnx__Mul.html#mul-14 "Online Documentation")
 
 
@@ -878,33 +684,21 @@ class Opset14(Opset13):
         """
 
         schema = get_schema("Mul", 14, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Mul", schema)
+        op = Op(self, "Mul", schema)
         return op(*self._prepare_inputs(schema, A, B))
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    T1 = TypeVar("T1", bound=INT32)
 
     def RNN(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        W: Union[DOUBLE, FLOAT, FLOAT16],
-        R: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        sequence_lens: Optional[INT32] = None,
-        initial_h: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
+        X: T,
+        W: T,
+        R: T,
+        B: Optional[T] = None,
+        sequence_lens: Optional[T1] = None,
+        initial_h: Optional[T] = None,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Sequence[str] = ("Tanh", "Tanh"),
@@ -912,7 +706,7 @@ class Opset14(Opset13):
         direction: str = "forward",
         hidden_size: Optional[int] = None,
         layout: int = 0,
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]:
+    ) -> Tuple[T, T]:
         r"""[🌐 RNN(14)](https://onnx.ai/onnx/operators/onnx__RNN.html#rnn-14 "Online Documentation")
 
 
@@ -1019,9 +813,7 @@ class Opset14(Opset13):
         """
 
         schema = get_schema("RNN", 14, "")
-        op: Callable[
-            ..., Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]
-        ] = Op(self, "RNN", schema)
+        op = Op(self, "RNN", schema)
         return op(
             *self._prepare_inputs(schema, X, W, R, B, sequence_lens, initial_h),
             activation_alpha=activation_alpha,
@@ -1033,9 +825,9 @@ class Opset14(Opset13):
             layout=layout,
         )
 
-    def Relu(
-        self, X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8]
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8)
+
+    def Relu(self, X: T) -> T:
         r"""[🌐 Relu(14)](https://onnx.ai/onnx/operators/onnx__Relu.html#relu-14 "Online Documentation")
 
 
@@ -1049,34 +841,11 @@ class Opset14(Opset13):
         """
 
         schema = get_schema("Relu", 14, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8]
-        ] = Op(self, "Relu", schema)
+        op = Op(self, "Relu", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def Reshape(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        shape: INT64,
-        allowzero: int = 0,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -1093,7 +862,9 @@ class Opset14(Opset13):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Reshape(self, data: T, shape: INT64, allowzero: int = 0) -> T:
         r"""[🌐 Reshape(14)](https://onnx.ai/onnx/operators/onnx__Reshape.html#reshape-14 "Online Documentation")
 
 
@@ -1125,60 +896,11 @@ class Opset14(Opset13):
         """
 
         schema = get_schema("Reshape", 14, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Reshape", schema)
+        op = Op(self, "Reshape", schema)
         return op(*self._prepare_inputs(schema, data, shape), allowzero=allowzero)
 
-    def Sub(
-        self,
-        A: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        B: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         DOUBLE,
         FLOAT,
@@ -1191,7 +913,9 @@ class Opset14(Opset13):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Sub(self, A: T, B: T) -> T:
         r"""[🌐 Sub(14)](https://onnx.ai/onnx/operators/onnx__Sub.html#sub-14 "Online Documentation")
 
 
@@ -1209,48 +933,11 @@ class Opset14(Opset13):
         """
 
         schema = get_schema("Sub", 14, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Sub", schema)
+        op = Op(self, "Sub", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def Trilu(
-        self,
-        input: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        k: Optional[INT64] = None,
-        upper: int = 1,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -1267,7 +954,9 @@ class Opset14(Opset13):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Trilu(self, input: T, k: Optional[INT64] = None, upper: int = 1) -> T:
         r"""[🌐 Trilu(14)](https://onnx.ai/onnx/operators/onnx__Trilu.html#trilu-14 "Online Documentation")
 
 
@@ -1297,25 +986,5 @@ class Opset14(Opset13):
         """
 
         schema = get_schema("Trilu", 14, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Trilu", schema)
+        op = Op(self, "Trilu", schema)
         return op(*self._prepare_inputs(schema, input, k), upper=upper)

--- a/onnxscript/onnx_opset/_impl/opset15.py
+++ b/onnxscript/onnx_opset/_impl/opset15.py
@@ -10,9 +10,8 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable
 from typing import Optional as _Optional
-from typing import Sequence, Tuple, Union
+from typing import Sequence, Tuple, TypeVar
 
 from onnx import TypeProto
 from onnx.defs import get_schema
@@ -46,21 +45,23 @@ class Opset15(Opset14):
     def __init__(self):
         super().__init__()
 
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    T1 = TypeVar("T1", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    T2 = TypeVar("T2", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
     def BatchNormalization(
         self,
-        X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        scale: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        B: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        input_mean: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        input_var: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
+        X: T,
+        scale: T1,
+        B: T1,
+        input_mean: T2,
+        input_var: T2,
         epsilon: float = 9.999999747378752e-06,
         momentum: float = 0.8999999761581421,
         training_mode: int = 0,
-    ) -> Tuple[
-        Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-    ]:
+    ) -> Tuple[T, T2, T2]:
         r"""[🌐 BatchNormalization(15)](https://onnx.ai/onnx/operators/onnx__BatchNormalization.html#batchnormalization-15 "Online Documentation")
 
 
@@ -139,14 +140,7 @@ class Opset15(Opset14):
         """
 
         schema = get_schema("BatchNormalization", 15, "")
-        op: Callable[
-            ...,
-            Tuple[
-                Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-                Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-                Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-            ],
-        ] = Op(self, "BatchNormalization", schema)
+        op = Op(self, "BatchNormalization", schema)
         return op(
             *self._prepare_inputs(schema, X, scale, B, input_mean, input_var),
             epsilon=epsilon,
@@ -154,12 +148,10 @@ class Opset15(Opset14):
             training_mode=training_mode,
         )
 
-    def Bernoulli(
-        self,
-        input: Union[DOUBLE, FLOAT, FLOAT16],
-        dtype: _Optional[int] = None,
-        seed: _Optional[float] = None,
-    ) -> Union[
+    T1 = TypeVar("T1", DOUBLE, FLOAT, FLOAT16)
+
+    T2 = TypeVar(
+        "T2",
         BFLOAT16,
         BOOL,
         DOUBLE,
@@ -173,7 +165,11 @@ class Opset15(Opset14):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Bernoulli(
+        self, input: T1, dtype: _Optional[int] = None, seed: _Optional[float] = None
+    ) -> T2:
         r"""[🌐 Bernoulli(15)](https://onnx.ai/onnx/operators/onnx__Bernoulli.html#bernoulli-15 "Online Documentation")
 
 
@@ -196,61 +192,11 @@ class Opset15(Opset14):
         """
 
         schema = get_schema("Bernoulli", 15, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Bernoulli", schema)
+        op = Op(self, "Bernoulli", schema)
         return op(*self._prepare_inputs(schema, input), dtype=dtype, seed=seed)
 
-    def CastLike(
-        self,
-        input: Union[
-            BFLOAT16,
-            BOOL,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        target_type: Union[
-            BFLOAT16,
-            BOOL,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    T1 = TypeVar(
+        "T1",
         BFLOAT16,
         BOOL,
         DOUBLE,
@@ -265,7 +211,27 @@ class Opset15(Opset14):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    T2 = TypeVar(
+        "T2",
+        BFLOAT16,
+        BOOL,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    def CastLike(self, input: T1, target_type: T2) -> T2:
         r"""[🌐 CastLike(15)](https://onnx.ai/onnx/operators/onnx__CastLike.html#castlike-15 "Online Documentation")
 
 
@@ -282,182 +248,11 @@ class Opset15(Opset14):
         """
 
         schema = get_schema("CastLike", 15, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "CastLike", schema)
+        op = Op(self, "CastLike", schema)
         return op(*self._prepare_inputs(schema, input, target_type))
 
-    def Optional(
-        self,
-        input: _Optional[
-            Union[
-                Sequence[BOOL],
-                Sequence[COMPLEX128],
-                Sequence[COMPLEX64],
-                Sequence[DOUBLE],
-                Sequence[FLOAT],
-                Sequence[FLOAT16],
-                Sequence[INT16],
-                Sequence[INT32],
-                Sequence[INT64],
-                Sequence[INT8],
-                Sequence[STRING],
-                Sequence[UINT16],
-                Sequence[UINT32],
-                Sequence[UINT64],
-                Sequence[UINT8],
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ]
-        ] = None,
-        type: _Optional[TypeProto] = None,
-    ) -> Union[
-        _Optional[Sequence[BOOL]],
-        _Optional[Sequence[COMPLEX128]],
-        _Optional[Sequence[COMPLEX64]],
-        _Optional[Sequence[DOUBLE]],
-        _Optional[Sequence[FLOAT]],
-        _Optional[Sequence[FLOAT16]],
-        _Optional[Sequence[INT16]],
-        _Optional[Sequence[INT32]],
-        _Optional[Sequence[INT64]],
-        _Optional[Sequence[INT8]],
-        _Optional[Sequence[STRING]],
-        _Optional[Sequence[UINT16]],
-        _Optional[Sequence[UINT32]],
-        _Optional[Sequence[UINT64]],
-        _Optional[Sequence[UINT8]],
-        _Optional[BOOL],
-        _Optional[COMPLEX128],
-        _Optional[COMPLEX64],
-        _Optional[DOUBLE],
-        _Optional[FLOAT],
-        _Optional[FLOAT16],
-        _Optional[INT16],
-        _Optional[INT32],
-        _Optional[INT64],
-        _Optional[INT8],
-        _Optional[STRING],
-        _Optional[UINT16],
-        _Optional[UINT32],
-        _Optional[UINT64],
-        _Optional[UINT8],
-    ]:
-        r"""[🌐 Optional(15)](https://onnx.ai/onnx/operators/onnx__Optional.html#optional-15 "Online Documentation")
-
-
-        Constructs an optional-type value containing either an empty optional of a certain type specified by the attribute,
-        or a non-empty value containing the input element.
-
-
-        Args:
-            input: (optional) The input element.
-
-            type: Type of the element in the optional output
-        """
-
-        schema = get_schema("Optional", 15, "")
-        op: Callable[
-            ...,
-            Union[
-                _Optional[Sequence[BOOL]],
-                _Optional[Sequence[COMPLEX128]],
-                _Optional[Sequence[COMPLEX64]],
-                _Optional[Sequence[DOUBLE]],
-                _Optional[Sequence[FLOAT]],
-                _Optional[Sequence[FLOAT16]],
-                _Optional[Sequence[INT16]],
-                _Optional[Sequence[INT32]],
-                _Optional[Sequence[INT64]],
-                _Optional[Sequence[INT8]],
-                _Optional[Sequence[STRING]],
-                _Optional[Sequence[UINT16]],
-                _Optional[Sequence[UINT32]],
-                _Optional[Sequence[UINT64]],
-                _Optional[Sequence[UINT8]],
-                _Optional[BOOL],
-                _Optional[COMPLEX128],
-                _Optional[COMPLEX64],
-                _Optional[DOUBLE],
-                _Optional[FLOAT],
-                _Optional[FLOAT16],
-                _Optional[INT16],
-                _Optional[INT32],
-                _Optional[INT64],
-                _Optional[INT8],
-                _Optional[STRING],
-                _Optional[UINT16],
-                _Optional[UINT32],
-                _Optional[UINT64],
-                _Optional[UINT8],
-            ],
-        ] = Op(self, "Optional", schema)
-        return op(*self._prepare_inputs(schema, input), type=type)
-
-    def OptionalGetElement(
-        self,
-        input: Union[
-            _Optional[Sequence[BOOL]],
-            _Optional[Sequence[COMPLEX128]],
-            _Optional[Sequence[COMPLEX64]],
-            _Optional[Sequence[DOUBLE]],
-            _Optional[Sequence[FLOAT]],
-            _Optional[Sequence[FLOAT16]],
-            _Optional[Sequence[INT16]],
-            _Optional[Sequence[INT32]],
-            _Optional[Sequence[INT64]],
-            _Optional[Sequence[INT8]],
-            _Optional[Sequence[STRING]],
-            _Optional[Sequence[UINT16]],
-            _Optional[Sequence[UINT32]],
-            _Optional[Sequence[UINT64]],
-            _Optional[Sequence[UINT8]],
-            _Optional[BOOL],
-            _Optional[COMPLEX128],
-            _Optional[COMPLEX64],
-            _Optional[DOUBLE],
-            _Optional[FLOAT],
-            _Optional[FLOAT16],
-            _Optional[INT16],
-            _Optional[INT32],
-            _Optional[INT64],
-            _Optional[INT8],
-            _Optional[STRING],
-            _Optional[UINT16],
-            _Optional[UINT32],
-            _Optional[UINT64],
-            _Optional[UINT8],
-        ],
-    ) -> Union[
+    V = TypeVar(
+        "V",
         Sequence[BOOL],
         Sequence[COMPLEX128],
         Sequence[COMPLEX64],
@@ -488,7 +283,129 @@ class Opset15(Opset14):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    O = TypeVar(
+        "O",
+        _Optional[Sequence[BOOL]],
+        _Optional[Sequence[COMPLEX128]],
+        _Optional[Sequence[COMPLEX64]],
+        _Optional[Sequence[DOUBLE]],
+        _Optional[Sequence[FLOAT]],
+        _Optional[Sequence[FLOAT16]],
+        _Optional[Sequence[INT16]],
+        _Optional[Sequence[INT32]],
+        _Optional[Sequence[INT64]],
+        _Optional[Sequence[INT8]],
+        _Optional[Sequence[STRING]],
+        _Optional[Sequence[UINT16]],
+        _Optional[Sequence[UINT32]],
+        _Optional[Sequence[UINT64]],
+        _Optional[Sequence[UINT8]],
+        _Optional[BOOL],
+        _Optional[COMPLEX128],
+        _Optional[COMPLEX64],
+        _Optional[DOUBLE],
+        _Optional[FLOAT],
+        _Optional[FLOAT16],
+        _Optional[INT16],
+        _Optional[INT32],
+        _Optional[INT64],
+        _Optional[INT8],
+        _Optional[STRING],
+        _Optional[UINT16],
+        _Optional[UINT32],
+        _Optional[UINT64],
+        _Optional[UINT8],
+    )
+
+    def Optional(self, input: _Optional[V] = None, type: _Optional[TypeProto] = None) -> O:
+        r"""[🌐 Optional(15)](https://onnx.ai/onnx/operators/onnx__Optional.html#optional-15 "Online Documentation")
+
+
+        Constructs an optional-type value containing either an empty optional of a certain type specified by the attribute,
+        or a non-empty value containing the input element.
+
+
+        Args:
+            input: (optional) The input element.
+
+            type: Type of the element in the optional output
+        """
+
+        schema = get_schema("Optional", 15, "")
+        op = Op(self, "Optional", schema)
+        return op(*self._prepare_inputs(schema, input), type=type)
+
+    O = TypeVar(
+        "O",
+        _Optional[Sequence[BOOL]],
+        _Optional[Sequence[COMPLEX128]],
+        _Optional[Sequence[COMPLEX64]],
+        _Optional[Sequence[DOUBLE]],
+        _Optional[Sequence[FLOAT]],
+        _Optional[Sequence[FLOAT16]],
+        _Optional[Sequence[INT16]],
+        _Optional[Sequence[INT32]],
+        _Optional[Sequence[INT64]],
+        _Optional[Sequence[INT8]],
+        _Optional[Sequence[STRING]],
+        _Optional[Sequence[UINT16]],
+        _Optional[Sequence[UINT32]],
+        _Optional[Sequence[UINT64]],
+        _Optional[Sequence[UINT8]],
+        _Optional[BOOL],
+        _Optional[COMPLEX128],
+        _Optional[COMPLEX64],
+        _Optional[DOUBLE],
+        _Optional[FLOAT],
+        _Optional[FLOAT16],
+        _Optional[INT16],
+        _Optional[INT32],
+        _Optional[INT64],
+        _Optional[INT8],
+        _Optional[STRING],
+        _Optional[UINT16],
+        _Optional[UINT32],
+        _Optional[UINT64],
+        _Optional[UINT8],
+    )
+
+    V = TypeVar(
+        "V",
+        Sequence[BOOL],
+        Sequence[COMPLEX128],
+        Sequence[COMPLEX64],
+        Sequence[DOUBLE],
+        Sequence[FLOAT],
+        Sequence[FLOAT16],
+        Sequence[INT16],
+        Sequence[INT32],
+        Sequence[INT64],
+        Sequence[INT8],
+        Sequence[STRING],
+        Sequence[UINT16],
+        Sequence[UINT32],
+        Sequence[UINT64],
+        Sequence[UINT8],
+        BOOL,
+        COMPLEX128,
+        COMPLEX64,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    def OptionalGetElement(self, input: O) -> V:
         r"""[🌐 OptionalGetElement(15)](https://onnx.ai/onnx/operators/onnx__OptionalGetElement.html#optionalgetelement-15 "Online Documentation")
 
 
@@ -501,78 +418,46 @@ class Opset15(Opset14):
         """
 
         schema = get_schema("OptionalGetElement", 15, "")
-        op: Callable[
-            ...,
-            Union[
-                Sequence[BOOL],
-                Sequence[COMPLEX128],
-                Sequence[COMPLEX64],
-                Sequence[DOUBLE],
-                Sequence[FLOAT],
-                Sequence[FLOAT16],
-                Sequence[INT16],
-                Sequence[INT32],
-                Sequence[INT64],
-                Sequence[INT8],
-                Sequence[STRING],
-                Sequence[UINT16],
-                Sequence[UINT32],
-                Sequence[UINT64],
-                Sequence[UINT8],
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "OptionalGetElement", schema)
+        op = Op(self, "OptionalGetElement", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def OptionalHasElement(
-        self,
-        input: Union[
-            _Optional[Sequence[BOOL]],
-            _Optional[Sequence[COMPLEX128]],
-            _Optional[Sequence[COMPLEX64]],
-            _Optional[Sequence[DOUBLE]],
-            _Optional[Sequence[FLOAT]],
-            _Optional[Sequence[FLOAT16]],
-            _Optional[Sequence[INT16]],
-            _Optional[Sequence[INT32]],
-            _Optional[Sequence[INT64]],
-            _Optional[Sequence[INT8]],
-            _Optional[Sequence[STRING]],
-            _Optional[Sequence[UINT16]],
-            _Optional[Sequence[UINT32]],
-            _Optional[Sequence[UINT64]],
-            _Optional[Sequence[UINT8]],
-            _Optional[BOOL],
-            _Optional[COMPLEX128],
-            _Optional[COMPLEX64],
-            _Optional[DOUBLE],
-            _Optional[FLOAT],
-            _Optional[FLOAT16],
-            _Optional[INT16],
-            _Optional[INT32],
-            _Optional[INT64],
-            _Optional[INT8],
-            _Optional[STRING],
-            _Optional[UINT16],
-            _Optional[UINT32],
-            _Optional[UINT64],
-            _Optional[UINT8],
-        ],
-    ) -> BOOL:
+    O = TypeVar(
+        "O",
+        _Optional[Sequence[BOOL]],
+        _Optional[Sequence[COMPLEX128]],
+        _Optional[Sequence[COMPLEX64]],
+        _Optional[Sequence[DOUBLE]],
+        _Optional[Sequence[FLOAT]],
+        _Optional[Sequence[FLOAT16]],
+        _Optional[Sequence[INT16]],
+        _Optional[Sequence[INT32]],
+        _Optional[Sequence[INT64]],
+        _Optional[Sequence[INT8]],
+        _Optional[Sequence[STRING]],
+        _Optional[Sequence[UINT16]],
+        _Optional[Sequence[UINT32]],
+        _Optional[Sequence[UINT64]],
+        _Optional[Sequence[UINT8]],
+        _Optional[BOOL],
+        _Optional[COMPLEX128],
+        _Optional[COMPLEX64],
+        _Optional[DOUBLE],
+        _Optional[FLOAT],
+        _Optional[FLOAT16],
+        _Optional[INT16],
+        _Optional[INT32],
+        _Optional[INT64],
+        _Optional[INT8],
+        _Optional[STRING],
+        _Optional[UINT16],
+        _Optional[UINT32],
+        _Optional[UINT64],
+        _Optional[UINT8],
+    )
+
+    B = TypeVar("B", bound=BOOL)
+
+    def OptionalHasElement(self, input: O) -> B:
         r"""[🌐 OptionalHasElement(15)](https://onnx.ai/onnx/operators/onnx__OptionalHasElement.html#optionalhaselement-15 "Online Documentation")
 
 
@@ -584,27 +469,28 @@ class Opset15(Opset14):
         """
 
         schema = get_schema("OptionalHasElement", 15, "")
-        op: Callable[..., BOOL] = Op(self, "OptionalHasElement", schema)
+        op = Op(self, "OptionalHasElement", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def Pow(
-        self,
-        X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64],
-        Y: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64)
+
+    T1 = TypeVar(
+        "T1",
+        BFLOAT16,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    def Pow(self, X: T, Y: T1) -> T:
         r"""[🌐 Pow(15)](https://onnx.ai/onnx/operators/onnx__Pow.html#pow-15 "Online Documentation")
 
 
@@ -620,34 +506,32 @@ class Opset15(Opset14):
         """
 
         schema = get_schema("Pow", 15, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64]] = Op(
-            self, "Pow", schema
-        )
+        op = Op(self, "Pow", schema)
         return op(*self._prepare_inputs(schema, X, Y))
 
-    def Shape(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        end: _Optional[int] = None,
-        start: int = 0,
-    ) -> INT64:
+    T = TypeVar(
+        "T",
+        BFLOAT16,
+        BOOL,
+        COMPLEX128,
+        COMPLEX64,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    T1 = TypeVar("T1", bound=INT64)
+
+    def Shape(self, data: T, end: _Optional[int] = None, start: int = 0) -> T1:
         r"""[🌐 Shape(15)](https://onnx.ai/onnx/operators/onnx__Shape.html#shape-15 "Online Documentation")
 
 
@@ -711,5 +595,5 @@ class Opset15(Opset14):
         """
 
         schema = get_schema("Shape", 15, "")
-        op: Callable[..., INT64] = Op(self, "Shape", schema)
+        op = Op(self, "Shape", schema)
         return op(*self._prepare_inputs(schema, data), end=end, start=start)

--- a/onnxscript/onnx_opset/_impl/opset16.py
+++ b/onnxscript/onnx_opset/_impl/opset16.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Sequence, Union
+from typing import Optional, Sequence, TypeVar
 
 from onnx import GraphProto
 from onnx.defs import get_schema
@@ -44,37 +44,25 @@ class Opset16(Opset15):
     def __init__(self):
         super().__init__()
 
-    def GreaterOrEqual(
-        self,
-        A: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        B: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> BOOL:
+    T = TypeVar(
+        "T",
+        BFLOAT16,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def GreaterOrEqual(self, A: T, B: T) -> T1:
         r"""[🌐 GreaterOrEqual(16)](https://onnx.ai/onnx/operators/onnx__GreaterOrEqual.html#greaterorequal-16 "Online Documentation")
 
 
@@ -91,33 +79,11 @@ class Opset16(Opset15):
         """
 
         schema = get_schema("GreaterOrEqual", 16, "")
-        op: Callable[..., BOOL] = Op(self, "GreaterOrEqual", schema)
+        op = Op(self, "GreaterOrEqual", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def GridSample(
-        self,
-        X: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        grid: Union[DOUBLE, FLOAT, FLOAT16],
-        align_corners: int = 0,
-        mode: str = "bilinear",
-        padding_mode: str = "zeros",
-    ) -> Union[
+    T1 = TypeVar(
+        "T1",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -133,7 +99,18 @@ class Opset16(Opset15):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    T2 = TypeVar("T2", DOUBLE, FLOAT, FLOAT16)
+
+    def GridSample(
+        self,
+        X: T1,
+        grid: T2,
+        align_corners: int = 0,
+        mode: str = "bilinear",
+        padding_mode: str = "zeros",
+    ) -> T1:
         r"""[🌐 GridSample(16)](https://onnx.ai/onnx/operators/onnx__GridSample.html#gridsample-16 "Online Documentation")
 
 
@@ -185,26 +162,7 @@ class Opset16(Opset15):
         """
 
         schema = get_schema("GridSample", 16, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "GridSample", schema)
+        op = Op(self, "GridSample", schema)
         return op(
             *self._prepare_inputs(schema, X, grid),
             align_corners=align_corners,
@@ -212,72 +170,8 @@ class Opset16(Opset15):
             padding_mode=padding_mode,
         )
 
-    def Identity(
-        self,
-        input: Union[
-            Optional[Sequence[BOOL]],
-            Optional[Sequence[COMPLEX128]],
-            Optional[Sequence[COMPLEX64]],
-            Optional[Sequence[DOUBLE]],
-            Optional[Sequence[FLOAT]],
-            Optional[Sequence[FLOAT16]],
-            Optional[Sequence[INT16]],
-            Optional[Sequence[INT32]],
-            Optional[Sequence[INT64]],
-            Optional[Sequence[INT8]],
-            Optional[Sequence[STRING]],
-            Optional[Sequence[UINT16]],
-            Optional[Sequence[UINT32]],
-            Optional[Sequence[UINT64]],
-            Optional[Sequence[UINT8]],
-            Optional[BOOL],
-            Optional[COMPLEX128],
-            Optional[COMPLEX64],
-            Optional[DOUBLE],
-            Optional[FLOAT],
-            Optional[FLOAT16],
-            Optional[INT16],
-            Optional[INT32],
-            Optional[INT64],
-            Optional[INT8],
-            Optional[STRING],
-            Optional[UINT16],
-            Optional[UINT32],
-            Optional[UINT64],
-            Optional[UINT8],
-            Sequence[BOOL],
-            Sequence[COMPLEX128],
-            Sequence[COMPLEX64],
-            Sequence[DOUBLE],
-            Sequence[FLOAT],
-            Sequence[FLOAT16],
-            Sequence[INT16],
-            Sequence[INT32],
-            Sequence[INT64],
-            Sequence[INT8],
-            Sequence[STRING],
-            Sequence[UINT16],
-            Sequence[UINT32],
-            Sequence[UINT64],
-            Sequence[UINT8],
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    V = TypeVar(
+        "V",
         Optional[Sequence[BOOL]],
         Optional[Sequence[COMPLEX128]],
         Optional[Sequence[COMPLEX64]],
@@ -339,7 +233,9 @@ class Opset16(Opset15):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Identity(self, input: V) -> V:
         r"""[🌐 Identity(16)](https://onnx.ai/onnx/operators/onnx__Identity.html#identity-16 "Online Documentation")
 
         Identity operator
@@ -349,80 +245,13 @@ class Opset16(Opset15):
         """
 
         schema = get_schema("Identity", 16, "")
-        op: Callable[
-            ...,
-            Union[
-                Optional[Sequence[BOOL]],
-                Optional[Sequence[COMPLEX128]],
-                Optional[Sequence[COMPLEX64]],
-                Optional[Sequence[DOUBLE]],
-                Optional[Sequence[FLOAT]],
-                Optional[Sequence[FLOAT16]],
-                Optional[Sequence[INT16]],
-                Optional[Sequence[INT32]],
-                Optional[Sequence[INT64]],
-                Optional[Sequence[INT8]],
-                Optional[Sequence[STRING]],
-                Optional[Sequence[UINT16]],
-                Optional[Sequence[UINT32]],
-                Optional[Sequence[UINT64]],
-                Optional[Sequence[UINT8]],
-                Optional[BOOL],
-                Optional[COMPLEX128],
-                Optional[COMPLEX64],
-                Optional[DOUBLE],
-                Optional[FLOAT],
-                Optional[FLOAT16],
-                Optional[INT16],
-                Optional[INT32],
-                Optional[INT64],
-                Optional[INT8],
-                Optional[STRING],
-                Optional[UINT16],
-                Optional[UINT32],
-                Optional[UINT64],
-                Optional[UINT8],
-                Sequence[BOOL],
-                Sequence[COMPLEX128],
-                Sequence[COMPLEX64],
-                Sequence[DOUBLE],
-                Sequence[FLOAT],
-                Sequence[FLOAT16],
-                Sequence[INT16],
-                Sequence[INT32],
-                Sequence[INT64],
-                Sequence[INT8],
-                Sequence[STRING],
-                Sequence[UINT16],
-                Sequence[UINT32],
-                Sequence[UINT64],
-                Sequence[UINT8],
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Identity", schema)
+        op = Op(self, "Identity", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def If(
-        self,
-        cond: BOOL,
-        else_branch: Optional[GraphProto] = None,
-        then_branch: Optional[GraphProto] = None,
-    ) -> Union[
+    B = TypeVar("B", bound=BOOL)
+
+    V = TypeVar(
+        "V",
         Optional[Sequence[BFLOAT16]],
         Optional[Sequence[BOOL]],
         Optional[Sequence[COMPLEX128]],
@@ -487,7 +316,14 @@ class Opset16(Opset15):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def If(
+        self,
+        cond: B,
+        else_branch: Optional[GraphProto] = None,
+        then_branch: Optional[GraphProto] = None,
+    ) -> V:
         r"""[🌐 If(16)](https://onnx.ai/onnx/operators/onnx__If.html#if-16 "Online Documentation")
 
         If conditional
@@ -505,84 +341,16 @@ class Opset16(Opset15):
         """
 
         schema = get_schema("If", 16, "")
-        op: Callable[
-            ...,
-            Union[
-                Optional[Sequence[BFLOAT16]],
-                Optional[Sequence[BOOL]],
-                Optional[Sequence[COMPLEX128]],
-                Optional[Sequence[COMPLEX64]],
-                Optional[Sequence[DOUBLE]],
-                Optional[Sequence[FLOAT]],
-                Optional[Sequence[FLOAT16]],
-                Optional[Sequence[INT16]],
-                Optional[Sequence[INT32]],
-                Optional[Sequence[INT64]],
-                Optional[Sequence[INT8]],
-                Optional[Sequence[STRING]],
-                Optional[Sequence[UINT16]],
-                Optional[Sequence[UINT32]],
-                Optional[Sequence[UINT64]],
-                Optional[Sequence[UINT8]],
-                Optional[BFLOAT16],
-                Optional[BOOL],
-                Optional[COMPLEX128],
-                Optional[COMPLEX64],
-                Optional[DOUBLE],
-                Optional[FLOAT],
-                Optional[FLOAT16],
-                Optional[INT16],
-                Optional[INT32],
-                Optional[INT64],
-                Optional[INT8],
-                Optional[STRING],
-                Optional[UINT16],
-                Optional[UINT32],
-                Optional[UINT64],
-                Optional[UINT8],
-                Sequence[BFLOAT16],
-                Sequence[BOOL],
-                Sequence[COMPLEX128],
-                Sequence[COMPLEX64],
-                Sequence[DOUBLE],
-                Sequence[FLOAT],
-                Sequence[FLOAT16],
-                Sequence[INT16],
-                Sequence[INT32],
-                Sequence[INT64],
-                Sequence[INT8],
-                Sequence[STRING],
-                Sequence[UINT16],
-                Sequence[UINT32],
-                Sequence[UINT64],
-                Sequence[UINT8],
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "If", schema)
+        op = Op(self, "If", schema)
         return op(
             *self._prepare_inputs(schema, cond),
             else_branch=else_branch,
             then_branch=then_branch,
         )
 
-    def LeakyRelu(
-        self, X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16], alpha: float = 0.009999999776482582
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    def LeakyRelu(self, X: T, alpha: float = 0.009999999776482582) -> T:
         r"""[🌐 LeakyRelu(16)](https://onnx.ai/onnx/operators/onnx__LeakyRelu.html#leakyrelu-16 "Online Documentation")
 
 
@@ -598,42 +366,28 @@ class Opset16(Opset15):
         """
 
         schema = get_schema("LeakyRelu", 16, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(
-            self, "LeakyRelu", schema
-        )
+        op = Op(self, "LeakyRelu", schema)
         return op(*self._prepare_inputs(schema, X), alpha=alpha)
 
-    def LessOrEqual(
-        self,
-        A: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        B: Union[
-            BFLOAT16,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> BOOL:
+    T = TypeVar(
+        "T",
+        BFLOAT16,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def LessOrEqual(self, A: T, B: T) -> T1:
         r"""[🌐 LessOrEqual(16)](https://onnx.ai/onnx/operators/onnx__LessOrEqual.html#lessorequal-16 "Online Documentation")
 
 
@@ -650,81 +404,15 @@ class Opset16(Opset15):
         """
 
         schema = get_schema("LessOrEqual", 16, "")
-        op: Callable[..., BOOL] = Op(self, "LessOrEqual", schema)
+        op = Op(self, "LessOrEqual", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def Loop(
-        self,
-        M: Optional[INT64],
-        cond: Optional[BOOL],
-        *v_initial: Union[
-            Optional[Sequence[BFLOAT16]],
-            Optional[Sequence[BOOL]],
-            Optional[Sequence[COMPLEX128]],
-            Optional[Sequence[COMPLEX64]],
-            Optional[Sequence[DOUBLE]],
-            Optional[Sequence[FLOAT]],
-            Optional[Sequence[FLOAT16]],
-            Optional[Sequence[INT16]],
-            Optional[Sequence[INT32]],
-            Optional[Sequence[INT64]],
-            Optional[Sequence[INT8]],
-            Optional[Sequence[STRING]],
-            Optional[Sequence[UINT16]],
-            Optional[Sequence[UINT32]],
-            Optional[Sequence[UINT64]],
-            Optional[Sequence[UINT8]],
-            Optional[BFLOAT16],
-            Optional[BOOL],
-            Optional[COMPLEX128],
-            Optional[COMPLEX64],
-            Optional[DOUBLE],
-            Optional[FLOAT],
-            Optional[FLOAT16],
-            Optional[INT16],
-            Optional[INT32],
-            Optional[INT64],
-            Optional[INT8],
-            Optional[STRING],
-            Optional[UINT16],
-            Optional[UINT32],
-            Optional[UINT64],
-            Optional[UINT8],
-            Sequence[BFLOAT16],
-            Sequence[BOOL],
-            Sequence[COMPLEX128],
-            Sequence[COMPLEX64],
-            Sequence[DOUBLE],
-            Sequence[FLOAT],
-            Sequence[FLOAT16],
-            Sequence[INT16],
-            Sequence[INT32],
-            Sequence[INT64],
-            Sequence[INT8],
-            Sequence[STRING],
-            Sequence[UINT16],
-            Sequence[UINT32],
-            Sequence[UINT64],
-            Sequence[UINT8],
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        body: Optional[GraphProto] = None,
-    ) -> Union[
+    I = TypeVar("I", bound=INT64)
+
+    B = TypeVar("B", bound=BOOL)
+
+    V = TypeVar(
+        "V",
         Optional[Sequence[BFLOAT16]],
         Optional[Sequence[BOOL]],
         Optional[Sequence[COMPLEX128]],
@@ -789,7 +477,15 @@ class Opset16(Opset15):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Loop(
+        self,
+        M: Optional[I],
+        cond: Optional[B],
+        *v_initial: V,
+        body: Optional[GraphProto] = None,
+    ) -> V:
         r"""[🌐 Loop(16)](https://onnx.ai/onnx/operators/onnx__Loop.html#loop-16 "Online Documentation")
 
 
@@ -950,82 +646,12 @@ class Opset16(Opset15):
         """
 
         schema = get_schema("Loop", 16, "")
-        op: Callable[
-            ...,
-            Union[
-                Optional[Sequence[BFLOAT16]],
-                Optional[Sequence[BOOL]],
-                Optional[Sequence[COMPLEX128]],
-                Optional[Sequence[COMPLEX64]],
-                Optional[Sequence[DOUBLE]],
-                Optional[Sequence[FLOAT]],
-                Optional[Sequence[FLOAT16]],
-                Optional[Sequence[INT16]],
-                Optional[Sequence[INT32]],
-                Optional[Sequence[INT64]],
-                Optional[Sequence[INT8]],
-                Optional[Sequence[STRING]],
-                Optional[Sequence[UINT16]],
-                Optional[Sequence[UINT32]],
-                Optional[Sequence[UINT64]],
-                Optional[Sequence[UINT8]],
-                Optional[BFLOAT16],
-                Optional[BOOL],
-                Optional[COMPLEX128],
-                Optional[COMPLEX64],
-                Optional[DOUBLE],
-                Optional[FLOAT],
-                Optional[FLOAT16],
-                Optional[INT16],
-                Optional[INT32],
-                Optional[INT64],
-                Optional[INT8],
-                Optional[STRING],
-                Optional[UINT16],
-                Optional[UINT32],
-                Optional[UINT64],
-                Optional[UINT8],
-                Sequence[BFLOAT16],
-                Sequence[BOOL],
-                Sequence[COMPLEX128],
-                Sequence[COMPLEX64],
-                Sequence[DOUBLE],
-                Sequence[FLOAT],
-                Sequence[FLOAT16],
-                Sequence[INT16],
-                Sequence[INT32],
-                Sequence[INT64],
-                Sequence[INT8],
-                Sequence[STRING],
-                Sequence[UINT16],
-                Sequence[UINT32],
-                Sequence[UINT64],
-                Sequence[UINT8],
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Loop", schema)
+        op = Op(self, "Loop", schema)
         return op(*self._prepare_inputs(schema, M, cond, *v_initial), body=body)
 
-    def PRelu(
-        self,
-        X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        slope: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def PRelu(self, X: T, slope: T) -> T:
         r"""[🌐 PRelu(16)](https://onnx.ai/onnx/operators/onnx__PRelu.html#prelu-16 "Online Documentation")
 
 
@@ -1043,23 +669,25 @@ class Opset16(Opset15):
         """
 
         schema = get_schema("PRelu", 16, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "PRelu", schema)
+        op = Op(self, "PRelu", schema)
         return op(*self._prepare_inputs(schema, X, slope))
+
+    T1 = TypeVar("T1", DOUBLE, FLOAT, FLOAT16)
+
+    T2 = TypeVar("T2", bound=INT64)
 
     def RoiAlign(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        rois: Union[DOUBLE, FLOAT, FLOAT16],
-        batch_indices: INT64,
+        X: T1,
+        rois: T1,
+        batch_indices: T2,
         coordinate_transformation_mode: str = "half_pixel",
         mode: str = "avg",
         output_height: int = 1,
         output_width: int = 1,
         sampling_ratio: int = 0,
         spatial_scale: float = 1.0,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T1:
         r"""[🌐 RoiAlign(16)](https://onnx.ai/onnx/operators/onnx__RoiAlign.html#roialign-16 "Online Documentation")
 
 
@@ -1115,7 +743,7 @@ class Opset16(Opset15):
         """
 
         schema = get_schema("RoiAlign", 16, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "RoiAlign", schema)
+        op = Op(self, "RoiAlign", schema)
         return op(
             *self._prepare_inputs(schema, X, rois, batch_indices),
             coordinate_transformation_mode=coordinate_transformation_mode,
@@ -1126,33 +754,8 @@ class Opset16(Opset15):
             spatial_scale=spatial_scale,
         )
 
-    def Scan(
-        self,
-        *initial_state_and_scan_inputs: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        body: Optional[GraphProto] = None,
-        num_scan_inputs: Optional[int] = None,
-        scan_input_axes: Optional[Sequence[int]] = None,
-        scan_input_directions: Optional[Sequence[int]] = None,
-        scan_output_axes: Optional[Sequence[int]] = None,
-        scan_output_directions: Optional[Sequence[int]] = None,
-    ) -> Union[
+    V = TypeVar(
+        "V",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -1169,7 +772,18 @@ class Opset16(Opset15):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Scan(
+        self,
+        *initial_state_and_scan_inputs: V,
+        body: Optional[GraphProto] = None,
+        num_scan_inputs: Optional[int] = None,
+        scan_input_axes: Optional[Sequence[int]] = None,
+        scan_input_directions: Optional[Sequence[int]] = None,
+        scan_output_axes: Optional[Sequence[int]] = None,
+        scan_output_directions: Optional[Sequence[int]] = None,
+    ) -> V:
         r"""[🌐 Scan(16)](https://onnx.ai/onnx/operators/onnx__Scan.html#scan-16 "Online Documentation")
 
 
@@ -1336,27 +950,7 @@ class Opset16(Opset15):
         """
 
         schema = get_schema("Scan", 16, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Scan", schema)
+        op = Op(self, "Scan", schema)
         return op(
             *self._prepare_inputs(schema, *initial_state_and_scan_inputs),
             body=body,
@@ -1367,48 +961,8 @@ class Opset16(Opset15):
             scan_output_directions=scan_output_directions,
         )
 
-    def ScatterElements(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        indices: Union[INT32, INT64],
-        updates: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axis: int = 0,
-        reduction: str = "none",
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -1425,7 +979,13 @@ class Opset16(Opset15):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    Tind = TypeVar("Tind", INT32, INT64)
+
+    def ScatterElements(
+        self, data: T, indices: Tind, updates: T, axis: int = 0, reduction: str = "none"
+    ) -> T:
         r"""[🌐 ScatterElements(16)](https://onnx.ai/onnx/operators/onnx__ScatterElements.html#scatterelements-16 "Online Documentation")
 
 
@@ -1521,74 +1081,15 @@ class Opset16(Opset15):
         """
 
         schema = get_schema("ScatterElements", 16, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "ScatterElements", schema)
+        op = Op(self, "ScatterElements", schema)
         return op(
             *self._prepare_inputs(schema, data, indices, updates),
             axis=axis,
             reduction=reduction,
         )
 
-    def ScatterND(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        indices: INT64,
-        updates: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        reduction: str = "none",
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -1605,7 +1106,9 @@ class Opset16(Opset15):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def ScatterND(self, data: T, indices: INT64, updates: T, reduction: str = "none") -> T:
         r"""[🌐 ScatterND(16)](https://onnx.ai/onnx/operators/onnx__ScatterND.html#scatternd-16 "Online Documentation")
 
 
@@ -1694,69 +1197,13 @@ class Opset16(Opset15):
         """
 
         schema = get_schema("ScatterND", 16, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "ScatterND", schema)
+        op = Op(self, "ScatterND", schema)
         return op(*self._prepare_inputs(schema, data, indices, updates), reduction=reduction)
 
-    def Where(
-        self,
-        condition: BOOL,
-        X: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        Y: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    B = TypeVar("B", bound=BOOL)
+
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -1773,7 +1220,9 @@ class Opset16(Opset15):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Where(self, condition: B, X: T, Y: T) -> T:
         r"""[🌐 Where(16)](https://onnx.ai/onnx/operators/onnx__Where.html#where-16 "Online Documentation")
 
 
@@ -1794,25 +1243,5 @@ class Opset16(Opset15):
         """
 
         schema = get_schema("Where", 16, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Where", schema)
+        op = Op(self, "Where", schema)
         return op(*self._prepare_inputs(schema, condition, X, Y))

--- a/onnxscript/onnx_opset/_impl/opset17.py
+++ b/onnxscript/onnx_opset/_impl/opset17.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Tuple, TypeVar
 
 from onnx import GraphProto
 from onnx.defs import get_schema
@@ -44,9 +44,10 @@ class Opset17(Opset16):
     def __init__(self):
         super().__init__()
 
-    def BlackmanWindow(
-        self, size: Union[INT32, INT64], output_datatype: int = 1, periodic: int = 1
-    ) -> Union[
+    T1 = TypeVar("T1", INT32, INT64)
+
+    T2 = TypeVar(
+        "T2",
         BFLOAT16,
         DOUBLE,
         FLOAT,
@@ -59,7 +60,9 @@ class Opset17(Opset16):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def BlackmanWindow(self, size: T1, output_datatype: int = 1, periodic: int = 1) -> T2:
         r"""[🌐 BlackmanWindow(17)](https://onnx.ai/onnx/operators/onnx__BlackmanWindow.html#blackmanwindow-17 "Online Documentation")
 
 
@@ -81,37 +84,25 @@ class Opset17(Opset16):
         """
 
         schema = get_schema("BlackmanWindow", 17, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "BlackmanWindow", schema)
+        op = Op(self, "BlackmanWindow", schema)
         return op(
             *self._prepare_inputs(schema, size),
             output_datatype=output_datatype,
             periodic=periodic,
         )
 
+    T1 = TypeVar("T1", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    T2 = TypeVar("T2", INT32, INT64)
+
     def DFT(
         self,
-        input: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        dft_length: Optional[Union[INT32, INT64]] = None,
+        input: T1,
+        dft_length: Optional[T2] = None,
         axis: int = 1,
         inverse: int = 0,
         onesided: int = 0,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    ) -> T1:
         r"""[🌐 DFT(17)](https://onnx.ai/onnx/operators/onnx__DFT.html#dft-17 "Online Documentation")
 
         Computes the discrete Fourier transform of input.
@@ -147,7 +138,7 @@ class Opset17(Opset16):
         """
 
         schema = get_schema("DFT", 17, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(self, "DFT", schema)
+        op = Op(self, "DFT", schema)
         return op(
             *self._prepare_inputs(schema, input, dft_length),
             axis=axis,
@@ -155,9 +146,10 @@ class Opset17(Opset16):
             onesided=onesided,
         )
 
-    def HammingWindow(
-        self, size: Union[INT32, INT64], output_datatype: int = 1, periodic: int = 1
-    ) -> Union[
+    T1 = TypeVar("T1", INT32, INT64)
+
+    T2 = TypeVar(
+        "T2",
         BFLOAT16,
         DOUBLE,
         FLOAT,
@@ -170,7 +162,9 @@ class Opset17(Opset16):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def HammingWindow(self, size: T1, output_datatype: int = 1, periodic: int = 1) -> T2:
         r"""[🌐 HammingWindow(17)](https://onnx.ai/onnx/operators/onnx__HammingWindow.html#hammingwindow-17 "Online Documentation")
 
 
@@ -192,32 +186,17 @@ class Opset17(Opset16):
         """
 
         schema = get_schema("HammingWindow", 17, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "HammingWindow", schema)
+        op = Op(self, "HammingWindow", schema)
         return op(
             *self._prepare_inputs(schema, size),
             output_datatype=output_datatype,
             periodic=periodic,
         )
 
-    def HannWindow(
-        self, size: Union[INT32, INT64], output_datatype: int = 1, periodic: int = 1
-    ) -> Union[
+    T1 = TypeVar("T1", INT32, INT64)
+
+    T2 = TypeVar(
+        "T2",
         BFLOAT16,
         DOUBLE,
         FLOAT,
@@ -230,7 +209,9 @@ class Opset17(Opset16):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def HannWindow(self, size: T1, output_datatype: int = 1, periodic: int = 1) -> T2:
         r"""[🌐 HannWindow(17)](https://onnx.ai/onnx/operators/onnx__HannWindow.html#hannwindow-17 "Online Documentation")
 
 
@@ -252,40 +233,26 @@ class Opset17(Opset16):
         """
 
         schema = get_schema("HannWindow", 17, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "HannWindow", schema)
+        op = Op(self, "HannWindow", schema)
         return op(
             *self._prepare_inputs(schema, size),
             output_datatype=output_datatype,
             periodic=periodic,
         )
 
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    U = TypeVar("U", BFLOAT16, FLOAT)
+
     def LayerNormalization(
         self,
-        X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        Scale: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        B: Optional[Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = None,
+        X: T,
+        Scale: T,
+        B: Optional[T] = None,
         axis: int = -1,
         epsilon: float = 9.999999747378752e-06,
         stash_type: int = 1,
-    ) -> Tuple[
-        Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16], Union[BFLOAT16, FLOAT], Union[BFLOAT16, FLOAT]
-    ]:
+    ) -> Tuple[T, U, U]:
         r"""[🌐 LayerNormalization(17)](https://onnx.ai/onnx/operators/onnx__LayerNormalization.html#layernormalization-17 "Online Documentation")
 
 
@@ -348,14 +315,7 @@ class Opset17(Opset16):
         """
 
         schema = get_schema("LayerNormalization", 17, "")
-        op: Callable[
-            ...,
-            Tuple[
-                Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-                Union[BFLOAT16, FLOAT],
-                Union[BFLOAT16, FLOAT],
-            ],
-        ] = Op(self, "LayerNormalization", schema)
+        op = Op(self, "LayerNormalization", schema)
         return op(
             *self._prepare_inputs(schema, X, Scale, B),
             axis=axis,
@@ -363,15 +323,12 @@ class Opset17(Opset16):
             stash_type=stash_type,
         )
 
-    def MelWeightMatrix(
-        self,
-        num_mel_bins: Union[INT32, INT64],
-        dft_length: Union[INT32, INT64],
-        sample_rate: Union[INT32, INT64],
-        lower_edge_hertz: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        upper_edge_hertz: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        output_datatype: int = 1,
-    ) -> Union[
+    T1 = TypeVar("T1", INT32, INT64)
+
+    T2 = TypeVar("T2", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    T3 = TypeVar(
+        "T3",
         BFLOAT16,
         DOUBLE,
         FLOAT,
@@ -384,7 +341,17 @@ class Opset17(Opset16):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def MelWeightMatrix(
+        self,
+        num_mel_bins: T1,
+        dft_length: T1,
+        sample_rate: T1,
+        lower_edge_hertz: T2,
+        upper_edge_hertz: T2,
+        output_datatype: int = 1,
+    ) -> T3:
         r"""[🌐 MelWeightMatrix(17)](https://onnx.ai/onnx/operators/onnx__MelWeightMatrix.html#melweightmatrix-17 "Online Documentation")
 
 
@@ -424,23 +391,7 @@ class Opset17(Opset16):
         """
 
         schema = get_schema("MelWeightMatrix", 17, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "MelWeightMatrix", schema)
+        op = Op(self, "MelWeightMatrix", schema)
         return op(
             *self._prepare_inputs(
                 schema,
@@ -453,14 +404,18 @@ class Opset17(Opset16):
             output_datatype=output_datatype,
         )
 
+    T1 = TypeVar("T1", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
+    T2 = TypeVar("T2", INT32, INT64)
+
     def STFT(
         self,
-        signal: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        frame_step: Union[INT32, INT64],
-        window: Optional[Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = None,
-        frame_length: Optional[Union[INT32, INT64]] = None,
+        signal: T1,
+        frame_step: T2,
+        window: Optional[T1] = None,
+        frame_length: Optional[T2] = None,
         onesided: int = 1,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    ) -> T1:
         r"""[🌐 STFT(17)](https://onnx.ai/onnx/operators/onnx__STFT.html#stft-17 "Online Documentation")
 
         Computes the Short-time Fourier Transform of the signal.
@@ -495,65 +450,14 @@ class Opset17(Opset16):
         """
 
         schema = get_schema("STFT", 17, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(self, "STFT", schema)
+        op = Op(self, "STFT", schema)
         return op(
             *self._prepare_inputs(schema, signal, frame_step, window, frame_length),
             onesided=onesided,
         )
 
-    def SequenceMap(
-        self,
-        input_sequence: Union[
-            Sequence[BOOL],
-            Sequence[COMPLEX128],
-            Sequence[COMPLEX64],
-            Sequence[DOUBLE],
-            Sequence[FLOAT],
-            Sequence[FLOAT16],
-            Sequence[INT16],
-            Sequence[INT32],
-            Sequence[INT64],
-            Sequence[INT8],
-            Sequence[STRING],
-            Sequence[UINT16],
-            Sequence[UINT32],
-            Sequence[UINT64],
-            Sequence[UINT8],
-        ],
-        *additional_inputs: Union[
-            Sequence[BOOL],
-            Sequence[COMPLEX128],
-            Sequence[COMPLEX64],
-            Sequence[DOUBLE],
-            Sequence[FLOAT],
-            Sequence[FLOAT16],
-            Sequence[INT16],
-            Sequence[INT32],
-            Sequence[INT64],
-            Sequence[INT8],
-            Sequence[STRING],
-            Sequence[UINT16],
-            Sequence[UINT32],
-            Sequence[UINT64],
-            Sequence[UINT8],
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        body: Optional[GraphProto] = None,
-    ) -> Union[
+    S = TypeVar(
+        "S",
         Sequence[BOOL],
         Sequence[COMPLEX128],
         Sequence[COMPLEX64],
@@ -569,7 +473,45 @@ class Opset17(Opset16):
         Sequence[UINT32],
         Sequence[UINT64],
         Sequence[UINT8],
-    ]:
+    )
+
+    V = TypeVar(
+        "V",
+        Sequence[BOOL],
+        Sequence[COMPLEX128],
+        Sequence[COMPLEX64],
+        Sequence[DOUBLE],
+        Sequence[FLOAT],
+        Sequence[FLOAT16],
+        Sequence[INT16],
+        Sequence[INT32],
+        Sequence[INT64],
+        Sequence[INT8],
+        Sequence[STRING],
+        Sequence[UINT16],
+        Sequence[UINT32],
+        Sequence[UINT64],
+        Sequence[UINT8],
+        BOOL,
+        COMPLEX128,
+        COMPLEX64,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    def SequenceMap(
+        self, input_sequence: S, *additional_inputs: V, body: Optional[GraphProto] = None
+    ) -> S:
         r"""[🌐 SequenceMap(17)](https://onnx.ai/onnx/operators/onnx__SequenceMap.html#sequencemap-17 "Online Documentation")
 
 
@@ -599,24 +541,5 @@ class Opset17(Opset16):
         """
 
         schema = get_schema("SequenceMap", 17, "")
-        op: Callable[
-            ...,
-            Union[
-                Sequence[BOOL],
-                Sequence[COMPLEX128],
-                Sequence[COMPLEX64],
-                Sequence[DOUBLE],
-                Sequence[FLOAT],
-                Sequence[FLOAT16],
-                Sequence[INT16],
-                Sequence[INT32],
-                Sequence[INT64],
-                Sequence[INT8],
-                Sequence[STRING],
-                Sequence[UINT16],
-                Sequence[UINT32],
-                Sequence[UINT64],
-                Sequence[UINT8],
-            ],
-        ] = Op(self, "SequenceMap", schema)
+        op = Op(self, "SequenceMap", schema)
         return op(*self._prepare_inputs(schema, input_sequence, *additional_inputs), body=body)

--- a/onnxscript/onnx_opset/_impl/opset18.py
+++ b/onnxscript/onnx_opset/_impl/opset18.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Sequence, Union
+from typing import Optional, Sequence, TypeVar
 
 from onnx.defs import get_schema
 
@@ -43,11 +43,9 @@ class Opset18(Opset17):
     def __init__(self):
         super().__init__()
 
-    def BitwiseAnd(
-        self,
-        A: Union[INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8],
-        B: Union[INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8],
-    ) -> Union[INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8]:
+    T = TypeVar("T", INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8)
+
+    def BitwiseAnd(self, A: T, B: T) -> T:
         r"""[🌐 BitwiseAnd(18)](https://onnx.ai/onnx/operators/onnx__BitwiseAnd.html#bitwiseand-18 "Online Documentation")
 
 
@@ -64,14 +62,12 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("BitwiseAnd", 18, "")
-        op: Callable[
-            ..., Union[INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8]
-        ] = Op(self, "BitwiseAnd", schema)
+        op = Op(self, "BitwiseAnd", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def BitwiseNot(
-        self, X: Union[INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8]
-    ) -> Union[INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8]:
+    T = TypeVar("T", INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8)
+
+    def BitwiseNot(self, X: T) -> T:
         r"""[🌐 BitwiseNot(18)](https://onnx.ai/onnx/operators/onnx__BitwiseNot.html#bitwisenot-18 "Online Documentation")
 
 
@@ -83,16 +79,12 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("BitwiseNot", 18, "")
-        op: Callable[
-            ..., Union[INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8]
-        ] = Op(self, "BitwiseNot", schema)
+        op = Op(self, "BitwiseNot", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def BitwiseOr(
-        self,
-        A: Union[INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8],
-        B: Union[INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8],
-    ) -> Union[INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8]:
+    T = TypeVar("T", INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8)
+
+    def BitwiseOr(self, A: T, B: T) -> T:
         r"""[🌐 BitwiseOr(18)](https://onnx.ai/onnx/operators/onnx__BitwiseOr.html#bitwiseor-18 "Online Documentation")
 
 
@@ -109,16 +101,12 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("BitwiseOr", 18, "")
-        op: Callable[
-            ..., Union[INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8]
-        ] = Op(self, "BitwiseOr", schema)
+        op = Op(self, "BitwiseOr", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def BitwiseXor(
-        self,
-        A: Union[INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8],
-        B: Union[INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8],
-    ) -> Union[INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8]:
+    T = TypeVar("T", INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8)
+
+    def BitwiseXor(self, A: T, B: T) -> T:
         r"""[🌐 BitwiseXor(18)](https://onnx.ai/onnx/operators/onnx__BitwiseXor.html#bitwisexor-18 "Online Documentation")
 
 
@@ -135,34 +123,11 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("BitwiseXor", 18, "")
-        op: Callable[
-            ..., Union[INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8]
-        ] = Op(self, "BitwiseXor", schema)
+        op = Op(self, "BitwiseXor", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def CenterCropPad(
-        self,
-        input_data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        shape: Union[INT32, INT64],
-        axes: Optional[Sequence[int]] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -179,7 +144,13 @@ class Opset18(Opset17):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    Tind = TypeVar("Tind", INT32, INT64)
+
+    def CenterCropPad(
+        self, input_data: T, shape: Tind, axes: Optional[Sequence[int]] = None
+    ) -> T:
         r"""[🌐 CenterCropPad(18)](https://onnx.ai/onnx/operators/onnx__CenterCropPad.html#centercroppad-18 "Online Documentation")
 
 
@@ -207,55 +178,11 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("CenterCropPad", 18, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "CenterCropPad", schema)
+        op = Op(self, "CenterCropPad", schema)
         return op(*self._prepare_inputs(schema, input_data, shape), axes=axes)
 
-    def Col2Im(
-        self,
-        input: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        image_shape: INT64,
-        block_shape: INT64,
-        dilations: Optional[Sequence[int]] = None,
-        pads: Optional[Sequence[int]] = None,
-        strides: Optional[Sequence[int]] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -272,7 +199,17 @@ class Opset18(Opset17):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Col2Im(
+        self,
+        input: T,
+        image_shape: INT64,
+        block_shape: INT64,
+        dilations: Optional[Sequence[int]] = None,
+        pads: Optional[Sequence[int]] = None,
+        strides: Optional[Sequence[int]] = None,
+    ) -> T:
         r"""[🌐 Col2Im(18)](https://onnx.ai/onnx/operators/onnx__Col2Im.html#col2im-18 "Online Documentation")
 
 
@@ -327,27 +264,7 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("Col2Im", 18, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Col2Im", schema)
+        op = Op(self, "Col2Im", schema)
         return op(
             *self._prepare_inputs(schema, input, image_shape, block_shape),
             dilations=dilations,
@@ -355,14 +272,16 @@ class Opset18(Opset17):
             strides=strides,
         )
 
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
+
     def GroupNormalization(
         self,
-        X: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        scale: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
-        bias: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16],
+        X: T,
+        scale: T,
+        bias: T,
         epsilon: float = 9.999999747378752e-06,
         num_groups: Optional[int] = None,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 GroupNormalization(18)](https://onnx.ai/onnx/operators/onnx__GroupNormalization.html#groupnormalization-18 "Online Documentation")
 
 
@@ -404,18 +323,18 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("GroupNormalization", 18, "")
-        op: Callable[..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16]] = Op(
-            self, "GroupNormalization", schema
-        )
+        op = Op(self, "GroupNormalization", schema)
         return op(
             *self._prepare_inputs(schema, X, scale, bias),
             epsilon=epsilon,
             num_groups=num_groups,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def LpPool(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         dilations: Optional[Sequence[int]] = None,
@@ -423,7 +342,7 @@ class Opset18(Opset17):
         p: int = 2,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 LpPool(18)](https://onnx.ai/onnx/operators/onnx__LpPool.html#lppool-18 "Online Documentation")
 
 
@@ -492,7 +411,7 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("LpPool", 18, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "LpPool", schema)
+        op = Op(self, "LpPool", schema)
         return op(
             *self._prepare_inputs(schema, X),
             auto_pad=auto_pad,
@@ -504,7 +423,9 @@ class Opset18(Opset17):
             strides=strides,
         )
 
-    def Mish(self, X: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Mish(self, X: T) -> T:
         r"""[🌐 Mish(18)](https://onnx.ai/onnx/operators/onnx__Mish.html#mish-18 "Online Documentation")
 
 
@@ -524,74 +445,41 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("Mish", 18, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Mish", schema)
+        op = Op(self, "Mish", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def OptionalGetElement(
-        self,
-        input: Union[
-            Optional[Sequence[BOOL]],
-            Optional[Sequence[COMPLEX128]],
-            Optional[Sequence[COMPLEX64]],
-            Optional[Sequence[DOUBLE]],
-            Optional[Sequence[FLOAT]],
-            Optional[Sequence[FLOAT16]],
-            Optional[Sequence[INT16]],
-            Optional[Sequence[INT32]],
-            Optional[Sequence[INT64]],
-            Optional[Sequence[INT8]],
-            Optional[Sequence[STRING]],
-            Optional[Sequence[UINT16]],
-            Optional[Sequence[UINT32]],
-            Optional[Sequence[UINT64]],
-            Optional[Sequence[UINT8]],
-            Optional[BOOL],
-            Optional[COMPLEX128],
-            Optional[COMPLEX64],
-            Optional[DOUBLE],
-            Optional[FLOAT],
-            Optional[FLOAT16],
-            Optional[INT16],
-            Optional[INT32],
-            Optional[INT64],
-            Optional[INT8],
-            Optional[STRING],
-            Optional[UINT16],
-            Optional[UINT32],
-            Optional[UINT64],
-            Optional[UINT8],
-            Sequence[BOOL],
-            Sequence[COMPLEX128],
-            Sequence[COMPLEX64],
-            Sequence[DOUBLE],
-            Sequence[FLOAT],
-            Sequence[FLOAT16],
-            Sequence[INT16],
-            Sequence[INT32],
-            Sequence[INT64],
-            Sequence[INT8],
-            Sequence[STRING],
-            Sequence[UINT16],
-            Sequence[UINT32],
-            Sequence[UINT64],
-            Sequence[UINT8],
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    O = TypeVar(
+        "O",
+        Optional[Sequence[BOOL]],
+        Optional[Sequence[COMPLEX128]],
+        Optional[Sequence[COMPLEX64]],
+        Optional[Sequence[DOUBLE]],
+        Optional[Sequence[FLOAT]],
+        Optional[Sequence[FLOAT16]],
+        Optional[Sequence[INT16]],
+        Optional[Sequence[INT32]],
+        Optional[Sequence[INT64]],
+        Optional[Sequence[INT8]],
+        Optional[Sequence[STRING]],
+        Optional[Sequence[UINT16]],
+        Optional[Sequence[UINT32]],
+        Optional[Sequence[UINT64]],
+        Optional[Sequence[UINT8]],
+        Optional[BOOL],
+        Optional[COMPLEX128],
+        Optional[COMPLEX64],
+        Optional[DOUBLE],
+        Optional[FLOAT],
+        Optional[FLOAT16],
+        Optional[INT16],
+        Optional[INT32],
+        Optional[INT64],
+        Optional[INT8],
+        Optional[STRING],
+        Optional[UINT16],
+        Optional[UINT32],
+        Optional[UINT64],
+        Optional[UINT8],
         Sequence[BOOL],
         Sequence[COMPLEX128],
         Sequence[COMPLEX64],
@@ -622,7 +510,43 @@ class Opset18(Opset17):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    V = TypeVar(
+        "V",
+        Sequence[BOOL],
+        Sequence[COMPLEX128],
+        Sequence[COMPLEX64],
+        Sequence[DOUBLE],
+        Sequence[FLOAT],
+        Sequence[FLOAT16],
+        Sequence[INT16],
+        Sequence[INT32],
+        Sequence[INT64],
+        Sequence[INT8],
+        Sequence[STRING],
+        Sequence[UINT16],
+        Sequence[UINT32],
+        Sequence[UINT64],
+        Sequence[UINT8],
+        BOOL,
+        COMPLEX128,
+        COMPLEX64,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    def OptionalGetElement(self, input: O) -> V:
         r"""[🌐 OptionalGetElement(18)](https://onnx.ai/onnx/operators/onnx__OptionalGetElement.html#optionalgetelement-18 "Online Documentation")
 
 
@@ -636,110 +560,76 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("OptionalGetElement", 18, "")
-        op: Callable[
-            ...,
-            Union[
-                Sequence[BOOL],
-                Sequence[COMPLEX128],
-                Sequence[COMPLEX64],
-                Sequence[DOUBLE],
-                Sequence[FLOAT],
-                Sequence[FLOAT16],
-                Sequence[INT16],
-                Sequence[INT32],
-                Sequence[INT64],
-                Sequence[INT8],
-                Sequence[STRING],
-                Sequence[UINT16],
-                Sequence[UINT32],
-                Sequence[UINT64],
-                Sequence[UINT8],
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "OptionalGetElement", schema)
+        op = Op(self, "OptionalGetElement", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def OptionalHasElement(
-        self,
-        input: Optional[
-            Union[
-                Optional[Sequence[BOOL]],
-                Optional[Sequence[COMPLEX128]],
-                Optional[Sequence[COMPLEX64]],
-                Optional[Sequence[DOUBLE]],
-                Optional[Sequence[FLOAT]],
-                Optional[Sequence[FLOAT16]],
-                Optional[Sequence[INT16]],
-                Optional[Sequence[INT32]],
-                Optional[Sequence[INT64]],
-                Optional[Sequence[INT8]],
-                Optional[Sequence[STRING]],
-                Optional[Sequence[UINT16]],
-                Optional[Sequence[UINT32]],
-                Optional[Sequence[UINT64]],
-                Optional[Sequence[UINT8]],
-                Optional[BOOL],
-                Optional[COMPLEX128],
-                Optional[COMPLEX64],
-                Optional[DOUBLE],
-                Optional[FLOAT],
-                Optional[FLOAT16],
-                Optional[INT16],
-                Optional[INT32],
-                Optional[INT64],
-                Optional[INT8],
-                Optional[STRING],
-                Optional[UINT16],
-                Optional[UINT32],
-                Optional[UINT64],
-                Optional[UINT8],
-                Sequence[BOOL],
-                Sequence[COMPLEX128],
-                Sequence[COMPLEX64],
-                Sequence[DOUBLE],
-                Sequence[FLOAT],
-                Sequence[FLOAT16],
-                Sequence[INT16],
-                Sequence[INT32],
-                Sequence[INT64],
-                Sequence[INT8],
-                Sequence[STRING],
-                Sequence[UINT16],
-                Sequence[UINT32],
-                Sequence[UINT64],
-                Sequence[UINT8],
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ]
-        ] = None,
-    ) -> BOOL:
+    O = TypeVar(
+        "O",
+        Optional[Sequence[BOOL]],
+        Optional[Sequence[COMPLEX128]],
+        Optional[Sequence[COMPLEX64]],
+        Optional[Sequence[DOUBLE]],
+        Optional[Sequence[FLOAT]],
+        Optional[Sequence[FLOAT16]],
+        Optional[Sequence[INT16]],
+        Optional[Sequence[INT32]],
+        Optional[Sequence[INT64]],
+        Optional[Sequence[INT8]],
+        Optional[Sequence[STRING]],
+        Optional[Sequence[UINT16]],
+        Optional[Sequence[UINT32]],
+        Optional[Sequence[UINT64]],
+        Optional[Sequence[UINT8]],
+        Optional[BOOL],
+        Optional[COMPLEX128],
+        Optional[COMPLEX64],
+        Optional[DOUBLE],
+        Optional[FLOAT],
+        Optional[FLOAT16],
+        Optional[INT16],
+        Optional[INT32],
+        Optional[INT64],
+        Optional[INT8],
+        Optional[STRING],
+        Optional[UINT16],
+        Optional[UINT32],
+        Optional[UINT64],
+        Optional[UINT8],
+        Sequence[BOOL],
+        Sequence[COMPLEX128],
+        Sequence[COMPLEX64],
+        Sequence[DOUBLE],
+        Sequence[FLOAT],
+        Sequence[FLOAT16],
+        Sequence[INT16],
+        Sequence[INT32],
+        Sequence[INT64],
+        Sequence[INT8],
+        Sequence[STRING],
+        Sequence[UINT16],
+        Sequence[UINT32],
+        Sequence[UINT64],
+        Sequence[UINT8],
+        BOOL,
+        COMPLEX128,
+        COMPLEX64,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    B = TypeVar("B", bound=BOOL)
+
+    def OptionalHasElement(self, input: Optional[O] = None) -> B:
         r"""[🌐 OptionalHasElement(18)](https://onnx.ai/onnx/operators/onnx__OptionalHasElement.html#optionalhaselement-18 "Online Documentation")
 
 
@@ -753,53 +643,11 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("OptionalHasElement", 18, "")
-        op: Callable[..., BOOL] = Op(self, "OptionalHasElement", schema)
+        op = Op(self, "OptionalHasElement", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def Pad(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        pads: INT64,
-        constant_value: Optional[
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ]
-        ] = None,
-        axes: Optional[Union[INT32, INT64]] = None,
-        mode: str = "constant",
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -816,7 +664,18 @@ class Opset18(Opset17):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    Tind = TypeVar("Tind", INT32, INT64)
+
+    def Pad(
+        self,
+        data: T,
+        pads: INT64,
+        constant_value: Optional[T] = None,
+        axes: Optional[Tind] = None,
+        mode: str = "constant",
+    ) -> T:
         r"""[🌐 Pad(18)](https://onnx.ai/onnx/operators/onnx__Pad.html#pad-18 "Online Documentation")
 
 
@@ -930,36 +789,18 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("Pad", 18, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Pad", schema)
+        op = Op(self, "Pad", schema)
         return op(*self._prepare_inputs(schema, data, pads, constant_value, axes), mode=mode)
+
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def ReduceL1(
         self,
-        data: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
+        data: T,
         axes: Optional[INT64] = None,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    ) -> T:
         r"""[🌐 ReduceL1(18)](https://onnx.ai/onnx/operators/onnx__ReduceL1.html#reducel1-18 "Online Documentation")
 
 
@@ -990,22 +831,22 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("ReduceL1", 18, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "ReduceL1", schema)
+        op = Op(self, "ReduceL1", schema)
         return op(
             *self._prepare_inputs(schema, data, axes),
             keepdims=keepdims,
             noop_with_empty_axes=noop_with_empty_axes,
         )
 
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceL2(
         self,
-        data: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
+        data: T,
         axes: Optional[INT64] = None,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    ) -> T:
         r"""[🌐 ReduceL2(18)](https://onnx.ai/onnx/operators/onnx__ReduceL2.html#reducel2-18 "Online Documentation")
 
 
@@ -1036,22 +877,22 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("ReduceL2", 18, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "ReduceL2", schema)
+        op = Op(self, "ReduceL2", schema)
         return op(
             *self._prepare_inputs(schema, data, axes),
             keepdims=keepdims,
             noop_with_empty_axes=noop_with_empty_axes,
         )
 
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceLogSum(
         self,
-        data: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
+        data: T,
         axes: Optional[INT64] = None,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    ) -> T:
         r"""[🌐 ReduceLogSum(18)](https://onnx.ai/onnx/operators/onnx__ReduceLogSum.html#reducelogsum-18 "Online Documentation")
 
 
@@ -1082,22 +923,22 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("ReduceLogSum", 18, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "ReduceLogSum", schema)
+        op = Op(self, "ReduceLogSum", schema)
         return op(
             *self._prepare_inputs(schema, data, axes),
             keepdims=keepdims,
             noop_with_empty_axes=noop_with_empty_axes,
         )
 
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceLogSumExp(
         self,
-        data: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
+        data: T,
         axes: Optional[INT64] = None,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    ) -> T:
         r"""[🌐 ReduceLogSumExp(18)](https://onnx.ai/onnx/operators/onnx__ReduceLogSumExp.html#reducelogsumexp-18 "Online Documentation")
 
 
@@ -1128,24 +969,24 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("ReduceLogSumExp", 18, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "ReduceLogSumExp", schema)
+        op = Op(self, "ReduceLogSumExp", schema)
         return op(
             *self._prepare_inputs(schema, data, axes),
             keepdims=keepdims,
             noop_with_empty_axes=noop_with_empty_axes,
         )
 
+    T = TypeVar(
+        "T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8
+    )
+
     def ReduceMax(
         self,
-        data: Union[
-            BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8
-        ],
+        data: T,
         axes: Optional[INT64] = None,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8]:
+    ) -> T:
         r"""[🌐 ReduceMax(18)](https://onnx.ai/onnx/operators/onnx__ReduceMax.html#reducemax-18 "Online Documentation")
 
 
@@ -1176,23 +1017,22 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("ReduceMax", 18, "")
-        op: Callable[
-            ...,
-            Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8],
-        ] = Op(self, "ReduceMax", schema)
+        op = Op(self, "ReduceMax", schema)
         return op(
             *self._prepare_inputs(schema, data, axes),
             keepdims=keepdims,
             noop_with_empty_axes=noop_with_empty_axes,
         )
 
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceMean(
         self,
-        data: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
+        data: T,
         axes: Optional[INT64] = None,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    ) -> T:
         r"""[🌐 ReduceMean(18)](https://onnx.ai/onnx/operators/onnx__ReduceMean.html#reducemean-18 "Online Documentation")
 
 
@@ -1223,24 +1063,24 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("ReduceMean", 18, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "ReduceMean", schema)
+        op = Op(self, "ReduceMean", schema)
         return op(
             *self._prepare_inputs(schema, data, axes),
             keepdims=keepdims,
             noop_with_empty_axes=noop_with_empty_axes,
         )
 
+    T = TypeVar(
+        "T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8
+    )
+
     def ReduceMin(
         self,
-        data: Union[
-            BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8
-        ],
+        data: T,
         axes: Optional[INT64] = None,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8]:
+    ) -> T:
         r"""[🌐 ReduceMin(18)](https://onnx.ai/onnx/operators/onnx__ReduceMin.html#reducemin-18 "Online Documentation")
 
 
@@ -1271,23 +1111,22 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("ReduceMin", 18, "")
-        op: Callable[
-            ...,
-            Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8],
-        ] = Op(self, "ReduceMin", schema)
+        op = Op(self, "ReduceMin", schema)
         return op(
             *self._prepare_inputs(schema, data, axes),
             keepdims=keepdims,
             noop_with_empty_axes=noop_with_empty_axes,
         )
 
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceProd(
         self,
-        data: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
+        data: T,
         axes: Optional[INT64] = None,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    ) -> T:
         r"""[🌐 ReduceProd(18)](https://onnx.ai/onnx/operators/onnx__ReduceProd.html#reduceprod-18 "Online Documentation")
 
 
@@ -1318,22 +1157,22 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("ReduceProd", 18, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "ReduceProd", schema)
+        op = Op(self, "ReduceProd", schema)
         return op(
             *self._prepare_inputs(schema, data, axes),
             keepdims=keepdims,
             noop_with_empty_axes=noop_with_empty_axes,
         )
 
+    T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
     def ReduceSumSquare(
         self,
-        data: Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
+        data: T,
         axes: Optional[INT64] = None,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
-    ) -> Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    ) -> T:
         r"""[🌐 ReduceSumSquare(18)](https://onnx.ai/onnx/operators/onnx__ReduceSumSquare.html#reducesumsquare-18 "Online Documentation")
 
 
@@ -1364,48 +1203,15 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("ReduceSumSquare", 18, "")
-        op: Callable[
-            ..., Union[BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]
-        ] = Op(self, "ReduceSumSquare", schema)
+        op = Op(self, "ReduceSumSquare", schema)
         return op(
             *self._prepare_inputs(schema, data, axes),
             keepdims=keepdims,
             noop_with_empty_axes=noop_with_empty_axes,
         )
 
-    def Resize(
-        self,
-        X: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        roi: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        scales: Optional[FLOAT] = None,
-        sizes: Optional[INT64] = None,
-        antialias: int = 0,
-        axes: Optional[Sequence[int]] = None,
-        coordinate_transformation_mode: str = "half_pixel",
-        cubic_coeff_a: float = -0.75,
-        exclude_outside: int = 0,
-        extrapolation_value: float = 0.0,
-        keep_aspect_ratio_policy: str = "stretch",
-        mode: str = "nearest",
-        nearest_mode: str = "round_prefer_floor",
-    ) -> Union[
+    T1 = TypeVar(
+        "T1",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -1422,7 +1228,26 @@ class Opset18(Opset17):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    T2 = TypeVar("T2", DOUBLE, FLOAT, FLOAT16)
+
+    def Resize(
+        self,
+        X: T1,
+        roi: Optional[T2] = None,
+        scales: Optional[FLOAT] = None,
+        sizes: Optional[INT64] = None,
+        antialias: int = 0,
+        axes: Optional[Sequence[int]] = None,
+        coordinate_transformation_mode: str = "half_pixel",
+        cubic_coeff_a: float = -0.75,
+        exclude_outside: int = 0,
+        extrapolation_value: float = 0.0,
+        keep_aspect_ratio_policy: str = "stretch",
+        mode: str = "nearest",
+        nearest_mode: str = "round_prefer_floor",
+    ) -> T1:
         r"""[🌐 Resize(18)](https://onnx.ai/onnx/operators/onnx__Resize.html#resize-18 "Online Documentation")
 
 
@@ -1566,27 +1391,7 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("Resize", 18, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Resize", schema)
+        op = Op(self, "Resize", schema)
         return op(
             *self._prepare_inputs(schema, X, roi, scales, sizes),
             antialias=antialias,
@@ -1600,48 +1405,8 @@ class Opset18(Opset17):
             nearest_mode=nearest_mode,
         )
 
-    def ScatterElements(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        indices: Union[INT32, INT64],
-        updates: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axis: int = 0,
-        reduction: str = "none",
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -1658,7 +1423,13 @@ class Opset18(Opset17):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    Tind = TypeVar("Tind", INT32, INT64)
+
+    def ScatterElements(
+        self, data: T, indices: Tind, updates: T, axis: int = 0, reduction: str = "none"
+    ) -> T:
         r"""[🌐 ScatterElements(18)](https://onnx.ai/onnx/operators/onnx__ScatterElements.html#scatterelements-18 "Online Documentation")
 
 
@@ -1756,74 +1527,15 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("ScatterElements", 18, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "ScatterElements", schema)
+        op = Op(self, "ScatterElements", schema)
         return op(
             *self._prepare_inputs(schema, data, indices, updates),
             axis=axis,
             reduction=reduction,
         )
 
-    def ScatterND(
-        self,
-        data: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        indices: INT64,
-        updates: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        reduction: str = "none",
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -1840,7 +1552,9 @@ class Opset18(Opset17):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def ScatterND(self, data: T, indices: INT64, updates: T, reduction: str = "none") -> T:
         r"""[🌐 ScatterND(18)](https://onnx.ai/onnx/operators/onnx__ScatterND.html#scatternd-18 "Online Documentation")
 
 
@@ -1944,53 +1658,11 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("ScatterND", 18, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "ScatterND", schema)
+        op = Op(self, "ScatterND", schema)
         return op(*self._prepare_inputs(schema, data, indices, updates), reduction=reduction)
 
-    def Split(
-        self,
-        input: Union[
-            BFLOAT16,
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        split: Optional[INT64] = None,
-        axis: int = 0,
-        num_outputs: Optional[int] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BFLOAT16,
         BOOL,
         COMPLEX128,
@@ -2007,7 +1679,15 @@ class Opset18(Opset17):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Split(
+        self,
+        input: T,
+        split: Optional[INT64] = None,
+        axis: int = 0,
+        num_outputs: Optional[int] = None,
+    ) -> T:
         r"""[🌐 Split(18)](https://onnx.ai/onnx/operators/onnx__Split.html#split-18 "Online Documentation")
 
         Split a tensor into a list of tensors, along the specified 'axis'.
@@ -2032,27 +1712,7 @@ class Opset18(Opset17):
         """
 
         schema = get_schema("Split", 18, "")
-        op: Callable[
-            ...,
-            Union[
-                BFLOAT16,
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Split", schema)
+        op = Op(self, "Split", schema)
         return op(
             *self._prepare_inputs(schema, input, split), axis=axis, num_outputs=num_outputs
         )

--- a/onnxscript/onnx_opset/_impl/opset2.py
+++ b/onnxscript/onnx_opset/_impl/opset2.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Sequence, Union
+from typing import Optional, Sequence, TypeVar
 
 from onnx.defs import get_schema
 
@@ -42,9 +42,9 @@ class Opset2(Opset1):
     def __init__(self):
         super().__init__()
 
-    def GlobalLpPool(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], p: int = 2
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def GlobalLpPool(self, X: T, p: int = 2) -> T:
         r"""[🌐 GlobalLpPool(2)](https://onnx.ai/onnx/operators/onnx__GlobalLpPool.html#globallppool-2 "Online Documentation")
 
 
@@ -63,18 +63,20 @@ class Opset2(Opset1):
         """
 
         schema = get_schema("GlobalLpPool", 2, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "GlobalLpPool", schema)
+        op = Op(self, "GlobalLpPool", schema)
         return op(*self._prepare_inputs(schema, X), p=p)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def LpPool(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
         auto_pad: str = "NOTSET",
         kernel_shape: Optional[Sequence[int]] = None,
         p: int = 2,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 LpPool(2)](https://onnx.ai/onnx/operators/onnx__LpPool.html#lppool-2 "Online Documentation")
 
 
@@ -116,7 +118,7 @@ class Opset2(Opset1):
         """
 
         schema = get_schema("LpPool", 2, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "LpPool", schema)
+        op = Op(self, "LpPool", schema)
         return op(
             *self._prepare_inputs(schema, X),
             auto_pad=auto_pad,
@@ -126,13 +128,15 @@ class Opset2(Opset1):
             strides=strides,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def Pad(
         self,
-        data: Union[DOUBLE, FLOAT, FLOAT16],
+        data: T,
         mode: str = "constant",
         pads: Optional[Sequence[int]] = None,
         value: float = 0.0,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 Pad(2)](https://onnx.ai/onnx/operators/onnx__Pad.html#pad-2 "Online Documentation")
 
 
@@ -171,31 +175,11 @@ class Opset2(Opset1):
         """
 
         schema = get_schema("Pad", 2, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Pad", schema)
+        op = Op(self, "Pad", schema)
         return op(*self._prepare_inputs(schema, data), mode=mode, pads=pads, value=value)
 
-    def Split(
-        self,
-        input: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axis: int = 0,
-        split: Optional[Sequence[int]] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -211,7 +195,9 @@ class Opset2(Opset1):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Split(self, input: T, axis: int = 0, split: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Split(2)](https://onnx.ai/onnx/operators/onnx__Split.html#split-2 "Online Documentation")
 
         Split a tensor into a list of tensors, along the specified
@@ -228,24 +214,5 @@ class Opset2(Opset1):
         """
 
         schema = get_schema("Split", 2, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Split", schema)
+        op = Op(self, "Split", schema)
         return op(*self._prepare_inputs(schema, input), axis=axis, split=split)

--- a/onnxscript/onnx_opset/_impl/opset3.py
+++ b/onnxscript/onnx_opset/_impl/opset3.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Tuple, TypeVar
 
 from onnx.defs import get_schema
 
@@ -26,14 +26,18 @@ class Opset3(Opset2):
     def __init__(self):
         super().__init__()
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    T1 = TypeVar("T1", bound=INT32)
+
     def GRU(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        W: Union[DOUBLE, FLOAT, FLOAT16],
-        R: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        sequence_lens: Optional[INT32] = None,
-        initial_h: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
+        X: T,
+        W: T,
+        R: T,
+        B: Optional[T] = None,
+        sequence_lens: Optional[T1] = None,
+        initial_h: Optional[T] = None,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Optional[Sequence[str]] = None,
@@ -42,7 +46,7 @@ class Opset3(Opset2):
         hidden_size: Optional[int] = None,
         linear_before_reset: int = 0,
         output_sequence: int = 0,
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]:
+    ) -> Tuple[T, T]:
         r"""[🌐 GRU(3)](https://onnx.ai/onnx/operators/onnx__GRU.html#gru-3 "Online Documentation")
 
 
@@ -179,9 +183,7 @@ class Opset3(Opset2):
         """
 
         schema = get_schema("GRU", 3, "")
-        op: Callable[
-            ..., Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]
-        ] = Op(self, "GRU", schema)
+        op = Op(self, "GRU", schema)
         return op(
             *self._prepare_inputs(schema, X, W, R, B, sequence_lens, initial_h),
             activation_alpha=activation_alpha,

--- a/onnxscript/onnx_opset/_impl/opset4.py
+++ b/onnxscript/onnx_opset/_impl/opset4.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Union
+from typing import Optional, TypeVar
 
 from onnx.defs import get_schema
 
@@ -42,27 +42,8 @@ class Opset4(Opset3):
     def __init__(self):
         super().__init__()
 
-    def Concat(
-        self,
-        *inputs: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axis: Optional[int] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -78,7 +59,9 @@ class Opset4(Opset3):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Concat(self, *inputs: T, axis: Optional[int] = None) -> T:
         r"""[🌐 Concat(4)](https://onnx.ai/onnx/operators/onnx__Concat.html#concat-4 "Online Documentation")
 
         Concatenate a list of tensors into a single tensor
@@ -90,24 +73,5 @@ class Opset4(Opset3):
         """
 
         schema = get_schema("Concat", 4, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Concat", schema)
+        op = Op(self, "Concat", schema)
         return op(*self._prepare_inputs(schema, *inputs), axis=axis)

--- a/onnxscript/onnx_opset/_impl/opset5.py
+++ b/onnxscript/onnx_opset/_impl/opset5.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Union
+from typing import TypeVar
 
 from onnx.defs import get_schema
 
@@ -42,27 +42,8 @@ class Opset5(Opset4):
     def __init__(self):
         super().__init__()
 
-    def Reshape(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        shape: INT64,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -78,7 +59,9 @@ class Opset5(Opset4):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Reshape(self, data: T, shape: INT64) -> T:
         r"""[🌐 Reshape(5)](https://onnx.ai/onnx/operators/onnx__Reshape.html#reshape-5 "Online Documentation")
 
 
@@ -97,24 +80,5 @@ class Opset5(Opset4):
         """
 
         schema = get_schema("Reshape", 5, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Reshape", schema)
+        op = Op(self, "Reshape", schema)
         return op(*self._prepare_inputs(schema, data, shape))

--- a/onnxscript/onnx_opset/_impl/opset6.py
+++ b/onnxscript/onnx_opset/_impl/opset6.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Tuple, Union
+from typing import Optional, Tuple, TypeVar
 
 from onnx.defs import get_schema
 
@@ -42,14 +42,11 @@ class Opset6(Opset5):
     def __init__(self):
         super().__init__()
 
-    def Abs(
-        self,
-        X: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-    ) -> Union[
-        DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-    ]:
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    def Abs(self, X: T) -> T:
         r"""[🌐 Abs(6)](https://onnx.ai/onnx/operators/onnx__Abs.html#abs-6 "Online Documentation")
 
 
@@ -63,31 +60,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Abs", 6, "")
-        op: Callable[
-            ...,
-            Union[
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Abs", schema)
+        op = Op(self, "Abs", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def Add(
-        self,
-        A: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        B: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axis: Optional[int] = None,
-        broadcast: int = 0,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def Add(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T:
         r"""[🌐 Add(6)](https://onnx.ai/onnx/operators/onnx__Add.html#add-6 "Online Documentation")
 
 
@@ -125,29 +103,23 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Add", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "Add", schema
-        )
+        op = Op(self, "Add", schema)
         return op(*self._prepare_inputs(schema, A, B), axis=axis, broadcast=broadcast)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def BatchNormalization(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        scale: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Union[DOUBLE, FLOAT, FLOAT16],
-        mean: Union[DOUBLE, FLOAT, FLOAT16],
-        var: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
+        scale: T,
+        B: T,
+        mean: T,
+        var: T,
         epsilon: float = 9.999999747378752e-06,
         is_test: int = 0,
         momentum: float = 0.8999999761581421,
         spatial: int = 1,
-    ) -> Tuple[
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-    ]:
+    ) -> Tuple[T, T, T, T, T]:
         r"""[🌐 BatchNormalization(6)](https://onnx.ai/onnx/operators/onnx__BatchNormalization.html#batchnormalization-6 "Online Documentation")
 
 
@@ -192,16 +164,7 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("BatchNormalization", 6, "")
-        op: Callable[
-            ...,
-            Tuple[
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-            ],
-        ] = Op(self, "BatchNormalization", schema)
+        op = Op(self, "BatchNormalization", schema)
         return op(
             *self._prepare_inputs(schema, X, scale, B, mean, var),
             epsilon=epsilon,
@@ -210,26 +173,39 @@ class Opset6(Opset5):
             spatial=spatial,
         )
 
-    def Cast(
-        self,
-        input: Union[
-            BOOL,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        to: Optional[int] = None,
-    ) -> Union[
-        BOOL, DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-    ]:
+    T1 = TypeVar(
+        "T1",
+        BOOL,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    T2 = TypeVar(
+        "T2",
+        BOOL,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    def Cast(self, input: T1, to: Optional[int] = None) -> T2:
         r"""[🌐 Cast(6)](https://onnx.ai/onnx/operators/onnx__Cast.html#cast-6 "Online Documentation")
 
 
@@ -248,26 +224,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Cast", 6, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Cast", schema)
+        op = Op(self, "Cast", schema)
         return op(*self._prepare_inputs(schema, input), to=to)
 
-    def Ceil(self, X: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Ceil(self, X: T) -> T:
         r"""[🌐 Ceil(6)](https://onnx.ai/onnx/operators/onnx__Ceil.html#ceil-6 "Online Documentation")
 
 
@@ -281,15 +243,14 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Ceil", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Ceil", schema)
+        op = Op(self, "Ceil", schema)
         return op(*self._prepare_inputs(schema, X))
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def Clip(
-        self,
-        input: Union[DOUBLE, FLOAT, FLOAT16],
-        max: float = 3.4028234663852886e38,
-        min: float = -3.4028234663852886e38,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+        self, input: T, max: float = 3.4028234663852886e38, min: float = -3.4028234663852886e38
+    ) -> T:
         r"""[🌐 Clip(6)](https://onnx.ai/onnx/operators/onnx__Clip.html#clip-6 "Online Documentation")
 
 
@@ -307,16 +268,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Clip", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Clip", schema)
+        op = Op(self, "Clip", schema)
         return op(*self._prepare_inputs(schema, input), max=max, min=min)
 
-    def Div(
-        self,
-        A: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        B: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axis: Optional[int] = None,
-        broadcast: int = 0,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def Div(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T:
         r"""[🌐 Div(6)](https://onnx.ai/onnx/operators/onnx__Div.html#div-6 "Online Documentation")
 
 
@@ -354,14 +311,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Div", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "Div", schema
-        )
+        op = Op(self, "Div", schema)
         return op(*self._prepare_inputs(schema, A, B), axis=axis, broadcast=broadcast)
 
-    def Dropout(
-        self, data: Union[DOUBLE, FLOAT, FLOAT16], is_test: int = 0, ratio: float = 0.5
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Dropout(self, data: T, is_test: int = 0, ratio: float = 0.5) -> Tuple[T, T]:
         r"""[🌐 Dropout(6)](https://onnx.ai/onnx/operators/onnx__Dropout.html#dropout-6 "Online Documentation")
 
 
@@ -382,14 +337,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Dropout", 6, "")
-        op: Callable[
-            ..., Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]
-        ] = Op(self, "Dropout", schema)
+        op = Op(self, "Dropout", schema)
         return op(*self._prepare_inputs(schema, data), is_test=is_test, ratio=ratio)
 
-    def Elu(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], alpha: float = 1.0
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Elu(self, X: T, alpha: float = 1.0) -> T:
         r"""[🌐 Elu(6)](https://onnx.ai/onnx/operators/onnx__Elu.html#elu-6 "Online Documentation")
 
 
@@ -406,10 +359,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Elu", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Elu", schema)
+        op = Op(self, "Elu", schema)
         return op(*self._prepare_inputs(schema, X), alpha=alpha)
 
-    def Exp(self, input: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Exp(self, input: T) -> T:
         r"""[🌐 Exp(6)](https://onnx.ai/onnx/operators/onnx__Exp.html#exp-6 "Online Documentation")
 
 
@@ -421,10 +376,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Exp", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Exp", schema)
+        op = Op(self, "Exp", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def Floor(self, X: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Floor(self, X: T) -> T:
         r"""[🌐 Floor(6)](https://onnx.ai/onnx/operators/onnx__Floor.html#floor-6 "Online Documentation")
 
 
@@ -438,20 +395,22 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Floor", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Floor", schema)
+        op = Op(self, "Floor", schema)
         return op(*self._prepare_inputs(schema, X))
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def Gemm(
         self,
-        A: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Union[DOUBLE, FLOAT, FLOAT16],
-        C: Union[DOUBLE, FLOAT, FLOAT16],
+        A: T,
+        B: T,
+        C: T,
         alpha: float = 1.0,
         beta: float = 1.0,
         broadcast: int = 0,
         transA: int = 0,
         transB: int = 0,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 Gemm(6)](https://onnx.ai/onnx/operators/onnx__Gemm.html#gemm-6 "Online Documentation")
 
         General Matrix multiplication:
@@ -484,7 +443,7 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Gemm", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Gemm", schema)
+        op = Op(self, "Gemm", schema)
         return op(
             *self._prepare_inputs(schema, A, B, C),
             alpha=alpha,
@@ -494,12 +453,9 @@ class Opset6(Opset5):
             transB=transB,
         )
 
-    def HardSigmoid(
-        self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        alpha: float = 0.20000000298023224,
-        beta: float = 0.5,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def HardSigmoid(self, X: T, alpha: float = 0.20000000298023224, beta: float = 0.5) -> T:
         r"""[🌐 HardSigmoid(6)](https://onnx.ai/onnx/operators/onnx__HardSigmoid.html#hardsigmoid-6 "Online Documentation")
 
 
@@ -517,16 +473,14 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("HardSigmoid", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "HardSigmoid", schema)
+        op = Op(self, "HardSigmoid", schema)
         return op(*self._prepare_inputs(schema, X), alpha=alpha, beta=beta)
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def InstanceNormalization(
-        self,
-        input: Union[DOUBLE, FLOAT, FLOAT16],
-        scale: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Union[DOUBLE, FLOAT, FLOAT16],
-        epsilon: float = 9.999999747378752e-06,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+        self, input: T, scale: T, B: T, epsilon: float = 9.999999747378752e-06
+    ) -> T:
         r"""[🌐 InstanceNormalization(6)](https://onnx.ai/onnx/operators/onnx__InstanceNormalization.html#instancenormalization-6 "Online Documentation")
 
 
@@ -553,14 +507,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("InstanceNormalization", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(
-            self, "InstanceNormalization", schema
-        )
+        op = Op(self, "InstanceNormalization", schema)
         return op(*self._prepare_inputs(schema, input, scale, B), epsilon=epsilon)
 
-    def LeakyRelu(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], alpha: float = 0.009999999776482582
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def LeakyRelu(self, X: T, alpha: float = 0.009999999776482582) -> T:
         r"""[🌐 LeakyRelu(6)](https://onnx.ai/onnx/operators/onnx__LeakyRelu.html#leakyrelu-6 "Online Documentation")
 
 
@@ -576,10 +528,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("LeakyRelu", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "LeakyRelu", schema)
+        op = Op(self, "LeakyRelu", schema)
         return op(*self._prepare_inputs(schema, X), alpha=alpha)
 
-    def Log(self, input: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Log(self, input: T) -> T:
         r"""[🌐 Log(6)](https://onnx.ai/onnx/operators/onnx__Log.html#log-6 "Online Documentation")
 
 
@@ -591,10 +545,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Log", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Log", schema)
+        op = Op(self, "Log", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def Max(self, *data_0: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Max(self, *data_0: T) -> T:
         r"""[🌐 Max(6)](https://onnx.ai/onnx/operators/onnx__Max.html#max-6 "Online Documentation")
 
 
@@ -607,10 +563,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Max", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Max", schema)
+        op = Op(self, "Max", schema)
         return op(*self._prepare_inputs(schema, *data_0))
 
-    def Mean(self, *data_0: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Mean(self, *data_0: T) -> T:
         r"""[🌐 Mean(6)](https://onnx.ai/onnx/operators/onnx__Mean.html#mean-6 "Online Documentation")
 
 
@@ -623,10 +581,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Mean", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Mean", schema)
+        op = Op(self, "Mean", schema)
         return op(*self._prepare_inputs(schema, *data_0))
 
-    def Min(self, *data_0: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Min(self, *data_0: T) -> T:
         r"""[🌐 Min(6)](https://onnx.ai/onnx/operators/onnx__Min.html#min-6 "Online Documentation")
 
 
@@ -639,16 +599,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Min", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Min", schema)
+        op = Op(self, "Min", schema)
         return op(*self._prepare_inputs(schema, *data_0))
 
-    def Mul(
-        self,
-        A: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        B: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axis: Optional[int] = None,
-        broadcast: int = 0,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def Mul(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T:
         r"""[🌐 Mul(6)](https://onnx.ai/onnx/operators/onnx__Mul.html#mul-6 "Online Documentation")
 
 
@@ -686,14 +642,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Mul", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "Mul", schema
-        )
+        op = Op(self, "Mul", schema)
         return op(*self._prepare_inputs(schema, A, B), axis=axis, broadcast=broadcast)
 
-    def Neg(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8]
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8)
+
+    def Neg(self, X: T) -> T:
         r"""[🌐 Neg(6)](https://onnx.ai/onnx/operators/onnx__Neg.html#neg-6 "Online Documentation")
 
 
@@ -707,14 +661,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Neg", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8]] = Op(
-            self, "Neg", schema
-        )
+        op = Op(self, "Neg", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def PRelu(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], slope: Union[DOUBLE, FLOAT, FLOAT16]
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def PRelu(self, X: T, slope: T) -> T:
         r"""[🌐 PRelu(6)](https://onnx.ai/onnx/operators/onnx__PRelu.html#prelu-6 "Online Documentation")
 
 
@@ -733,10 +685,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("PRelu", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "PRelu", schema)
+        op = Op(self, "PRelu", schema)
         return op(*self._prepare_inputs(schema, X, slope))
 
-    def Reciprocal(self, X: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Reciprocal(self, X: T) -> T:
         r"""[🌐 Reciprocal(6)](https://onnx.ai/onnx/operators/onnx__Reciprocal.html#reciprocal-6 "Online Documentation")
 
 
@@ -750,10 +704,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Reciprocal", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Reciprocal", schema)
+        op = Op(self, "Reciprocal", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def Relu(self, X: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Relu(self, X: T) -> T:
         r"""[🌐 Relu(6)](https://onnx.ai/onnx/operators/onnx__Relu.html#relu-6 "Online Documentation")
 
 
@@ -767,15 +723,14 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Relu", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Relu", schema)
+        op = Op(self, "Relu", schema)
         return op(*self._prepare_inputs(schema, X))
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def Selu(
-        self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        alpha: float = 1.6732631921768188,
-        gamma: float = 1.0507010221481323,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+        self, X: T, alpha: float = 1.6732631921768188, gamma: float = 1.0507010221481323
+    ) -> T:
         r"""[🌐 Selu(6)](https://onnx.ai/onnx/operators/onnx__Selu.html#selu-6 "Online Documentation")
 
 
@@ -796,10 +751,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Selu", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Selu", schema)
+        op = Op(self, "Selu", schema)
         return op(*self._prepare_inputs(schema, X), alpha=alpha, gamma=gamma)
 
-    def Sigmoid(self, X: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Sigmoid(self, X: T) -> T:
         r"""[🌐 Sigmoid(6)](https://onnx.ai/onnx/operators/onnx__Sigmoid.html#sigmoid-6 "Online Documentation")
 
 
@@ -813,10 +770,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Sigmoid", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Sigmoid", schema)
+        op = Op(self, "Sigmoid", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def Sqrt(self, X: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Sqrt(self, X: T) -> T:
         r"""[🌐 Sqrt(6)](https://onnx.ai/onnx/operators/onnx__Sqrt.html#sqrt-6 "Online Documentation")
 
 
@@ -830,16 +789,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Sqrt", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Sqrt", schema)
+        op = Op(self, "Sqrt", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def Sub(
-        self,
-        A: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        B: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        axis: Optional[int] = None,
-        broadcast: int = 0,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def Sub(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T:
         r"""[🌐 Sub(6)](https://onnx.ai/onnx/operators/onnx__Sub.html#sub-6 "Online Documentation")
 
 
@@ -877,12 +832,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Sub", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "Sub", schema
-        )
+        op = Op(self, "Sub", schema)
         return op(*self._prepare_inputs(schema, A, B), axis=axis, broadcast=broadcast)
 
-    def Sum(self, *data_0: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Sum(self, *data_0: T) -> T:
         r"""[🌐 Sum(6)](https://onnx.ai/onnx/operators/onnx__Sum.html#sum-6 "Online Documentation")
 
 
@@ -895,10 +850,12 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Sum", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Sum", schema)
+        op = Op(self, "Sum", schema)
         return op(*self._prepare_inputs(schema, *data_0))
 
-    def Tanh(self, input: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Tanh(self, input: T) -> T:
         r"""[🌐 Tanh(6)](https://onnx.ai/onnx/operators/onnx__Tanh.html#tanh-6 "Online Documentation")
 
 
@@ -910,30 +867,11 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Tanh", 6, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Tanh", schema)
+        op = Op(self, "Tanh", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def Tile(
-        self,
-        input: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        repeats: INT64,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -949,7 +887,11 @@ class Opset6(Opset5):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    T1 = TypeVar("T1", bound=INT64)
+
+    def Tile(self, input: T, repeats: T1) -> T:
         r"""[🌐 Tile(6)](https://onnx.ai/onnx/operators/onnx__Tile.html#tile-6 "Online Documentation")
 
         Constructs a tensor by tiling a given tensor.
@@ -965,24 +907,5 @@ class Opset6(Opset5):
         """
 
         schema = get_schema("Tile", 6, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Tile", schema)
+        op = Op(self, "Tile", schema)
         return op(*self._prepare_inputs(schema, input, repeats))

--- a/onnxscript/onnx_opset/_impl/opset7.py
+++ b/onnxscript/onnx_opset/_impl/opset7.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Tuple, TypeVar
 
 from onnx.defs import get_schema
 
@@ -42,7 +42,9 @@ class Opset7(Opset6):
     def __init__(self):
         super().__init__()
 
-    def Acos(self, input: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Acos(self, input: T) -> T:
         r"""[🌐 Acos(7)](https://onnx.ai/onnx/operators/onnx__Acos.html#acos-7 "Online Documentation")
 
 
@@ -54,14 +56,12 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Acos", 7, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Acos", schema)
+        op = Op(self, "Acos", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def Add(
-        self,
-        A: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        B: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def Add(self, A: T, B: T) -> T:
         r"""[🌐 Add(7)](https://onnx.ai/onnx/operators/onnx__Add.html#add-7 "Online Documentation")
 
 
@@ -77,12 +77,14 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Add", 7, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "Add", schema
-        )
+        op = Op(self, "Add", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def And(self, A: BOOL, B: BOOL) -> BOOL:
+    T = TypeVar("T", bound=BOOL)
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def And(self, A: T, B: T) -> T1:
         r"""[🌐 And(7)](https://onnx.ai/onnx/operators/onnx__And.html#and-7 "Online Documentation")
 
 
@@ -99,10 +101,12 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("And", 7, "")
-        op: Callable[..., BOOL] = Op(self, "And", schema)
+        op = Op(self, "And", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def Asin(self, input: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Asin(self, input: T) -> T:
         r"""[🌐 Asin(7)](https://onnx.ai/onnx/operators/onnx__Asin.html#asin-7 "Online Documentation")
 
 
@@ -114,10 +118,12 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Asin", 7, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Asin", schema)
+        op = Op(self, "Asin", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def Atan(self, input: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Atan(self, input: T) -> T:
         r"""[🌐 Atan(7)](https://onnx.ai/onnx/operators/onnx__Atan.html#atan-7 "Online Documentation")
 
 
@@ -129,18 +135,20 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Atan", 7, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Atan", schema)
+        op = Op(self, "Atan", schema)
         return op(*self._prepare_inputs(schema, input))
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def AveragePool(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
         auto_pad: str = "NOTSET",
         count_include_pad: int = 0,
         kernel_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 AveragePool(7)](https://onnx.ai/onnx/operators/onnx__AveragePool.html#averagepool-7 "Online Documentation")
 
 
@@ -203,7 +211,7 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("AveragePool", 7, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "AveragePool", schema)
+        op = Op(self, "AveragePool", schema)
         return op(
             *self._prepare_inputs(schema, X),
             auto_pad=auto_pad,
@@ -213,23 +221,19 @@ class Opset7(Opset6):
             strides=strides,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def BatchNormalization(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        scale: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Union[DOUBLE, FLOAT, FLOAT16],
-        mean: Union[DOUBLE, FLOAT, FLOAT16],
-        var: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
+        scale: T,
+        B: T,
+        mean: T,
+        var: T,
         epsilon: float = 9.999999747378752e-06,
         momentum: float = 0.8999999761581421,
         spatial: int = 1,
-    ) -> Tuple[
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-    ]:
+    ) -> Tuple[T, T, T, T, T]:
         r"""[🌐 BatchNormalization(7)](https://onnx.ai/onnx/operators/onnx__BatchNormalization.html#batchnormalization-7 "Online Documentation")
 
 
@@ -276,16 +280,7 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("BatchNormalization", 7, "")
-        op: Callable[
-            ...,
-            Tuple[
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-            ],
-        ] = Op(self, "BatchNormalization", schema)
+        op = Op(self, "BatchNormalization", schema)
         return op(
             *self._prepare_inputs(schema, X, scale, B, mean, var),
             epsilon=epsilon,
@@ -293,7 +288,9 @@ class Opset7(Opset6):
             spatial=spatial,
         )
 
-    def Cos(self, input: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Cos(self, input: T) -> T:
         r"""[🌐 Cos(7)](https://onnx.ai/onnx/operators/onnx__Cos.html#cos-7 "Online Documentation")
 
 
@@ -305,14 +302,12 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Cos", 7, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Cos", schema)
+        op = Op(self, "Cos", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def Div(
-        self,
-        A: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        B: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def Div(self, A: T, B: T) -> T:
         r"""[🌐 Div(7)](https://onnx.ai/onnx/operators/onnx__Div.html#div-7 "Online Documentation")
 
 
@@ -328,14 +323,12 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Div", 7, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "Div", schema
-        )
+        op = Op(self, "Div", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def Dropout(
-        self, data: Union[DOUBLE, FLOAT, FLOAT16], ratio: float = 0.5
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Dropout(self, data: T, ratio: float = 0.5) -> Tuple[T, T]:
         r"""[🌐 Dropout(7)](https://onnx.ai/onnx/operators/onnx__Dropout.html#dropout-7 "Online Documentation")
 
 
@@ -354,12 +347,14 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Dropout", 7, "")
-        op: Callable[
-            ..., Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]
-        ] = Op(self, "Dropout", schema)
+        op = Op(self, "Dropout", schema)
         return op(*self._prepare_inputs(schema, data), ratio=ratio)
 
-    def Equal(self, A: Union[BOOL, INT32, INT64], B: Union[BOOL, INT32, INT64]) -> BOOL:
+    T = TypeVar("T", BOOL, INT32, INT64)
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Equal(self, A: T, B: T) -> T1:
         r"""[🌐 Equal(7)](https://onnx.ai/onnx/operators/onnx__Equal.html#equal-7 "Online Documentation")
 
 
@@ -376,17 +371,21 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Equal", 7, "")
-        op: Callable[..., BOOL] = Op(self, "Equal", schema)
+        op = Op(self, "Equal", schema)
         return op(*self._prepare_inputs(schema, A, B))
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    T1 = TypeVar("T1", bound=INT32)
 
     def GRU(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        W: Union[DOUBLE, FLOAT, FLOAT16],
-        R: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        sequence_lens: Optional[INT32] = None,
-        initial_h: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
+        X: T,
+        W: T,
+        R: T,
+        B: Optional[T] = None,
+        sequence_lens: Optional[T1] = None,
+        initial_h: Optional[T] = None,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Optional[Sequence[str]] = None,
@@ -394,7 +393,7 @@ class Opset7(Opset6):
         direction: str = "forward",
         hidden_size: Optional[int] = None,
         linear_before_reset: int = 0,
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]:
+    ) -> Tuple[T, T]:
         r"""[🌐 GRU(7)](https://onnx.ai/onnx/operators/onnx__GRU.html#gru-7 "Online Documentation")
 
 
@@ -529,9 +528,7 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("GRU", 7, "")
-        op: Callable[
-            ..., Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]
-        ] = Op(self, "GRU", schema)
+        op = Op(self, "GRU", schema)
         return op(
             *self._prepare_inputs(schema, X, W, R, B, sequence_lens, initial_h),
             activation_alpha=activation_alpha,
@@ -543,16 +540,18 @@ class Opset7(Opset6):
             linear_before_reset=linear_before_reset,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
     def Gemm(
         self,
-        A: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Union[DOUBLE, FLOAT, FLOAT16],
-        C: Union[DOUBLE, FLOAT, FLOAT16],
+        A: T,
+        B: T,
+        C: T,
         alpha: float = 1.0,
         beta: float = 1.0,
         transA: int = 0,
         transB: int = 0,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T:
         r"""[🌐 Gemm(7)](https://onnx.ai/onnx/operators/onnx__Gemm.html#gemm-7 "Online Documentation")
 
         General Matrix multiplication:
@@ -588,7 +587,7 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Gemm", 7, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Gemm", schema)
+        op = Op(self, "Gemm", schema)
         return op(
             *self._prepare_inputs(schema, A, B, C),
             alpha=alpha,
@@ -597,9 +596,11 @@ class Opset7(Opset6):
             transB=transB,
         )
 
-    def Greater(
-        self, A: Union[DOUBLE, FLOAT, FLOAT16], B: Union[DOUBLE, FLOAT, FLOAT16]
-    ) -> BOOL:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Greater(self, A: T, B: T) -> T1:
         r"""[🌐 Greater(7)](https://onnx.ai/onnx/operators/onnx__Greater.html#greater-7 "Online Documentation")
 
 
@@ -616,19 +617,23 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Greater", 7, "")
-        op: Callable[..., BOOL] = Op(self, "Greater", schema)
+        op = Op(self, "Greater", schema)
         return op(*self._prepare_inputs(schema, A, B))
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    T1 = TypeVar("T1", bound=INT32)
 
     def LSTM(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        W: Union[DOUBLE, FLOAT, FLOAT16],
-        R: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        sequence_lens: Optional[INT32] = None,
-        initial_h: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        initial_c: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        P: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
+        X: T,
+        W: T,
+        R: T,
+        B: Optional[T] = None,
+        sequence_lens: Optional[T1] = None,
+        initial_h: Optional[T] = None,
+        initial_c: Optional[T] = None,
+        P: Optional[T] = None,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Optional[Sequence[str]] = None,
@@ -636,11 +641,7 @@ class Opset7(Opset6):
         direction: str = "forward",
         hidden_size: Optional[int] = None,
         input_forget: int = 0,
-    ) -> Tuple[
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-    ]:
+    ) -> Tuple[T, T, T]:
         r"""[🌐 LSTM(7)](https://onnx.ai/onnx/operators/onnx__LSTM.html#lstm-7 "Online Documentation")
 
 
@@ -790,14 +791,7 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("LSTM", 7, "")
-        op: Callable[
-            ...,
-            Tuple[
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-            ],
-        ] = Op(self, "LSTM", schema)
+        op = Op(self, "LSTM", schema)
         return op(
             *self._prepare_inputs(schema, X, W, R, B, sequence_lens, initial_h, initial_c, P),
             activation_alpha=activation_alpha,
@@ -809,7 +803,11 @@ class Opset7(Opset6):
             input_forget=input_forget,
         )
 
-    def Less(self, A: Union[DOUBLE, FLOAT, FLOAT16], B: Union[DOUBLE, FLOAT, FLOAT16]) -> BOOL:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Less(self, A: T, B: T) -> T1:
         r"""[🌐 Less(7)](https://onnx.ai/onnx/operators/onnx__Less.html#less-7 "Online Documentation")
 
 
@@ -826,14 +824,12 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Less", 7, "")
-        op: Callable[..., BOOL] = Op(self, "Less", schema)
+        op = Op(self, "Less", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def Mul(
-        self,
-        A: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        B: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def Mul(self, A: T, B: T) -> T:
         r"""[🌐 Mul(7)](https://onnx.ai/onnx/operators/onnx__Mul.html#mul-7 "Online Documentation")
 
 
@@ -849,18 +845,16 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Mul", 7, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "Mul", schema
-        )
+        op = Op(self, "Mul", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
+    T1 = TypeVar("T1", DOUBLE, FLOAT, FLOAT16)
+
+    T2 = TypeVar("T2", INT32, INT64)
+
     def Multinomial(
-        self,
-        input: Union[DOUBLE, FLOAT, FLOAT16],
-        dtype: int = 6,
-        sample_size: int = 1,
-        seed: Optional[float] = None,
-    ) -> Union[INT32, INT64]:
+        self, input: T1, dtype: int = 6, sample_size: int = 1, seed: Optional[float] = None
+    ) -> T2:
         r"""[🌐 Multinomial(7)](https://onnx.ai/onnx/operators/onnx__Multinomial.html#multinomial-7 "Online Documentation")
 
 
@@ -884,7 +878,7 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Multinomial", 7, "")
-        op: Callable[..., Union[INT32, INT64]] = Op(self, "Multinomial", schema)
+        op = Op(self, "Multinomial", schema)
         return op(
             *self._prepare_inputs(schema, input),
             dtype=dtype,
@@ -892,7 +886,11 @@ class Opset7(Opset6):
             seed=seed,
         )
 
-    def Or(self, A: BOOL, B: BOOL) -> BOOL:
+    T = TypeVar("T", bound=BOOL)
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Or(self, A: T, B: T) -> T1:
         r"""[🌐 Or(7)](https://onnx.ai/onnx/operators/onnx__Or.html#or-7 "Online Documentation")
 
 
@@ -909,12 +907,12 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Or", 7, "")
-        op: Callable[..., BOOL] = Op(self, "Or", schema)
+        op = Op(self, "Or", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def PRelu(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], slope: Union[DOUBLE, FLOAT, FLOAT16]
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def PRelu(self, X: T, slope: T) -> T:
         r"""[🌐 PRelu(7)](https://onnx.ai/onnx/operators/onnx__PRelu.html#prelu-7 "Online Documentation")
 
 
@@ -931,12 +929,12 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("PRelu", 7, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "PRelu", schema)
+        op = Op(self, "PRelu", schema)
         return op(*self._prepare_inputs(schema, X, slope))
 
-    def Pow(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], Y: Union[DOUBLE, FLOAT, FLOAT16]
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Pow(self, X: T, Y: T) -> T:
         r"""[🌐 Pow(7)](https://onnx.ai/onnx/operators/onnx__Pow.html#pow-7 "Online Documentation")
 
 
@@ -952,24 +950,28 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Pow", 7, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Pow", schema)
+        op = Op(self, "Pow", schema)
         return op(*self._prepare_inputs(schema, X, Y))
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    T1 = TypeVar("T1", bound=INT32)
 
     def RNN(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        W: Union[DOUBLE, FLOAT, FLOAT16],
-        R: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
-        sequence_lens: Optional[INT32] = None,
-        initial_h: Optional[Union[DOUBLE, FLOAT, FLOAT16]] = None,
+        X: T,
+        W: T,
+        R: T,
+        B: Optional[T] = None,
+        sequence_lens: Optional[T1] = None,
+        initial_h: Optional[T] = None,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Sequence[str] = ("Tanh", "Tanh"),
         clip: Optional[float] = None,
         direction: str = "forward",
         hidden_size: Optional[int] = None,
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]:
+    ) -> Tuple[T, T]:
         r"""[🌐 RNN(7)](https://onnx.ai/onnx/operators/onnx__RNN.html#rnn-7 "Online Documentation")
 
 
@@ -1087,9 +1089,7 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("RNN", 7, "")
-        op: Callable[
-            ..., Tuple[Union[DOUBLE, FLOAT, FLOAT16], Union[DOUBLE, FLOAT, FLOAT16]]
-        ] = Op(self, "RNN", schema)
+        op = Op(self, "RNN", schema)
         return op(
             *self._prepare_inputs(schema, X, W, R, B, sequence_lens, initial_h),
             activation_alpha=activation_alpha,
@@ -1100,7 +1100,9 @@ class Opset7(Opset6):
             hidden_size=hidden_size,
         )
 
-    def Sin(self, input: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Sin(self, input: T) -> T:
         r"""[🌐 Sin(7)](https://onnx.ai/onnx/operators/onnx__Sin.html#sin-7 "Online Documentation")
 
 
@@ -1112,14 +1114,12 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Sin", 7, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Sin", schema)
+        op = Op(self, "Sin", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def Sub(
-        self,
-        A: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        B: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def Sub(self, A: T, B: T) -> T:
         r"""[🌐 Sub(7)](https://onnx.ai/onnx/operators/onnx__Sub.html#sub-7 "Online Documentation")
 
 
@@ -1135,12 +1135,12 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Sub", 7, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "Sub", schema
-        )
+        op = Op(self, "Sub", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def Tan(self, input: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Tan(self, input: T) -> T:
         r"""[🌐 Tan(7)](https://onnx.ai/onnx/operators/onnx__Tan.html#tan-7 "Online Documentation")
 
 
@@ -1152,31 +1152,11 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Tan", 7, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Tan", schema)
+        op = Op(self, "Tan", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def Upsample(
-        self,
-        X: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        mode: str = "nearest",
-        scales: Optional[Sequence[float]] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -1192,7 +1172,11 @@ class Opset7(Opset6):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Upsample(
+        self, X: T, mode: str = "nearest", scales: Optional[Sequence[float]] = None
+    ) -> T:
         r"""[🌐 Upsample(7)](https://onnx.ai/onnx/operators/onnx__Upsample.html#upsample-7 "Online Documentation")
 
 
@@ -1213,29 +1197,14 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Upsample", 7, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Upsample", schema)
+        op = Op(self, "Upsample", schema)
         return op(*self._prepare_inputs(schema, X), mode=mode, scales=scales)
 
-    def Xor(self, A: BOOL, B: BOOL) -> BOOL:
+    T = TypeVar("T", bound=BOOL)
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Xor(self, A: T, B: T) -> T1:
         r"""[🌐 Xor(7)](https://onnx.ai/onnx/operators/onnx__Xor.html#xor-7 "Online Documentation")
 
 
@@ -1252,5 +1221,5 @@ class Opset7(Opset6):
         """
 
         schema = get_schema("Xor", 7, "")
-        op: Callable[..., BOOL] = Op(self, "Xor", schema)
+        op = Op(self, "Xor", schema)
         return op(*self._prepare_inputs(schema, A, B))

--- a/onnxscript/onnx_opset/_impl/opset8.py
+++ b/onnxscript/onnx_opset/_impl/opset8.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Tuple, TypeVar
 
 from onnx import GraphProto
 from onnx.defs import get_schema
@@ -43,27 +43,8 @@ class Opset8(Opset7):
     def __init__(self):
         super().__init__()
 
-    def Expand(
-        self,
-        input: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        shape: INT64,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -79,7 +60,9 @@ class Opset8(Opset7):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Expand(self, input: T, shape: INT64) -> T:
         r"""[🌐 Expand(8)](https://onnx.ai/onnx/operators/onnx__Expand.html#expand-8 "Online Documentation")
 
 
@@ -101,29 +84,12 @@ class Opset8(Opset7):
         """
 
         schema = get_schema("Expand", 8, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Expand", schema)
+        op = Op(self, "Expand", schema)
         return op(*self._prepare_inputs(schema, input, shape))
 
-    def Max(self, *data_0: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Max(self, *data_0: T) -> T:
         r"""[🌐 Max(8)](https://onnx.ai/onnx/operators/onnx__Max.html#max-8 "Online Documentation")
 
 
@@ -137,18 +103,22 @@ class Opset8(Opset7):
         """
 
         schema = get_schema("Max", 8, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Max", schema)
+        op = Op(self, "Max", schema)
         return op(*self._prepare_inputs(schema, *data_0))
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    I = TypeVar("I", bound=INT64)
 
     def MaxPool(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
         auto_pad: str = "NOTSET",
         kernel_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
         storage_order: int = 0,
         strides: Optional[Sequence[int]] = None,
-    ) -> Tuple[Union[DOUBLE, FLOAT, FLOAT16], INT64]:
+    ) -> Tuple[T, I]:
         r"""[🌐 MaxPool(8)](https://onnx.ai/onnx/operators/onnx__MaxPool.html#maxpool-8 "Online Documentation")
 
 
@@ -211,9 +181,7 @@ class Opset8(Opset7):
         """
 
         schema = get_schema("MaxPool", 8, "")
-        op: Callable[..., Tuple[Union[DOUBLE, FLOAT, FLOAT16], INT64]] = Op(
-            self, "MaxPool", schema
-        )
+        op = Op(self, "MaxPool", schema)
         return op(
             *self._prepare_inputs(schema, X),
             auto_pad=auto_pad,
@@ -223,7 +191,9 @@ class Opset8(Opset7):
             strides=strides,
         )
 
-    def Mean(self, *data_0: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Mean(self, *data_0: T) -> T:
         r"""[🌐 Mean(8)](https://onnx.ai/onnx/operators/onnx__Mean.html#mean-8 "Online Documentation")
 
 
@@ -237,10 +207,12 @@ class Opset8(Opset7):
         """
 
         schema = get_schema("Mean", 8, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Mean", schema)
+        op = Op(self, "Mean", schema)
         return op(*self._prepare_inputs(schema, *data_0))
 
-    def Min(self, *data_0: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Min(self, *data_0: T) -> T:
         r"""[🌐 Min(8)](https://onnx.ai/onnx/operators/onnx__Min.html#min-8 "Online Documentation")
 
 
@@ -254,33 +226,13 @@ class Opset8(Opset7):
         """
 
         schema = get_schema("Min", 8, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Min", schema)
+        op = Op(self, "Min", schema)
         return op(*self._prepare_inputs(schema, *data_0))
 
-    def Scan(
-        self,
-        sequence_lens: Optional[INT64],
-        *initial_state_and_scan_inputs: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        body: Optional[GraphProto] = None,
-        directions: Optional[Sequence[int]] = None,
-        num_scan_inputs: Optional[int] = None,
-    ) -> Union[
+    I = TypeVar("I", bound=INT64)
+
+    V = TypeVar(
+        "V",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -296,7 +248,16 @@ class Opset8(Opset7):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Scan(
+        self,
+        sequence_lens: Optional[I],
+        *initial_state_and_scan_inputs: V,
+        body: Optional[GraphProto] = None,
+        directions: Optional[Sequence[int]] = None,
+        num_scan_inputs: Optional[int] = None,
+    ) -> V:
         r"""[🌐 Scan(8)](https://onnx.ai/onnx/operators/onnx__Scan.html#scan-8 "Online Documentation")
 
 
@@ -453,26 +414,7 @@ class Opset8(Opset7):
         """
 
         schema = get_schema("Scan", 8, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Scan", schema)
+        op = Op(self, "Scan", schema)
         return op(
             *self._prepare_inputs(schema, sequence_lens, *initial_state_and_scan_inputs),
             body=body,
@@ -480,7 +422,9 @@ class Opset8(Opset7):
             num_scan_inputs=num_scan_inputs,
         )
 
-    def Sum(self, *data_0: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Sum(self, *data_0: T) -> T:
         r"""[🌐 Sum(8)](https://onnx.ai/onnx/operators/onnx__Sum.html#sum-8 "Online Documentation")
 
 
@@ -494,5 +438,5 @@ class Opset8(Opset7):
         """
 
         schema = get_schema("Sum", 8, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Sum", schema)
+        op = Op(self, "Sum", schema)
         return op(*self._prepare_inputs(schema, *data_0))

--- a/onnxscript/onnx_opset/_impl/opset9.py
+++ b/onnxscript/onnx_opset/_impl/opset9.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Tuple, TypeVar
 
 from onnx import GraphProto, TensorProto
 from onnx.defs import get_schema
@@ -43,7 +43,9 @@ class Opset9(Opset8):
     def __init__(self):
         super().__init__()
 
-    def Acosh(self, input: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Acosh(self, input: T) -> T:
         r"""[🌐 Acosh(9)](https://onnx.ai/onnx/operators/onnx__Acosh.html#acosh-9 "Online Documentation")
 
 
@@ -55,10 +57,12 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Acosh", 9, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Acosh", schema)
+        op = Op(self, "Acosh", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def Asinh(self, input: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Asinh(self, input: T) -> T:
         r"""[🌐 Asinh(9)](https://onnx.ai/onnx/operators/onnx__Asinh.html#asinh-9 "Online Documentation")
 
 
@@ -70,10 +74,12 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Asinh", 9, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Asinh", schema)
+        op = Op(self, "Asinh", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def Atanh(self, input: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Atanh(self, input: T) -> T:
         r"""[🌐 Atanh(9)](https://onnx.ai/onnx/operators/onnx__Atanh.html#atanh-9 "Online Documentation")
 
 
@@ -85,25 +91,21 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Atanh", 9, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Atanh", schema)
+        op = Op(self, "Atanh", schema)
         return op(*self._prepare_inputs(schema, input))
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def BatchNormalization(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        scale: Union[DOUBLE, FLOAT, FLOAT16],
-        B: Union[DOUBLE, FLOAT, FLOAT16],
-        mean: Union[DOUBLE, FLOAT, FLOAT16],
-        var: Union[DOUBLE, FLOAT, FLOAT16],
+        X: T,
+        scale: T,
+        B: T,
+        mean: T,
+        var: T,
         epsilon: float = 9.999999747378752e-06,
         momentum: float = 0.8999999761581421,
-    ) -> Tuple[
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-        Union[DOUBLE, FLOAT, FLOAT16],
-    ]:
+    ) -> Tuple[T, T, T, T, T]:
         r"""[🌐 BatchNormalization(9)](https://onnx.ai/onnx/operators/onnx__BatchNormalization.html#batchnormalization-9 "Online Documentation")
 
 
@@ -144,41 +146,15 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("BatchNormalization", 9, "")
-        op: Callable[
-            ...,
-            Tuple[
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-                Union[DOUBLE, FLOAT, FLOAT16],
-            ],
-        ] = Op(self, "BatchNormalization", schema)
+        op = Op(self, "BatchNormalization", schema)
         return op(
             *self._prepare_inputs(schema, X, scale, B, mean, var),
             epsilon=epsilon,
             momentum=momentum,
         )
 
-    def Cast(
-        self,
-        input: Union[
-            BOOL,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        to: Optional[int] = None,
-    ) -> Union[
+    T1 = TypeVar(
+        "T1",
         BOOL,
         DOUBLE,
         FLOAT,
@@ -192,7 +168,26 @@ class Opset9(Opset8):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    T2 = TypeVar(
+        "T2",
+        BOOL,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    def Cast(self, input: T1, to: Optional[int] = None) -> T2:
         r"""[🌐 Cast(9)](https://onnx.ai/onnx/operators/onnx__Cast.html#cast-9 "Online Documentation")
 
 
@@ -225,48 +220,11 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Cast", 9, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Cast", schema)
+        op = Op(self, "Cast", schema)
         return op(*self._prepare_inputs(schema, input), to=to)
 
-    def Compress(
-        self,
-        input: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        condition: BOOL,
-        axis: Optional[int] = None,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -282,7 +240,11 @@ class Opset9(Opset8):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Compress(self, input: T, condition: T1, axis: Optional[int] = None) -> T:
         r"""[🌐 Compress(9)](https://onnx.ai/onnx/operators/onnx__Compress.html#compress-9 "Online Documentation")
 
 
@@ -305,31 +267,11 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Compress", 9, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Compress", schema)
+        op = Op(self, "Compress", schema)
         return op(*self._prepare_inputs(schema, input, condition), axis=axis)
 
-    def Constant(
-        self, value: Optional[TensorProto] = None
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -345,7 +287,9 @@ class Opset9(Opset8):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Constant(self, value: Optional[TensorProto] = None) -> T:
         r"""[🌐 Constant(9)](https://onnx.ai/onnx/operators/onnx__Constant.html#constant-9 "Online Documentation")
 
         A constant tensor.
@@ -355,33 +299,28 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Constant", 9, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Constant", schema)
+        op = Op(self, "Constant", schema)
         return op(value=value)
 
-    def ConstantOfShape(
-        self, input: INT64, value: Optional[TensorProto] = None
-    ) -> Union[
-        BOOL, DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-    ]:
+    T1 = TypeVar("T1", bound=INT64)
+
+    T2 = TypeVar(
+        "T2",
+        BOOL,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    def ConstantOfShape(self, input: T1, value: Optional[TensorProto] = None) -> T2:
         r"""[🌐 ConstantOfShape(9)](https://onnx.ai/onnx/operators/onnx__ConstantOfShape.html#constantofshape-9 "Online Documentation")
 
 
@@ -398,26 +337,12 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("ConstantOfShape", 9, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "ConstantOfShape", schema)
+        op = Op(self, "ConstantOfShape", schema)
         return op(*self._prepare_inputs(schema, input), value=value)
 
-    def Cosh(self, input: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Cosh(self, input: T) -> T:
         r"""[🌐 Cosh(9)](https://onnx.ai/onnx/operators/onnx__Cosh.html#cosh-9 "Online Documentation")
 
 
@@ -429,17 +354,14 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Cosh", 9, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Cosh", schema)
+        op = Op(self, "Cosh", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def Erf(
-        self,
-        input: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-    ) -> Union[
-        DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-    ]:
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    def Erf(self, input: T) -> T:
         r"""[🌐 Erf(9)](https://onnx.ai/onnx/operators/onnx__Erf.html#erf-9 "Online Documentation")
 
 
@@ -451,45 +373,42 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Erf", 9, "")
-        op: Callable[
-            ...,
-            Union[
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Erf", schema)
+        op = Op(self, "Erf", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def EyeLike(
-        self,
-        input: Union[
-            BOOL,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        dtype: Optional[int] = None,
-        k: int = 0,
-    ) -> Union[
-        BOOL, DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-    ]:
+    T1 = TypeVar(
+        "T1",
+        BOOL,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    T2 = TypeVar(
+        "T2",
+        BOOL,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    def EyeLike(self, input: T1, dtype: Optional[int] = None, k: int = 0) -> T2:
         r"""[🌐 EyeLike(9)](https://onnx.ai/onnx/operators/onnx__EyeLike.html#eyelike-9 "Online Documentation")
 
 
@@ -516,46 +435,11 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("EyeLike", 9, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "EyeLike", schema)
+        op = Op(self, "EyeLike", schema)
         return op(*self._prepare_inputs(schema, input), dtype=dtype, k=k)
 
-    def Flatten(
-        self,
-        input: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axis: int = 1,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -571,7 +455,9 @@ class Opset9(Opset8):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Flatten(self, input: T, axis: int = 1) -> T:
         r"""[🌐 Flatten(9)](https://onnx.ai/onnx/operators/onnx__Flatten.html#flatten-9 "Online Documentation")
 
 
@@ -591,38 +477,21 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Flatten", 9, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Flatten", schema)
+        op = Op(self, "Flatten", schema)
         return op(*self._prepare_inputs(schema, input), axis=axis)
+
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def Gemm(
         self,
-        A: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        B: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        C: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
+        A: T,
+        B: T,
+        C: T,
         alpha: float = 1.0,
         beta: float = 1.0,
         transA: int = 0,
         transB: int = 0,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    ) -> T:
         r"""[🌐 Gemm(9)](https://onnx.ai/onnx/operators/onnx__Gemm.html#gemm-9 "Online Documentation")
 
         General Matrix multiplication:
@@ -658,9 +527,7 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Gemm", 9, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "Gemm", schema
-        )
+        op = Op(self, "Gemm", schema)
         return op(
             *self._prepare_inputs(schema, A, B, C),
             alpha=alpha,
@@ -669,15 +536,13 @@ class Opset9(Opset8):
             transB=transB,
         )
 
-    def Greater(
-        self,
-        A: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        B: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-    ) -> BOOL:
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Greater(self, A: T, B: T) -> T1:
         r"""[🌐 Greater(9)](https://onnx.ai/onnx/operators/onnx__Greater.html#greater-9 "Online Documentation")
 
 
@@ -694,10 +559,14 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Greater", 9, "")
-        op: Callable[..., BOOL] = Op(self, "Greater", schema)
+        op = Op(self, "Greater", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def IsNaN(self, X: Union[DOUBLE, FLOAT, FLOAT16]) -> BOOL:
+    T1 = TypeVar("T1", DOUBLE, FLOAT, FLOAT16)
+
+    T2 = TypeVar("T2", bound=BOOL)
+
+    def IsNaN(self, X: T1) -> T2:
         r"""[🌐 IsNaN(9)](https://onnx.ai/onnx/operators/onnx__IsNaN.html#isnan-9 "Online Documentation")
 
         Returns which elements of the input are NaN.
@@ -707,18 +576,16 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("IsNaN", 9, "")
-        op: Callable[..., BOOL] = Op(self, "IsNaN", schema)
+        op = Op(self, "IsNaN", schema)
         return op(*self._prepare_inputs(schema, X))
 
-    def Less(
-        self,
-        A: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        B: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-    ) -> BOOL:
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    T1 = TypeVar("T1", bound=BOOL)
+
+    def Less(self, A: T, B: T) -> T1:
         r"""[🌐 Less(9)](https://onnx.ai/onnx/operators/onnx__Less.html#less-9 "Online Documentation")
 
 
@@ -735,14 +602,12 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Less", 9, "")
-        op: Callable[..., BOOL] = Op(self, "Less", schema)
+        op = Op(self, "Less", schema)
         return op(*self._prepare_inputs(schema, A, B))
 
-    def MatMul(
-        self,
-        A: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        B: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def MatMul(self, A: T, B: T) -> T:
         r"""[🌐 MatMul(9)](https://onnx.ai/onnx/operators/onnx__MatMul.html#matmul-9 "Online Documentation")
 
 
@@ -756,20 +621,22 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("MatMul", 9, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "MatMul", schema
-        )
+        op = Op(self, "MatMul", schema)
         return op(*self._prepare_inputs(schema, A, B))
+
+    T1 = TypeVar("T1", DOUBLE, FLOAT, FLOAT16)
+
+    T2 = TypeVar("T2", bound=INT64)
 
     def MaxUnpool(
         self,
-        X: Union[DOUBLE, FLOAT, FLOAT16],
-        I: INT64,
-        output_shape: Optional[INT64] = None,
+        X: T1,
+        I: T2,
+        output_shape: Optional[T2] = None,
         kernel_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T1:
         r"""[🌐 MaxUnpool(9)](https://onnx.ai/onnx/operators/onnx__MaxUnpool.html#maxunpool-9 "Online Documentation")
 
 
@@ -832,7 +699,7 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("MaxUnpool", 9, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "MaxUnpool", schema)
+        op = Op(self, "MaxUnpool", schema)
         return op(
             *self._prepare_inputs(schema, X, I, output_shape),
             kernel_shape=kernel_shape,
@@ -840,9 +707,9 @@ class Opset9(Opset8):
             strides=strides,
         )
 
-    def MeanVarianceNormalization(
-        self, X: Union[DOUBLE, FLOAT, FLOAT16], axes: Sequence[int] = (0, 2, 3)
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def MeanVarianceNormalization(self, X: T, axes: Sequence[int] = (0, 2, 3)) -> T:
         r"""[🌐 MeanVarianceNormalization(9)](https://onnx.ai/onnx/operators/onnx__MeanVarianceNormalization.html#meanvariancenormalization-9 "Online Documentation")
 
 
@@ -860,76 +727,11 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("MeanVarianceNormalization", 9, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(
-            self, "MeanVarianceNormalization", schema
-        )
+        op = Op(self, "MeanVarianceNormalization", schema)
         return op(*self._prepare_inputs(schema, X), axes=axes)
 
-    def NonZero(
-        self,
-        X: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> INT64:
-        r"""[🌐 NonZero(9)](https://onnx.ai/onnx/operators/onnx__NonZero.html#nonzero-9 "Online Documentation")
-
-
-            Returns the indices of the elements that are non-zero
-            (in row-major order - by dimension).
-            NonZero behaves similar to numpy.nonzero:
-            https://docs.scipy.org/doc/numpy/reference/generated/numpy.nonzero.html,
-            but for scalar input, NonZero produces output shape (0, N) instead of (1, N), which is different from Numpy's behavior.
-
-
-        Args:
-            X: input
-        """
-
-        schema = get_schema("NonZero", 9, "")
-        op: Callable[..., INT64] = Op(self, "NonZero", schema)
-        return op(*self._prepare_inputs(schema, X))
-
-    def OneHot(
-        self,
-        indices: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        depth: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        values: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axis: int = -1,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -945,7 +747,55 @@ class Opset9(Opset8):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def NonZero(self, X: T) -> INT64:
+        r"""[🌐 NonZero(9)](https://onnx.ai/onnx/operators/onnx__NonZero.html#nonzero-9 "Online Documentation")
+
+
+            Returns the indices of the elements that are non-zero
+            (in row-major order - by dimension).
+            NonZero behaves similar to numpy.nonzero:
+            https://docs.scipy.org/doc/numpy/reference/generated/numpy.nonzero.html,
+            but for scalar input, NonZero produces output shape (0, N) instead of (1, N), which is different from Numpy's behavior.
+
+
+        Args:
+            X: input
+        """
+
+        schema = get_schema("NonZero", 9, "")
+        op = Op(self, "NonZero", schema)
+        return op(*self._prepare_inputs(schema, X))
+
+    T1 = TypeVar(
+        "T1", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    T2 = TypeVar(
+        "T2", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    T3 = TypeVar(
+        "T3",
+        BOOL,
+        COMPLEX128,
+        COMPLEX64,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    def OneHot(self, indices: T1, depth: T2, values: T3, axis: int = -1) -> T3:
         r"""[🌐 OneHot(9)](https://onnx.ai/onnx/operators/onnx__OneHot.html#onehot-9 "Online Documentation")
 
 
@@ -988,33 +838,12 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("OneHot", 9, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "OneHot", schema)
+        op = Op(self, "OneHot", schema)
         return op(*self._prepare_inputs(schema, indices, depth, values), axis=axis)
 
-    def PRelu(
-        self,
-        X: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-        slope: Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64],
-    ) -> Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
+
+    def PRelu(self, X: T, slope: T) -> T:
         r"""[🌐 PRelu(9)](https://onnx.ai/onnx/operators/onnx__PRelu.html#prelu-9 "Online Documentation")
 
 
@@ -1032,37 +861,11 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("PRelu", 9, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64]] = Op(
-            self, "PRelu", schema
-        )
+        op = Op(self, "PRelu", schema)
         return op(*self._prepare_inputs(schema, X, slope))
 
-    def Scan(
-        self,
-        *initial_state_and_scan_inputs: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        body: Optional[GraphProto] = None,
-        num_scan_inputs: Optional[int] = None,
-        scan_input_axes: Optional[Sequence[int]] = None,
-        scan_input_directions: Optional[Sequence[int]] = None,
-        scan_output_axes: Optional[Sequence[int]] = None,
-        scan_output_directions: Optional[Sequence[int]] = None,
-    ) -> Union[
+    V = TypeVar(
+        "V",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -1078,7 +881,18 @@ class Opset9(Opset8):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Scan(
+        self,
+        *initial_state_and_scan_inputs: V,
+        body: Optional[GraphProto] = None,
+        num_scan_inputs: Optional[int] = None,
+        scan_input_axes: Optional[Sequence[int]] = None,
+        scan_input_directions: Optional[Sequence[int]] = None,
+        scan_output_axes: Optional[Sequence[int]] = None,
+        scan_output_directions: Optional[Sequence[int]] = None,
+    ) -> V:
         r"""[🌐 Scan(9)](https://onnx.ai/onnx/operators/onnx__Scan.html#scan-9 "Online Documentation")
 
 
@@ -1243,26 +1057,7 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Scan", 9, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Scan", schema)
+        op = Op(self, "Scan", schema)
         return op(
             *self._prepare_inputs(schema, *initial_state_and_scan_inputs),
             body=body,
@@ -1273,45 +1068,8 @@ class Opset9(Opset8):
             scan_output_directions=scan_output_directions,
         )
 
-    def Scatter(
-        self,
-        data: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        indices: Union[INT32, INT64],
-        updates: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        axis: int = 0,
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -1327,7 +1085,11 @@ class Opset9(Opset8):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    Tind = TypeVar("Tind", INT32, INT64)
+
+    def Scatter(self, data: T, indices: Tind, updates: T, axis: int = 0) -> T:
         r"""[🌐 Scatter(9)](https://onnx.ai/onnx/operators/onnx__Scatter.html#scatter-9 "Online Documentation")
 
 
@@ -1376,38 +1138,14 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Scatter", 9, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Scatter", schema)
+        op = Op(self, "Scatter", schema)
         return op(*self._prepare_inputs(schema, data, indices, updates), axis=axis)
 
-    def Shrink(
-        self,
-        input: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-        bias: float = 0.0,
-        lambd: float = 0.5,
-    ) -> Union[
-        DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-    ]:
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    def Shrink(self, input: T, bias: float = 0.0, lambd: float = 0.5) -> T:
         r"""[🌐 Shrink(9)](https://onnx.ai/onnx/operators/onnx__Shrink.html#shrink-9 "Online Documentation")
 
 
@@ -1426,32 +1164,14 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Shrink", 9, "")
-        op: Callable[
-            ...,
-            Union[
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Shrink", schema)
+        op = Op(self, "Shrink", schema)
         return op(*self._prepare_inputs(schema, input), bias=bias, lambd=lambd)
 
-    def Sign(
-        self,
-        input: Union[
-            DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-        ],
-    ) -> Union[
-        DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
-    ]:
+    T = TypeVar(
+        "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
+    )
+
+    def Sign(self, input: T) -> T:
         r"""[🌐 Sign(9)](https://onnx.ai/onnx/operators/onnx__Sign.html#sign-9 "Online Documentation")
 
 
@@ -1464,25 +1184,12 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Sign", 9, "")
-        op: Callable[
-            ...,
-            Union[
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Sign", schema)
+        op = Op(self, "Sign", schema)
         return op(*self._prepare_inputs(schema, input))
 
-    def Sinh(self, input: Union[DOUBLE, FLOAT, FLOAT16]) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
+
+    def Sinh(self, input: T) -> T:
         r"""[🌐 Sinh(9)](https://onnx.ai/onnx/operators/onnx__Sinh.html#sinh-9 "Online Documentation")
 
 
@@ -1494,12 +1201,16 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Sinh", 9, "")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Sinh", schema)
+        op = Op(self, "Sinh", schema)
         return op(*self._prepare_inputs(schema, input))
+
+    T = TypeVar("T", INT32, INT64, STRING)
+
+    T1 = TypeVar("T1", bound=FLOAT)
 
     def TfIdfVectorizer(
         self,
-        X: Union[INT32, INT64, STRING],
+        X: T,
         max_gram_length: Optional[int] = None,
         max_skip_count: Optional[int] = None,
         min_gram_length: Optional[int] = None,
@@ -1509,7 +1220,7 @@ class Opset9(Opset8):
         pool_int64s: Optional[Sequence[int]] = None,
         pool_strings: Optional[Sequence[str]] = None,
         weights: Optional[Sequence[float]] = None,
-    ) -> FLOAT:
+    ) -> T1:
         r"""[🌐 TfIdfVectorizer(9)](https://onnx.ai/onnx/operators/onnx__TfIdfVectorizer.html#tfidfvectorizer-9 "Online Documentation")
 
 
@@ -1594,7 +1305,7 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("TfIdfVectorizer", 9, "")
-        op: Callable[..., FLOAT] = Op(self, "TfIdfVectorizer", schema)
+        op = Op(self, "TfIdfVectorizer", schema)
         return op(
             *self._prepare_inputs(schema, X),
             max_gram_length=max_gram_length,
@@ -1608,28 +1319,8 @@ class Opset9(Opset8):
             weights=weights,
         )
 
-    def Upsample(
-        self,
-        X: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        scales: FLOAT,
-        mode: str = "nearest",
-    ) -> Union[
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -1645,7 +1336,9 @@ class Opset9(Opset8):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Upsample(self, X: T, scales: FLOAT, mode: str = "nearest") -> T:
         r"""[🌐 Upsample(9)](https://onnx.ai/onnx/operators/onnx__Upsample.html#upsample-9 "Online Documentation")
 
 
@@ -1666,66 +1359,13 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Upsample", 9, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Upsample", schema)
+        op = Op(self, "Upsample", schema)
         return op(*self._prepare_inputs(schema, X, scales), mode=mode)
 
-    def Where(
-        self,
-        condition: BOOL,
-        X: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-        Y: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
-    ) -> Union[
+    B = TypeVar("B", bound=BOOL)
+
+    T = TypeVar(
+        "T",
         BOOL,
         COMPLEX128,
         COMPLEX64,
@@ -1741,7 +1381,9 @@ class Opset9(Opset8):
         UINT32,
         UINT64,
         UINT8,
-    ]:
+    )
+
+    def Where(self, condition: B, X: T, Y: T) -> T:
         r"""[🌐 Where(9)](https://onnx.ai/onnx/operators/onnx__Where.html#where-9 "Online Documentation")
 
 
@@ -1762,24 +1404,5 @@ class Opset9(Opset8):
         """
 
         schema = get_schema("Where", 9, "")
-        op: Callable[
-            ...,
-            Union[
-                BOOL,
-                COMPLEX128,
-                COMPLEX64,
-                DOUBLE,
-                FLOAT,
-                FLOAT16,
-                INT16,
-                INT32,
-                INT64,
-                INT8,
-                STRING,
-                UINT16,
-                UINT32,
-                UINT64,
-                UINT8,
-            ],
-        ] = Op(self, "Where", schema)
+        op = Op(self, "Where", schema)
         return op(*self._prepare_inputs(schema, condition, X, Y))

--- a/onnxscript/onnx_opset/_impl/opset_ai_onnx_ml1.py
+++ b/onnxscript/onnx_opset/_impl/opset_ai_onnx_ml1.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Mapping, Optional, Sequence, Tuple, Union
+from typing import Mapping, Optional, Sequence, Tuple, TypeVar
 
 from onnx.defs import get_schema
 
@@ -25,9 +25,9 @@ class Opset_ai_onnx_ml1(Opset):
     def __init__(self):
         super().__init__()
 
-    def ArrayFeatureExtractor(
-        self, X: Union[DOUBLE, FLOAT, INT32, INT64, STRING], Y: INT64
-    ) -> Union[DOUBLE, FLOAT, INT32, INT64, STRING]:
+    T = TypeVar("T", DOUBLE, FLOAT, INT32, INT64, STRING)
+
+    def ArrayFeatureExtractor(self, X: T, Y: INT64) -> T:
         r"""[🌐 ai.onnx.ml::ArrayFeatureExtractor(1)](https://onnx.ai/onnx/operators/onnx_aionnxml_ArrayFeatureExtractor.html#arrayfeatureextractor-1 "Online Documentation")
 
 
@@ -43,14 +43,12 @@ class Opset_ai_onnx_ml1(Opset):
         """
 
         schema = get_schema("ArrayFeatureExtractor", 1, "ai.onnx.ml")
-        op: Callable[..., Union[DOUBLE, FLOAT, INT32, INT64, STRING]] = Op(
-            self, "ArrayFeatureExtractor", schema
-        )
+        op = Op(self, "ArrayFeatureExtractor", schema)
         return op(*self._prepare_inputs(schema, X, Y))
 
-    def Binarizer(
-        self, X: Union[DOUBLE, FLOAT, INT32, INT64], threshold: float = 0.0
-    ) -> Union[DOUBLE, FLOAT, INT32, INT64]:
+    T = TypeVar("T", DOUBLE, FLOAT, INT32, INT64)
+
+    def Binarizer(self, X: T, threshold: float = 0.0) -> T:
         r"""[🌐 ai.onnx.ml::Binarizer(1)](https://onnx.ai/onnx/operators/onnx_aionnxml_Binarizer.html#binarizer-1 "Online Documentation")
 
 
@@ -64,16 +62,16 @@ class Opset_ai_onnx_ml1(Opset):
         """
 
         schema = get_schema("Binarizer", 1, "ai.onnx.ml")
-        op: Callable[..., Union[DOUBLE, FLOAT, INT32, INT64]] = Op(self, "Binarizer", schema)
+        op = Op(self, "Binarizer", schema)
         return op(*self._prepare_inputs(schema, X), threshold=threshold)
 
+    T1 = TypeVar("T1", Mapping[int, FLOAT], Mapping[int, STRING])
+
+    T2 = TypeVar("T2", FLOAT, INT64, STRING)
+
     def CastMap(
-        self,
-        X: Union[Mapping[int, FLOAT], Mapping[int, STRING]],
-        cast_to: str = "TO_FLOAT",
-        map_form: str = "DENSE",
-        max_map: int = 1,
-    ) -> Union[FLOAT, INT64, STRING]:
+        self, X: T1, cast_to: str = "TO_FLOAT", map_form: str = "DENSE", max_map: int = 1
+    ) -> T2:
         r"""[🌐 ai.onnx.ml::CastMap(1)](https://onnx.ai/onnx/operators/onnx_aionnxml_CastMap.html#castmap-1 "Online Documentation")
 
 
@@ -99,7 +97,7 @@ class Opset_ai_onnx_ml1(Opset):
         """
 
         schema = get_schema("CastMap", 1, "ai.onnx.ml")
-        op: Callable[..., Union[FLOAT, INT64, STRING]] = Op(self, "CastMap", schema)
+        op = Op(self, "CastMap", schema)
         return op(
             *self._prepare_inputs(schema, X),
             cast_to=cast_to,
@@ -107,14 +105,18 @@ class Opset_ai_onnx_ml1(Opset):
             max_map=max_map,
         )
 
+    T1 = TypeVar("T1", INT64, STRING)
+
+    T2 = TypeVar("T2", INT64, STRING)
+
     def CategoryMapper(
         self,
-        X: Union[INT64, STRING],
+        X: T1,
         cats_int64s: Optional[Sequence[int]] = None,
         cats_strings: Optional[Sequence[str]] = None,
         default_int64: int = -1,
         default_string: str = "_Unused",
-    ) -> Union[INT64, STRING]:
+    ) -> T2:
         r"""[🌐 ai.onnx.ml::CategoryMapper(1)](https://onnx.ai/onnx/operators/onnx_aionnxml_CategoryMapper.html#categorymapper-1 "Online Documentation")
 
 
@@ -150,7 +152,7 @@ class Opset_ai_onnx_ml1(Opset):
         """
 
         schema = get_schema("CategoryMapper", 1, "ai.onnx.ml")
-        op: Callable[..., Union[INT64, STRING]] = Op(self, "CategoryMapper", schema)
+        op = Op(self, "CategoryMapper", schema)
         return op(
             *self._prepare_inputs(schema, X),
             cats_int64s=cats_int64s,
@@ -159,19 +161,24 @@ class Opset_ai_onnx_ml1(Opset):
             default_string=default_string,
         )
 
+    T1 = TypeVar(
+        "T1",
+        Mapping[int, DOUBLE],
+        Mapping[int, FLOAT],
+        Mapping[int, STRING],
+        Mapping[str, DOUBLE],
+        Mapping[str, FLOAT],
+        Mapping[str, INT64],
+    )
+
+    T2 = TypeVar("T2", DOUBLE, FLOAT, INT64, STRING)
+
     def DictVectorizer(
         self,
-        X: Union[
-            Mapping[int, DOUBLE],
-            Mapping[int, FLOAT],
-            Mapping[int, STRING],
-            Mapping[str, DOUBLE],
-            Mapping[str, FLOAT],
-            Mapping[str, INT64],
-        ],
+        X: T1,
         int64_vocabulary: Optional[Sequence[int]] = None,
         string_vocabulary: Optional[Sequence[str]] = None,
-    ) -> Union[DOUBLE, FLOAT, INT64, STRING]:
+    ) -> T2:
         r"""[🌐 ai.onnx.ml::DictVectorizer(1)](https://onnx.ai/onnx/operators/onnx_aionnxml_DictVectorizer.html#dictvectorizer-1 "Online Documentation")
 
 
@@ -202,19 +209,17 @@ class Opset_ai_onnx_ml1(Opset):
         """
 
         schema = get_schema("DictVectorizer", 1, "ai.onnx.ml")
-        op: Callable[..., Union[DOUBLE, FLOAT, INT64, STRING]] = Op(
-            self, "DictVectorizer", schema
-        )
+        op = Op(self, "DictVectorizer", schema)
         return op(
             *self._prepare_inputs(schema, X),
             int64_vocabulary=int64_vocabulary,
             string_vocabulary=string_vocabulary,
         )
 
+    T1 = TypeVar("T1", DOUBLE, FLOAT, INT32, INT64)
+
     def FeatureVectorizer(
-        self,
-        *X: Union[DOUBLE, FLOAT, INT32, INT64],
-        inputdimensions: Optional[Sequence[int]] = None,
+        self, *X: T1, inputdimensions: Optional[Sequence[int]] = None
     ) -> FLOAT:
         r"""[🌐 ai.onnx.ml::FeatureVectorizer(1)](https://onnx.ai/onnx/operators/onnx_aionnxml_FeatureVectorizer.html#featurevectorizer-1 "Online Documentation")
 
@@ -235,17 +240,19 @@ class Opset_ai_onnx_ml1(Opset):
         """
 
         schema = get_schema("FeatureVectorizer", 1, "ai.onnx.ml")
-        op: Callable[..., FLOAT] = Op(self, "FeatureVectorizer", schema)
+        op = Op(self, "FeatureVectorizer", schema)
         return op(*self._prepare_inputs(schema, *X), inputdimensions=inputdimensions)
+
+    T = TypeVar("T", DOUBLE, FLOAT, INT32, INT64)
 
     def Imputer(
         self,
-        X: Union[DOUBLE, FLOAT, INT32, INT64],
+        X: T,
         imputed_value_floats: Optional[Sequence[float]] = None,
         imputed_value_int64s: Optional[Sequence[int]] = None,
         replaced_value_float: float = 0.0,
         replaced_value_int64: int = 0,
-    ) -> Union[DOUBLE, FLOAT, INT32, INT64]:
+    ) -> T:
         r"""[🌐 ai.onnx.ml::Imputer(1)](https://onnx.ai/onnx/operators/onnx_aionnxml_Imputer.html#imputer-1 "Online Documentation")
 
 
@@ -276,7 +283,7 @@ class Opset_ai_onnx_ml1(Opset):
         """
 
         schema = get_schema("Imputer", 1, "ai.onnx.ml")
-        op: Callable[..., Union[DOUBLE, FLOAT, INT32, INT64]] = Op(self, "Imputer", schema)
+        op = Op(self, "Imputer", schema)
         return op(
             *self._prepare_inputs(schema, X),
             imputed_value_floats=imputed_value_floats,
@@ -285,13 +292,17 @@ class Opset_ai_onnx_ml1(Opset):
             replaced_value_int64=replaced_value_int64,
         )
 
+    T1 = TypeVar("T1", INT64, STRING)
+
+    T2 = TypeVar("T2", INT64, STRING)
+
     def LabelEncoder(
         self,
-        X: Union[INT64, STRING],
+        X: T1,
         classes_strings: Optional[Sequence[str]] = None,
         default_int64: int = -1,
         default_string: str = "_Unused",
-    ) -> Union[INT64, STRING]:
+    ) -> T2:
         r"""[🌐 ai.onnx.ml::LabelEncoder(1)](https://onnx.ai/onnx/operators/onnx_aionnxml_LabelEncoder.html#labelencoder-1 "Online Documentation")
 
 
@@ -326,7 +337,7 @@ class Opset_ai_onnx_ml1(Opset):
         """
 
         schema = get_schema("LabelEncoder", 1, "ai.onnx.ml")
-        op: Callable[..., Union[INT64, STRING]] = Op(self, "LabelEncoder", schema)
+        op = Op(self, "LabelEncoder", schema)
         return op(
             *self._prepare_inputs(schema, X),
             classes_strings=classes_strings,
@@ -334,16 +345,20 @@ class Opset_ai_onnx_ml1(Opset):
             default_string=default_string,
         )
 
+    T1 = TypeVar("T1", DOUBLE, FLOAT, INT32, INT64)
+
+    T2 = TypeVar("T2", INT64, STRING)
+
     def LinearClassifier(
         self,
-        X: Union[DOUBLE, FLOAT, INT32, INT64],
+        X: T1,
         classlabels_ints: Optional[Sequence[int]] = None,
         classlabels_strings: Optional[Sequence[str]] = None,
         coefficients: Optional[Sequence[float]] = None,
         intercepts: Optional[Sequence[float]] = None,
         multi_class: int = 0,
         post_transform: str = "NONE",
-    ) -> Tuple[Union[INT64, STRING], FLOAT]:
+    ) -> Tuple[T2, FLOAT]:
         r"""[🌐 ai.onnx.ml::LinearClassifier(1)](https://onnx.ai/onnx/operators/onnx_aionnxml_LinearClassifier.html#linearclassifier-1 "Online Documentation")
 
 
@@ -372,9 +387,7 @@ class Opset_ai_onnx_ml1(Opset):
         """
 
         schema = get_schema("LinearClassifier", 1, "ai.onnx.ml")
-        op: Callable[..., Tuple[Union[INT64, STRING], FLOAT]] = Op(
-            self, "LinearClassifier", schema
-        )
+        op = Op(self, "LinearClassifier", schema)
         return op(
             *self._prepare_inputs(schema, X),
             classlabels_ints=classlabels_ints,
@@ -385,9 +398,11 @@ class Opset_ai_onnx_ml1(Opset):
             post_transform=post_transform,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, INT32, INT64)
+
     def LinearRegressor(
         self,
-        X: Union[DOUBLE, FLOAT, INT32, INT64],
+        X: T,
         coefficients: Optional[Sequence[float]] = None,
         intercepts: Optional[Sequence[float]] = None,
         post_transform: str = "NONE",
@@ -422,7 +437,7 @@ class Opset_ai_onnx_ml1(Opset):
         """
 
         schema = get_schema("LinearRegressor", 1, "ai.onnx.ml")
-        op: Callable[..., FLOAT] = Op(self, "LinearRegressor", schema)
+        op = Op(self, "LinearRegressor", schema)
         return op(
             *self._prepare_inputs(schema, X),
             coefficients=coefficients,
@@ -431,7 +446,9 @@ class Opset_ai_onnx_ml1(Opset):
             targets=targets,
         )
 
-    def Normalizer(self, X: Union[DOUBLE, FLOAT, INT32, INT64], norm: str = "MAX") -> FLOAT:
+    T = TypeVar("T", DOUBLE, FLOAT, INT32, INT64)
+
+    def Normalizer(self, X: T, norm: str = "MAX") -> FLOAT:
         r"""[🌐 ai.onnx.ml::Normalizer(1)](https://onnx.ai/onnx/operators/onnx_aionnxml_Normalizer.html#normalizer-1 "Online Documentation")
 
 
@@ -460,12 +477,14 @@ class Opset_ai_onnx_ml1(Opset):
         """
 
         schema = get_schema("Normalizer", 1, "ai.onnx.ml")
-        op: Callable[..., FLOAT] = Op(self, "Normalizer", schema)
+        op = Op(self, "Normalizer", schema)
         return op(*self._prepare_inputs(schema, X), norm=norm)
+
+    T = TypeVar("T", DOUBLE, FLOAT, INT32, INT64, STRING)
 
     def OneHotEncoder(
         self,
-        X: Union[DOUBLE, FLOAT, INT32, INT64, STRING],
+        X: T,
         cats_int64s: Optional[Sequence[int]] = None,
         cats_strings: Optional[Sequence[str]] = None,
         zeros: int = 1,
@@ -500,7 +519,7 @@ class Opset_ai_onnx_ml1(Opset):
         """
 
         schema = get_schema("OneHotEncoder", 1, "ai.onnx.ml")
-        op: Callable[..., FLOAT] = Op(self, "OneHotEncoder", schema)
+        op = Op(self, "OneHotEncoder", schema)
         return op(
             *self._prepare_inputs(schema, X),
             cats_int64s=cats_int64s,
@@ -508,9 +527,13 @@ class Opset_ai_onnx_ml1(Opset):
             zeros=zeros,
         )
 
+    T1 = TypeVar("T1", DOUBLE, FLOAT, INT32, INT64)
+
+    T2 = TypeVar("T2", INT64, STRING)
+
     def SVMClassifier(
         self,
-        X: Union[DOUBLE, FLOAT, INT32, INT64],
+        X: T1,
         classlabels_ints: Optional[Sequence[int]] = None,
         classlabels_strings: Optional[Sequence[str]] = None,
         coefficients: Optional[Sequence[float]] = None,
@@ -522,7 +545,7 @@ class Opset_ai_onnx_ml1(Opset):
         rho: Optional[Sequence[float]] = None,
         support_vectors: Optional[Sequence[float]] = None,
         vectors_per_class: Optional[Sequence[int]] = None,
-    ) -> Tuple[Union[INT64, STRING], FLOAT]:
+    ) -> Tuple[T2, FLOAT]:
         r"""[🌐 ai.onnx.ml::SVMClassifier(1)](https://onnx.ai/onnx/operators/onnx_aionnxml_SVMClassifier.html#svmclassifier-1 "Online Documentation")
 
 
@@ -554,9 +577,7 @@ class Opset_ai_onnx_ml1(Opset):
         """
 
         schema = get_schema("SVMClassifier", 1, "ai.onnx.ml")
-        op: Callable[..., Tuple[Union[INT64, STRING], FLOAT]] = Op(
-            self, "SVMClassifier", schema
-        )
+        op = Op(self, "SVMClassifier", schema)
         return op(
             *self._prepare_inputs(schema, X),
             classlabels_ints=classlabels_ints,
@@ -572,9 +593,11 @@ class Opset_ai_onnx_ml1(Opset):
             vectors_per_class=vectors_per_class,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, INT32, INT64)
+
     def SVMRegressor(
         self,
-        X: Union[DOUBLE, FLOAT, INT32, INT64],
+        X: T,
         coefficients: Optional[Sequence[float]] = None,
         kernel_params: Optional[Sequence[float]] = None,
         kernel_type: str = "LINEAR",
@@ -611,7 +634,7 @@ class Opset_ai_onnx_ml1(Opset):
         """
 
         schema = get_schema("SVMRegressor", 1, "ai.onnx.ml")
-        op: Callable[..., FLOAT] = Op(self, "SVMRegressor", schema)
+        op = Op(self, "SVMRegressor", schema)
         return op(
             *self._prepare_inputs(schema, X),
             coefficients=coefficients,
@@ -624,9 +647,11 @@ class Opset_ai_onnx_ml1(Opset):
             support_vectors=support_vectors,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, INT32, INT64)
+
     def Scaler(
         self,
-        X: Union[DOUBLE, FLOAT, INT32, INT64],
+        X: T,
         offset: Optional[Sequence[float]] = None,
         scale: Optional[Sequence[float]] = None,
     ) -> FLOAT:
@@ -649,12 +674,16 @@ class Opset_ai_onnx_ml1(Opset):
         """
 
         schema = get_schema("Scaler", 1, "ai.onnx.ml")
-        op: Callable[..., FLOAT] = Op(self, "Scaler", schema)
+        op = Op(self, "Scaler", schema)
         return op(*self._prepare_inputs(schema, X), offset=offset, scale=scale)
+
+    T1 = TypeVar("T1", DOUBLE, FLOAT, INT32, INT64)
+
+    T2 = TypeVar("T2", INT64, STRING)
 
     def TreeEnsembleClassifier(
         self,
-        X: Union[DOUBLE, FLOAT, INT32, INT64],
+        X: T1,
         base_values: Optional[Sequence[float]] = None,
         class_ids: Optional[Sequence[int]] = None,
         class_nodeids: Optional[Sequence[int]] = None,
@@ -672,7 +701,7 @@ class Opset_ai_onnx_ml1(Opset):
         nodes_truenodeids: Optional[Sequence[int]] = None,
         nodes_values: Optional[Sequence[float]] = None,
         post_transform: str = "NONE",
-    ) -> Tuple[Union[INT64, STRING], FLOAT]:
+    ) -> Tuple[T2, FLOAT]:
         r"""[🌐 ai.onnx.ml::TreeEnsembleClassifier(1)](https://onnx.ai/onnx/operators/onnx_aionnxml_TreeEnsembleClassifier.html#treeensembleclassifier-1 "Online Documentation")
 
 
@@ -742,9 +771,7 @@ class Opset_ai_onnx_ml1(Opset):
         """
 
         schema = get_schema("TreeEnsembleClassifier", 1, "ai.onnx.ml")
-        op: Callable[..., Tuple[Union[INT64, STRING], FLOAT]] = Op(
-            self, "TreeEnsembleClassifier", schema
-        )
+        op = Op(self, "TreeEnsembleClassifier", schema)
         return op(
             *self._prepare_inputs(schema, X),
             base_values=base_values,
@@ -766,9 +793,11 @@ class Opset_ai_onnx_ml1(Opset):
             post_transform=post_transform,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, INT32, INT64)
+
     def TreeEnsembleRegressor(
         self,
-        X: Union[DOUBLE, FLOAT, INT32, INT64],
+        X: T,
         aggregate_function: str = "SUM",
         base_values: Optional[Sequence[float]] = None,
         n_targets: Optional[int] = None,
@@ -859,7 +888,7 @@ class Opset_ai_onnx_ml1(Opset):
         """
 
         schema = get_schema("TreeEnsembleRegressor", 1, "ai.onnx.ml")
-        op: Callable[..., FLOAT] = Op(self, "TreeEnsembleRegressor", schema)
+        op = Op(self, "TreeEnsembleRegressor", schema)
         return op(
             *self._prepare_inputs(schema, X),
             aggregate_function=aggregate_function,
@@ -881,12 +910,14 @@ class Opset_ai_onnx_ml1(Opset):
             target_weights=target_weights,
         )
 
+    T = TypeVar("T", Sequence[Mapping[int, FLOAT]], Sequence[Mapping[str, FLOAT]])
+
     def ZipMap(
         self,
         X: FLOAT,
         classlabels_int64s: Optional[Sequence[int]] = None,
         classlabels_strings: Optional[Sequence[str]] = None,
-    ) -> Union[Sequence[Mapping[int, FLOAT]], Sequence[Mapping[str, FLOAT]]]:
+    ) -> T:
         r"""[🌐 ai.onnx.ml::ZipMap(1)](https://onnx.ai/onnx/operators/onnx_aionnxml_ZipMap.html#zipmap-1 "Online Documentation")
 
 
@@ -910,9 +941,7 @@ class Opset_ai_onnx_ml1(Opset):
         """
 
         schema = get_schema("ZipMap", 1, "ai.onnx.ml")
-        op: Callable[
-            ..., Union[Sequence[Mapping[int, FLOAT]], Sequence[Mapping[str, FLOAT]]]
-        ] = Op(self, "ZipMap", schema)
+        op = Op(self, "ZipMap", schema)
         return op(
             *self._prepare_inputs(schema, X),
             classlabels_int64s=classlabels_int64s,

--- a/onnxscript/onnx_opset/_impl/opset_ai_onnx_ml2.py
+++ b/onnxscript/onnx_opset/_impl/opset_ai_onnx_ml2.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Sequence, Union
+from typing import Optional, Sequence, TypeVar
 
 from onnx.defs import get_schema
 
@@ -26,9 +26,13 @@ class Opset_ai_onnx_ml2(Opset_ai_onnx_ml1):
     def __init__(self):
         super().__init__()
 
+    T1 = TypeVar("T1", FLOAT, INT64, STRING)
+
+    T2 = TypeVar("T2", FLOAT, INT64, STRING)
+
     def LabelEncoder(
         self,
-        X: Union[FLOAT, INT64, STRING],
+        X: T1,
         default_float: float = -0.0,
         default_int64: int = -1,
         default_string: str = "_Unused",
@@ -38,7 +42,7 @@ class Opset_ai_onnx_ml2(Opset_ai_onnx_ml1):
         values_floats: Optional[Sequence[float]] = None,
         values_int64s: Optional[Sequence[int]] = None,
         values_strings: Optional[Sequence[str]] = None,
-    ) -> Union[FLOAT, INT64, STRING]:
+    ) -> T2:
         r"""[🌐 ai.onnx.ml::LabelEncoder(2)](https://onnx.ai/onnx/operators/onnx_aionnxml_LabelEncoder.html#labelencoder-2 "Online Documentation")
 
 
@@ -91,7 +95,7 @@ class Opset_ai_onnx_ml2(Opset_ai_onnx_ml1):
         """
 
         schema = get_schema("LabelEncoder", 2, "ai.onnx.ml")
-        op: Callable[..., Union[FLOAT, INT64, STRING]] = Op(self, "LabelEncoder", schema)
+        op = Op(self, "LabelEncoder", schema)
         return op(
             *self._prepare_inputs(schema, X),
             default_float=default_float,

--- a/onnxscript/onnx_opset/_impl/opset_ai_onnx_ml3.py
+++ b/onnxscript/onnx_opset/_impl/opset_ai_onnx_ml3.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Tuple, TypeVar
 
 from onnx import TensorProto
 from onnx.defs import get_schema
@@ -27,9 +27,13 @@ class Opset_ai_onnx_ml3(Opset_ai_onnx_ml2):
     def __init__(self):
         super().__init__()
 
+    T1 = TypeVar("T1", DOUBLE, FLOAT, INT32, INT64)
+
+    T2 = TypeVar("T2", INT64, STRING)
+
     def TreeEnsembleClassifier(
         self,
-        X: Union[DOUBLE, FLOAT, INT32, INT64],
+        X: T1,
         base_values: Optional[Sequence[float]] = None,
         base_values_as_tensor: Optional[TensorProto] = None,
         class_ids: Optional[Sequence[int]] = None,
@@ -51,7 +55,7 @@ class Opset_ai_onnx_ml3(Opset_ai_onnx_ml2):
         nodes_values: Optional[Sequence[float]] = None,
         nodes_values_as_tensor: Optional[TensorProto] = None,
         post_transform: str = "NONE",
-    ) -> Tuple[Union[INT64, STRING], FLOAT]:
+    ) -> Tuple[T2, FLOAT]:
         r"""[🌐 ai.onnx.ml::TreeEnsembleClassifier(3)](https://onnx.ai/onnx/operators/onnx_aionnxml_TreeEnsembleClassifier.html#treeensembleclassifier-3 "Online Documentation")
 
 
@@ -134,9 +138,7 @@ class Opset_ai_onnx_ml3(Opset_ai_onnx_ml2):
         """
 
         schema = get_schema("TreeEnsembleClassifier", 3, "ai.onnx.ml")
-        op: Callable[..., Tuple[Union[INT64, STRING], FLOAT]] = Op(
-            self, "TreeEnsembleClassifier", schema
-        )
+        op = Op(self, "TreeEnsembleClassifier", schema)
         return op(
             *self._prepare_inputs(schema, X),
             base_values=base_values,
@@ -162,9 +164,11 @@ class Opset_ai_onnx_ml3(Opset_ai_onnx_ml2):
             post_transform=post_transform,
         )
 
+    T = TypeVar("T", DOUBLE, FLOAT, INT32, INT64)
+
     def TreeEnsembleRegressor(
         self,
-        X: Union[DOUBLE, FLOAT, INT32, INT64],
+        X: T,
         aggregate_function: str = "SUM",
         base_values: Optional[Sequence[float]] = None,
         base_values_as_tensor: Optional[TensorProto] = None,
@@ -272,7 +276,7 @@ class Opset_ai_onnx_ml3(Opset_ai_onnx_ml2):
         """
 
         schema = get_schema("TreeEnsembleRegressor", 3, "ai.onnx.ml")
-        op: Callable[..., FLOAT] = Op(self, "TreeEnsembleRegressor", schema)
+        op = Op(self, "TreeEnsembleRegressor", schema)
         return op(
             *self._prepare_inputs(schema, X),
             aggregate_function=aggregate_function,

--- a/onnxscript/onnx_opset/_impl/opset_ai_onnx_preview_training1.py
+++ b/onnxscript/onnx_opset/_impl/opset_ai_onnx_preview_training1.py
@@ -10,7 +10,7 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
-from typing import Callable, Optional, Sequence, Union
+from typing import Optional, Sequence, TypeVar
 
 from onnx.defs import get_schema
 
@@ -41,15 +41,21 @@ class Opset_ai_onnx_preview_training1(Opset):
     def __init__(self):
         super().__init__()
 
+    T1 = TypeVar("T1", DOUBLE, FLOAT)
+
+    T2 = TypeVar("T2", bound=INT64)
+
+    T3 = TypeVar("T3", DOUBLE, FLOAT)
+
     def Adagrad(
         self,
-        R: Union[DOUBLE, FLOAT],
-        T: INT64,
-        *inputs: Union[DOUBLE, FLOAT],
+        R: T1,
+        T: T2,
+        *inputs: T3,
         decay_factor: float = 0.0,
         epsilon: float = 9.999999974752427e-07,
         norm_coefficient: float = 0.0,
-    ) -> Union[DOUBLE, FLOAT]:
+    ) -> T3:
         r"""[🌐 ai.onnx.preview.training::Adagrad(1)](https://onnx.ai/onnx/operators/onnx_aionnxpreviewtraining_Adagrad.html#adagrad-1 "Online Documentation")
 
 
@@ -129,7 +135,7 @@ class Opset_ai_onnx_preview_training1(Opset):
         """
 
         schema = get_schema("Adagrad", 1, "ai.onnx.preview.training")
-        op: Callable[..., Union[DOUBLE, FLOAT]] = Op(self, "Adagrad", schema)
+        op = Op(self, "Adagrad", schema)
         return op(
             *self._prepare_inputs(schema, R, T, *inputs),
             decay_factor=decay_factor,
@@ -137,17 +143,23 @@ class Opset_ai_onnx_preview_training1(Opset):
             norm_coefficient=norm_coefficient,
         )
 
+    T1 = TypeVar("T1", DOUBLE, FLOAT)
+
+    T2 = TypeVar("T2", bound=INT64)
+
+    T3 = TypeVar("T3", DOUBLE, FLOAT)
+
     def Adam(
         self,
-        R: Union[DOUBLE, FLOAT],
-        T: INT64,
-        *inputs: Union[DOUBLE, FLOAT],
+        R: T1,
+        T: T2,
+        *inputs: T3,
         alpha: float = 0.8999999761581421,
         beta: float = 0.9990000128746033,
         epsilon: float = 9.999999974752427e-07,
         norm_coefficient: float = 0.0,
         norm_coefficient_post: float = 0.0,
-    ) -> Union[DOUBLE, FLOAT]:
+    ) -> T3:
         r"""[🌐 ai.onnx.preview.training::Adam(1)](https://onnx.ai/onnx/operators/onnx_aionnxpreviewtraining_Adam.html#adam-1 "Online Documentation")
 
 
@@ -244,7 +256,7 @@ class Opset_ai_onnx_preview_training1(Opset):
         """
 
         schema = get_schema("Adam", 1, "ai.onnx.preview.training")
-        op: Callable[..., Union[DOUBLE, FLOAT]] = Op(self, "Adam", schema)
+        op = Op(self, "Adam", schema)
         return op(
             *self._prepare_inputs(schema, R, T, *inputs),
             alpha=alpha,
@@ -254,29 +266,34 @@ class Opset_ai_onnx_preview_training1(Opset):
             norm_coefficient_post=norm_coefficient_post,
         )
 
+    T1 = TypeVar(
+        "T1",
+        BOOL,
+        COMPLEX128,
+        COMPLEX64,
+        DOUBLE,
+        FLOAT,
+        FLOAT16,
+        INT16,
+        INT32,
+        INT64,
+        INT8,
+        STRING,
+        UINT16,
+        UINT32,
+        UINT64,
+        UINT8,
+    )
+
+    T2 = TypeVar("T2", DOUBLE, FLOAT, FLOAT16)
+
     def Gradient(
         self,
-        *Inputs: Union[
-            BOOL,
-            COMPLEX128,
-            COMPLEX64,
-            DOUBLE,
-            FLOAT,
-            FLOAT16,
-            INT16,
-            INT32,
-            INT64,
-            INT8,
-            STRING,
-            UINT16,
-            UINT32,
-            UINT64,
-            UINT8,
-        ],
+        *Inputs: T1,
         xs: Optional[Sequence[str]] = None,
         y: Optional[str] = None,
         zs: Optional[Sequence[str]] = None,
-    ) -> Union[DOUBLE, FLOAT, FLOAT16]:
+    ) -> T2:
         r"""[🌐 ai.onnx.preview.training::Gradient(1)](https://onnx.ai/onnx/operators/onnx_aionnxpreviewtraining_Gradient.html#gradient-1 "Online Documentation")
 
 
@@ -441,19 +458,25 @@ class Opset_ai_onnx_preview_training1(Opset):
         """
 
         schema = get_schema("Gradient", 1, "ai.onnx.preview.training")
-        op: Callable[..., Union[DOUBLE, FLOAT, FLOAT16]] = Op(self, "Gradient", schema)
+        op = Op(self, "Gradient", schema)
         return op(*self._prepare_inputs(schema, *Inputs), xs=xs, y=y, zs=zs)
+
+    T1 = TypeVar("T1", DOUBLE, FLOAT)
+
+    T2 = TypeVar("T2", bound=INT64)
+
+    T3 = TypeVar("T3", DOUBLE, FLOAT)
 
     def Momentum(
         self,
-        R: Union[DOUBLE, FLOAT],
-        T: INT64,
-        *inputs: Union[DOUBLE, FLOAT],
+        R: T1,
+        T: T2,
+        *inputs: T3,
         alpha: Optional[float] = None,
         beta: Optional[float] = None,
         mode: Optional[str] = None,
         norm_coefficient: Optional[float] = None,
-    ) -> Union[DOUBLE, FLOAT]:
+    ) -> T3:
         r"""[🌐 ai.onnx.preview.training::Momentum(1)](https://onnx.ai/onnx/operators/onnx_aionnxpreviewtraining_Momentum.html#momentum-1 "Online Documentation")
 
 
@@ -543,7 +566,7 @@ class Opset_ai_onnx_preview_training1(Opset):
         """
 
         schema = get_schema("Momentum", 1, "ai.onnx.preview.training")
-        op: Callable[..., Union[DOUBLE, FLOAT]] = Op(self, "Momentum", schema)
+        op = Op(self, "Momentum", schema)
         return op(
             *self._prepare_inputs(schema, R, T, *inputs),
             alpha=alpha,

--- a/opgen/onnx_opset_builder.py
+++ b/opgen/onnx_opset_builder.py
@@ -80,6 +80,31 @@ class TensorTypeRef(cg.TypeRef):
         super().__init__(MODULE_ONNX_SCRIPT_TYPES, "Tensor")
 
 
+class FunctionDefContext:
+    def __init__(self):
+        self.func: Optional[cg.FunctionDef] = None
+        self.__type_constraints: dict[str, list[cg.TypeRef]] = {}
+
+    def append_type_constraint(self, name: str, types: list[cg.TypeRef]):
+        self.__type_constraints.setdefault(name, types)
+
+    def make_type_constraint_typevars(self):
+        for name, types in self.__type_constraints.items():
+            if len(types) == 1:
+                typevar = cg.Call(
+                    cg.Name("TypeVar"),
+                    cg.Constant(name),
+                    cg.Assign(cg.Name("bound"), types[0]),
+                )
+            else:
+                typevar = cg.Call(
+                    cg.Name("TypeVar"),
+                    cg.Constant(name),
+                    *types,
+                )
+            yield cg.Assign(cg.Name(name), typevar)
+
+
 class UnsupportedOpError(NotImplementedError):
     def __init__(self, op: QualOpName, message: str):
         super().__init__(self, message)
@@ -235,11 +260,19 @@ class OpsetsBuilder:
                     continue
 
             try:
-                function = self._make_function(qualname, schema)
+                func_context = self._make_function(qualname, schema)
                 opset_class = cg.first_or_none(opset.get_children_of_type(cg.ClassDef))
+                have_typevars = False
                 if opset_class:
-                    opset_class.append_body(function)
+                    for typevar in func_context.make_type_constraint_typevars():
+                        have_typevars = True
+                        opset_class.append_body(typevar)
+                    opset_class.append_body(func_context.func)
                     self._result.all_ops_count += 1
+                if have_typevars:
+                    opset.prepend_child(
+                        cg.ImportFrom("typing", cg.Alias("TypeVar")), cg.Module.Roles.Body
+                    )
             except NotImplementedError as error:
                 if not isinstance(error, UnsupportedOpError):
                     error = UnsupportedOpError(qualname, str(error))
@@ -324,10 +357,11 @@ class OpsetsBuilder:
                 )
             module.accept(cg.ImportAdjuster())
 
-    def _make_function(self, qualname: QualOpName, schema: OpSchema) -> cg.FunctionDef:
+    def _make_function(self, qualname: QualOpName, schema: OpSchema) -> FunctionDefContext:
         op_inputs: list[cg.Expr] = []
         op_attrs: list[cg.Expr] = []
-        args = list(self._make_function_args(schema))
+        func_context = FunctionDefContext()
+        args = list(self._make_function_args(schema, func_context))
 
         for arg in args:
             if arg.name == "self":
@@ -355,10 +389,13 @@ class OpsetsBuilder:
         def return_type():
             return cg.TypeRef.make_composite_if_multiple(
                 cg.TypingRefs.Tuple,
-                *[self._make_union_typeref(output.types) for output in schema.outputs],
+                *[
+                    self._make_input_output_type(func_context, output.type_str, output.types)
+                    for output in schema.outputs
+                ],
             )
 
-        func = cg.FunctionDef(
+        func_context.func = cg.FunctionDef(
             qualname.name,
             *args,
             return_type=return_type(),
@@ -381,17 +418,18 @@ class OpsetsBuilder:
                         cg.Constant(qualname.name),
                         cg.Name("schema"),
                     ),
-                    cg.TypingRefs.Callable(cg.EllipsisTypeRef(), return_type()),
                 ),
                 cg.Return(op_call),
             ],
         )
 
-        return func
+        return func_context
 
-    def _make_function_args(self, schema: OpSchema) -> Iterable[cg.Arg]:
+    def _make_function_args(
+        self, schema: OpSchema, func_context: FunctionDefContext
+    ) -> Iterable[cg.Arg]:
         yield cg.Arg("self")
-        yield from self._make_function_input_args(schema)
+        yield from self._make_function_input_args(schema, func_context)
         yield from self._make_function_attr_args(schema)
 
     def _make_input_arg_name(self, input_name: str, schema: OpSchema):
@@ -404,7 +442,9 @@ class OpsetsBuilder:
                 return f"{input_name}_"
         return input_name
 
-    def _make_function_input_args(self, schema: OpSchema) -> Iterable[cg.Arg]:
+    def _make_function_input_args(
+        self, schema: OpSchema, func_context: FunctionDefContext
+    ) -> Iterable[cg.Arg]:
         args: list[cg.Arg] = []
         for input in schema.inputs:
             optional = input.option == OpSchema.FormalParameterOption.Optional
@@ -439,7 +479,7 @@ class OpsetsBuilder:
             if len(doctags) > 0:
                 doc = f"({', '.join(doctags)}) {doc}"
 
-            type = self._make_union_typeref(input.types)
+            type = self._make_input_output_type(func_context, input.type_str, input.types)
             if optional and not isinstance(type, cg.TypingRefs.Optional):
                 type = cg.TypingRefs.Optional(type)
 
@@ -493,11 +533,22 @@ class OpsetsBuilder:
 
         yield from sorted(attr_args, key=lambda p: p.has_default_value)
 
-    def _make_union_typeref(self, onnx_types: list[str]) -> cg.TypingRefs.Union:
-        return cg.TypeRef.make_composite_if_multiple(
-            cg.TypingRefs.Union,
-            *[parse_input_output_type(type) for type in sorted(onnx_types)],
-        )
+    def _make_input_output_type(
+        self,
+        func_context: FunctionDefContext,
+        constraint_name: str,
+        onnx_types: list[str],
+    ) -> cg.TypeRef:
+        py_types = [parse_input_output_type(type) for type in sorted(onnx_types)]
+        try:
+            # input.type_str will either be a valid ONNX type (e.g. 'tensor(int)')
+            # or the name of a type constraint. If it parses as a type, it's not
+            # constrained; otherwise bind the underlying types to the constraint.
+            parse_input_output_type(constraint_name)
+            return cg.TypeRef.make_composite_if_multiple(cg.TypingRefs.Union, *py_types)
+        except NotImplementedError:
+            func_context.append_type_constraint(constraint_name, py_types)
+            return cg.TypeRef(None, constraint_name)
 
 
 def parse_input_output_type(onnx_type: str) -> cg.TypeRef:

--- a/opgen/onnx_opset_builder.py
+++ b/opgen/onnx_opset_builder.py
@@ -409,13 +409,13 @@ class OpsetsBuilder:
         for input in schema.inputs:
             optional = input.option == OpSchema.FormalParameterOption.Optional
             variadic = input.option == OpSchema.FormalParameterOption.Variadic
-            heterogeneous = not input.isHomogeneous
+            heterogeneous = not input.is_homogeneous
             differentiable = (
-                input.differentiationCategory
+                input.differentiation_category
                 == OpSchema.DifferentiationCategory.Differentiable
             )
             non_differentiable = (
-                input.differentiationCategory
+                input.differentiation_category
                 == OpSchema.DifferentiationCategory.NonDifferentiable
             )
 


### PR DESCRIPTION
Given a hypothetical `OpSchema` _Thing_ that has two identically type-constrained inputs and a type constrained output:

```
inputs:
  T1: tensor(int32), tensor(int64)
  T2: tensor(int32), tensor(int64)
outputs:
  T1
```

We were previously ignoring the type constraint itself, which is problematic especially when the return type should be the same type as one of the constrained arguments, since this is unsolvable.

### Before

```python
def Thing(a: Union[INT32, INT64], b: Union[INT32, INT64) -> Union[INT32, INT64]:
   ...

# error: we don't know that Thing is constrained to return INT64 tensor:
Thing(some_INT64_tensor, some_INT32_tensor)
```

This PR addresses the issue by translating type constraints on the schema into proper `typing.TypeVar` usage:

### After

```python
T1 = TypeVar("T1", INT32, INT64)
T2 = TypeVar("T2", INT32, INT64)

def Thing(a: T1, b: T2) -> T1:
   ...

# because 'a: T1' is given an INT64, we know we will return 'INT64'
Thing(some_INT64_tensor, some_INT32_tensor)
```

