### PR TITLE
requirements: bump onnx-weekly>=1.15.0.dev20230605

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 setuptools>=61.0.0
 numpy
-onnx-weekly>=1.14.0.dev20230403
+onnx-weekly>=1.15.0.dev20230605
 onnxruntime
 typing_extensions
 

--- a/requirements/ci/requirements-onnx-weekly.txt
+++ b/requirements/ci/requirements-onnx-weekly.txt
@@ -1,1 +1,1 @@
-onnx-weekly==1.15.0.dev20230529
+onnx-weekly>=1.15.0.dev20230605


### PR DESCRIPTION
Tests were failing locally in an environment with `onnx-weekly` already installed after re-running `pip install -r requirements-dev.txt`.