### PR TITLE
opgen: make all OpSchema attributes keyword-only args in Python

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -4433,8 +4433,8 @@ def _aten_native_batch_norm_inference_onnx(
         training_mode=training,
     )
     # Cannot return 2 dup output, so have to do twice with different variable name
-    empty_mean = op.Cast(op.Shape(input, 0, 0), to=FLOAT.dtype)
-    empty_var = op.Cast(op.Shape(input, 0, 0), to=FLOAT.dtype)
+    empty_mean = op.Cast(op.Shape(input, start=0, end=0), to=FLOAT.dtype)
+    empty_var = op.Cast(op.Shape(input, start=0, end=0), to=FLOAT.dtype)
     return norm, empty_mean, empty_var
 
 
@@ -4663,7 +4663,7 @@ def aten_new_empty_dtype(
 
     # using zero to simulate empty array
     result = op.ConstantOfShape(size)
-    return op.Cast(result, dtype)
+    return op.Cast(result, to=dtype)
 
 
 @torch_op("aten::new_empty_strided")

--- a/onnxscript/onnx_opset/_impl/opset1.py
+++ b/onnxscript/onnx_opset/_impl/opset1.py
@@ -43,7 +43,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Abs(self, X: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
+    def Abs(self, X: T, *, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Abs(1)](https://onnx.ai/onnx/operators/onnx__Abs.html#abs-1 "Online Documentation")
 
 
@@ -68,6 +68,7 @@ class Opset1(Opset):
         self,
         A: T,
         B: T,
+        *,
         axis: Optional[int] = None,
         broadcast: int = 0,
         consumed_inputs: Optional[Sequence[int]] = None,
@@ -123,7 +124,7 @@ class Opset1(Opset):
 
     T1 = TypeVar("T1", bound=BOOL)
 
-    def And(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T1:
+    def And(self, A: T, B: T, *, axis: Optional[int] = None, broadcast: int = 0) -> T1:
         r"""[🌐 And(1)](https://onnx.ai/onnx/operators/onnx__And.html#and-1 "Online Documentation")
 
 
@@ -153,7 +154,7 @@ class Opset1(Opset):
         "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
     )
 
-    def ArgMax(self, data: T, axis: int = 0, keepdims: int = 1) -> INT64:
+    def ArgMax(self, data: T, *, axis: int = 0, keepdims: int = 1) -> INT64:
         r"""[🌐 ArgMax(1)](https://onnx.ai/onnx/operators/onnx__ArgMax.html#argmax-1 "Online Documentation")
 
 
@@ -179,7 +180,7 @@ class Opset1(Opset):
         "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
     )
 
-    def ArgMin(self, data: T, axis: int = 0, keepdims: int = 1) -> INT64:
+    def ArgMin(self, data: T, *, axis: int = 0, keepdims: int = 1) -> INT64:
         r"""[🌐 ArgMin(1)](https://onnx.ai/onnx/operators/onnx__ArgMin.html#argmin-1 "Online Documentation")
 
 
@@ -206,6 +207,7 @@ class Opset1(Opset):
     def AveragePool(
         self,
         X: T,
+        *,
         auto_pad: str = "NOTSET",
         kernel_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
@@ -288,6 +290,7 @@ class Opset1(Opset):
         B: T,
         mean: T,
         var: T,
+        *,
         consumed_inputs: Optional[Sequence[int]] = None,
         epsilon: float = 9.999999747378752e-06,
         is_test: int = 0,
@@ -378,7 +381,7 @@ class Opset1(Opset):
         UINT8,
     )
 
-    def Cast(self, input: T1, to: Optional[str] = None) -> T2:
+    def Cast(self, input: T1, *, to: Optional[str] = None) -> T2:
         r"""[🌐 Cast(1)](https://onnx.ai/onnx/operators/onnx__Cast.html#cast-1 "Online Documentation")
 
 
@@ -402,7 +405,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Ceil(self, X: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
+    def Ceil(self, X: T, *, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Ceil(1)](https://onnx.ai/onnx/operators/onnx__Ceil.html#ceil-1 "Online Documentation")
 
 
@@ -426,6 +429,7 @@ class Opset1(Opset):
     def Clip(
         self,
         input: T,
+        *,
         consumed_inputs: Optional[Sequence[int]] = None,
         max: Optional[float] = None,
         min: Optional[float] = None,
@@ -476,7 +480,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Constant(self, value: Optional[TensorProto] = None) -> T:
+    def Constant(self, *, value: Optional[TensorProto] = None) -> T:
         r"""[🌐 Constant(1)](https://onnx.ai/onnx/operators/onnx__Constant.html#constant-1 "Online Documentation")
 
         A constant tensor.
@@ -496,6 +500,7 @@ class Opset1(Opset):
         X: T,
         W: T,
         B: Optional[T] = None,
+        *,
         auto_pad: str = "NOTSET",
         dilations: Optional[Sequence[int]] = None,
         group: int = 1,
@@ -579,6 +584,7 @@ class Opset1(Opset):
         X: T,
         W: T,
         B: Optional[T] = None,
+        *,
         auto_pad: str = "NOTSET",
         dilations: Optional[Sequence[int]] = None,
         group: int = 1,
@@ -690,7 +696,7 @@ class Opset1(Opset):
         UINT8,
     )
 
-    def DepthToSpace(self, input: T, blocksize: Optional[int] = None) -> T:
+    def DepthToSpace(self, input: T, *, blocksize: Optional[int] = None) -> T:
         r"""[🌐 DepthToSpace(1)](https://onnx.ai/onnx/operators/onnx__DepthToSpace.html#depthtospace-1 "Online Documentation")
 
         DepthToSpace rearranges (permutes) data from depth into blocks of spatial data.
@@ -716,6 +722,7 @@ class Opset1(Opset):
         self,
         A: T,
         B: T,
+        *,
         axis: Optional[int] = None,
         broadcast: int = 0,
         consumed_inputs: Optional[Sequence[int]] = None,
@@ -772,6 +779,7 @@ class Opset1(Opset):
     def Dropout(
         self,
         data: T,
+        *,
         consumed_inputs: Optional[Sequence[int]] = None,
         is_test: int = 0,
         ratio: float = 0.5,
@@ -809,7 +817,7 @@ class Opset1(Opset):
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def Elu(
-        self, X: T, alpha: float = 1.0, consumed_inputs: Optional[Sequence[int]] = None
+        self, X: T, *, alpha: float = 1.0, consumed_inputs: Optional[Sequence[int]] = None
     ) -> T:
         r"""[🌐 Elu(1)](https://onnx.ai/onnx/operators/onnx__Elu.html#elu-1 "Online Documentation")
 
@@ -838,7 +846,7 @@ class Opset1(Opset):
 
     T1 = TypeVar("T1", bound=BOOL)
 
-    def Equal(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T1:
+    def Equal(self, A: T, B: T, *, axis: Optional[int] = None, broadcast: int = 0) -> T1:
         r"""[🌐 Equal(1)](https://onnx.ai/onnx/operators/onnx__Equal.html#equal-1 "Online Documentation")
 
 
@@ -866,7 +874,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Exp(self, input: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
+    def Exp(self, input: T, *, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Exp(1)](https://onnx.ai/onnx/operators/onnx__Exp.html#exp-1 "Online Documentation")
 
 
@@ -885,7 +893,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Flatten(self, input: T, axis: int = 1) -> T:
+    def Flatten(self, input: T, *, axis: int = 1) -> T:
         r"""[🌐 Flatten(1)](https://onnx.ai/onnx/operators/onnx__Flatten.html#flatten-1 "Online Documentation")
 
 
@@ -910,7 +918,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Floor(self, X: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
+    def Floor(self, X: T, *, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Floor(1)](https://onnx.ai/onnx/operators/onnx__Floor.html#floor-1 "Online Documentation")
 
 
@@ -941,6 +949,7 @@ class Opset1(Opset):
         B: Optional[T] = None,
         sequence_lens: Optional[T1] = None,
         initial_h: Optional[T] = None,
+        *,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Optional[Sequence[str]] = None,
@@ -1111,7 +1120,7 @@ class Opset1(Opset):
 
     Tind = TypeVar("Tind", INT32, INT64)
 
-    def Gather(self, data: T, indices: Tind, axis: int = 0) -> T:
+    def Gather(self, data: T, indices: Tind, *, axis: int = 0) -> T:
         r"""[🌐 Gather(1)](https://onnx.ai/onnx/operators/onnx__Gather.html#gather-1 "Online Documentation")
 
 
@@ -1185,6 +1194,7 @@ class Opset1(Opset):
         A: T,
         B: T,
         C: T,
+        *,
         alpha: float = 1.0,
         beta: float = 1.0,
         broadcast: int = 0,
@@ -1257,7 +1267,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def GlobalLpPool(self, X: T, p: float = 2.0) -> T:
+    def GlobalLpPool(self, X: T, *, p: float = 2.0) -> T:
         r"""[🌐 GlobalLpPool(1)](https://onnx.ai/onnx/operators/onnx__GlobalLpPool.html#globallppool-1 "Online Documentation")
 
 
@@ -1305,7 +1315,7 @@ class Opset1(Opset):
 
     T1 = TypeVar("T1", bound=BOOL)
 
-    def Greater(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T1:
+    def Greater(self, A: T, B: T, *, axis: Optional[int] = None, broadcast: int = 0) -> T1:
         r"""[🌐 Greater(1)](https://onnx.ai/onnx/operators/onnx__Greater.html#greater-1 "Online Documentation")
 
 
@@ -1336,6 +1346,7 @@ class Opset1(Opset):
     def HardSigmoid(
         self,
         X: T,
+        *,
         alpha: float = 0.20000000298023224,
         beta: float = 0.5,
         consumed_inputs: Optional[Sequence[int]] = None,
@@ -1369,7 +1380,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Hardmax(self, input: T, axis: int = 1) -> T:
+    def Hardmax(self, input: T, *, axis: int = 1) -> T:
         r"""[🌐 Hardmax(1)](https://onnx.ai/onnx/operators/onnx__Hardmax.html#hardmax-1 "Online Documentation")
 
 
@@ -1458,6 +1469,7 @@ class Opset1(Opset):
     def If(
         self,
         cond: B,
+        *,
         else_branch: Optional[GraphProto] = None,
         then_branch: Optional[GraphProto] = None,
     ) -> V:
@@ -1492,6 +1504,7 @@ class Opset1(Opset):
         input: T,
         scale: T,
         B: T,
+        *,
         consumed_inputs: Optional[Sequence[int]] = None,
         epsilon: float = 9.999999747378752e-06,
     ) -> T:
@@ -1532,6 +1545,7 @@ class Opset1(Opset):
     def LRN(
         self,
         X: T,
+        *,
         alpha: float = 9.999999747378752e-05,
         beta: float = 0.75,
         bias: float = 1.0,
@@ -1589,6 +1603,7 @@ class Opset1(Opset):
         initial_h: Optional[T] = None,
         initial_c: Optional[T] = None,
         P: Optional[T] = None,
+        *,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Optional[Sequence[str]] = None,
@@ -1767,6 +1782,7 @@ class Opset1(Opset):
     def LeakyRelu(
         self,
         X: T,
+        *,
         alpha: float = 0.009999999776482582,
         consumed_inputs: Optional[Sequence[int]] = None,
     ) -> T:
@@ -1796,7 +1812,7 @@ class Opset1(Opset):
 
     T1 = TypeVar("T1", bound=BOOL)
 
-    def Less(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T1:
+    def Less(self, A: T, B: T, *, axis: Optional[int] = None, broadcast: int = 0) -> T1:
         r"""[🌐 Less(1)](https://onnx.ai/onnx/operators/onnx__Less.html#less-1 "Online Documentation")
 
 
@@ -1824,7 +1840,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Log(self, input: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
+    def Log(self, input: T, *, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Log(1)](https://onnx.ai/onnx/operators/onnx__Log.html#log-1 "Online Documentation")
 
 
@@ -1843,7 +1859,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def LogSoftmax(self, input: T, axis: int = 1) -> T:
+    def LogSoftmax(self, input: T, *, axis: int = 1) -> T:
         r"""[🌐 LogSoftmax(1)](https://onnx.ai/onnx/operators/onnx__LogSoftmax.html#logsoftmax-1 "Online Documentation")
 
 
@@ -2049,7 +2065,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def LpNormalization(self, input: T, axis: int = -1, p: int = 2) -> T:
+    def LpNormalization(self, input: T, *, axis: int = -1, p: int = 2) -> T:
         r"""[🌐 LpNormalization(1)](https://onnx.ai/onnx/operators/onnx__LpNormalization.html#lpnormalization-1 "Online Documentation")
 
 
@@ -2073,6 +2089,7 @@ class Opset1(Opset):
     def LpPool(
         self,
         X: T,
+        *,
         auto_pad: str = "NOTSET",
         kernel_shape: Optional[Sequence[int]] = None,
         p: float = 2.0,
@@ -2175,6 +2192,7 @@ class Opset1(Opset):
     def MaxPool(
         self,
         X: T,
+        *,
         auto_pad: str = "NOTSET",
         kernel_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
@@ -2254,6 +2272,7 @@ class Opset1(Opset):
         self,
         X: T,
         rois: T,
+        *,
         pooled_shape: Optional[Sequence[int]] = None,
         spatial_scale: float = 1.0,
     ) -> T:
@@ -2334,6 +2353,7 @@ class Opset1(Opset):
         self,
         A: T,
         B: T,
+        *,
         axis: Optional[int] = None,
         broadcast: int = 0,
         consumed_inputs: Optional[Sequence[int]] = None,
@@ -2387,7 +2407,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Neg(self, X: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
+    def Neg(self, X: T, *, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Neg(1)](https://onnx.ai/onnx/operators/onnx__Neg.html#neg-1 "Online Documentation")
 
 
@@ -2427,7 +2447,7 @@ class Opset1(Opset):
 
     T1 = TypeVar("T1", bound=BOOL)
 
-    def Or(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T1:
+    def Or(self, A: T, B: T, *, axis: Optional[int] = None, broadcast: int = 0) -> T1:
         r"""[🌐 Or(1)](https://onnx.ai/onnx/operators/onnx__Or.html#or-1 "Online Documentation")
 
 
@@ -2455,7 +2475,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def PRelu(self, X: T, slope: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
+    def PRelu(self, X: T, slope: T, *, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 PRelu(1)](https://onnx.ai/onnx/operators/onnx__PRelu.html#prelu-1 "Online Documentation")
 
 
@@ -2484,6 +2504,7 @@ class Opset1(Opset):
     def Pad(
         self,
         data: T,
+        *,
         mode: str = "constant",
         paddings: Optional[Sequence[int]] = None,
         value: float = 0.0,
@@ -2532,7 +2553,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Pow(self, X: T, Y: T, axis: Optional[int] = None, broadcast: int = 0) -> T:
+    def Pow(self, X: T, Y: T, *, axis: Optional[int] = None, broadcast: int = 0) -> T:
         r"""[🌐 Pow(1)](https://onnx.ai/onnx/operators/onnx__Pow.html#pow-1 "Online Documentation")
 
 
@@ -2587,6 +2608,7 @@ class Opset1(Opset):
         B: Optional[T] = None,
         sequence_lens: Optional[T1] = None,
         initial_h: Optional[T] = None,
+        *,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Sequence[str] = ("Tanh", "Tanh"),
@@ -2730,6 +2752,7 @@ class Opset1(Opset):
 
     def RandomNormal(
         self,
+        *,
         dtype: int = 1,
         mean: float = 0.0,
         scale: float = 1.0,
@@ -2790,6 +2813,7 @@ class Opset1(Opset):
     def RandomNormalLike(
         self,
         input: T1,
+        *,
         dtype: Optional[int] = None,
         mean: float = 0.0,
         scale: float = 1.0,
@@ -2835,6 +2859,7 @@ class Opset1(Opset):
 
     def RandomUniform(
         self,
+        *,
         dtype: int = 1,
         high: float = 1.0,
         low: float = 0.0,
@@ -2894,6 +2919,7 @@ class Opset1(Opset):
     def RandomUniformLike(
         self,
         input: T1,
+        *,
         dtype: Optional[int] = None,
         high: float = 1.0,
         low: float = 0.0,
@@ -2933,7 +2959,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Reciprocal(self, X: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
+    def Reciprocal(self, X: T, *, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Reciprocal(1)](https://onnx.ai/onnx/operators/onnx__Reciprocal.html#reciprocal-1 "Online Documentation")
 
 
@@ -2954,7 +2980,9 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
-    def ReduceL1(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
+    def ReduceL1(
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceL1(1)](https://onnx.ai/onnx/operators/onnx__ReduceL1.html#reducel1-1 "Online Documentation")
 
 
@@ -2981,7 +3009,9 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
-    def ReduceL2(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
+    def ReduceL2(
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceL2(1)](https://onnx.ai/onnx/operators/onnx__ReduceL2.html#reducel2-1 "Online Documentation")
 
 
@@ -3009,7 +3039,7 @@ class Opset1(Opset):
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def ReduceLogSum(
-        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
     ) -> T:
         r"""[🌐 ReduceLogSum(1)](https://onnx.ai/onnx/operators/onnx__ReduceLogSum.html#reducelogsum-1 "Online Documentation")
 
@@ -3038,7 +3068,7 @@ class Opset1(Opset):
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def ReduceLogSumExp(
-        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
     ) -> T:
         r"""[🌐 ReduceLogSumExp(1)](https://onnx.ai/onnx/operators/onnx__ReduceLogSumExp.html#reducelogsumexp-1 "Online Documentation")
 
@@ -3066,7 +3096,9 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
-    def ReduceMax(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
+    def ReduceMax(
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceMax(1)](https://onnx.ai/onnx/operators/onnx__ReduceMax.html#reducemax-1 "Online Documentation")
 
 
@@ -3094,7 +3126,7 @@ class Opset1(Opset):
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def ReduceMean(
-        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
     ) -> T:
         r"""[🌐 ReduceMean(1)](https://onnx.ai/onnx/operators/onnx__ReduceMean.html#reducemean-1 "Online Documentation")
 
@@ -3122,7 +3154,9 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
-    def ReduceMin(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
+    def ReduceMin(
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceMin(1)](https://onnx.ai/onnx/operators/onnx__ReduceMin.html#reducemin-1 "Online Documentation")
 
 
@@ -3150,7 +3184,7 @@ class Opset1(Opset):
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def ReduceProd(
-        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
     ) -> T:
         r"""[🌐 ReduceProd(1)](https://onnx.ai/onnx/operators/onnx__ReduceProd.html#reduceprod-1 "Online Documentation")
 
@@ -3178,7 +3212,9 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
-    def ReduceSum(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
+    def ReduceSum(
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceSum(1)](https://onnx.ai/onnx/operators/onnx__ReduceSum.html#reducesum-1 "Online Documentation")
 
 
@@ -3206,7 +3242,7 @@ class Opset1(Opset):
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def ReduceSumSquare(
-        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
     ) -> T:
         r"""[🌐 ReduceSumSquare(1)](https://onnx.ai/onnx/operators/onnx__ReduceSumSquare.html#reducesumsquare-1 "Online Documentation")
 
@@ -3234,7 +3270,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Relu(self, X: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
+    def Relu(self, X: T, *, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Relu(1)](https://onnx.ai/onnx/operators/onnx__Relu.html#relu-1 "Online Documentation")
 
 
@@ -3258,6 +3294,7 @@ class Opset1(Opset):
     def Reshape(
         self,
         data: T,
+        *,
         consumed_inputs: Optional[Sequence[int]] = None,
         shape: Optional[Sequence[int]] = None,
     ) -> T:
@@ -3291,6 +3328,7 @@ class Opset1(Opset):
     def Selu(
         self,
         X: T,
+        *,
         alpha: float = 1.673200011253357,
         consumed_inputs: Optional[Sequence[int]] = None,
         gamma: float = 1.0506999492645264,
@@ -3361,7 +3399,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Sigmoid(self, X: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
+    def Sigmoid(self, X: T, *, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Sigmoid(1)](https://onnx.ai/onnx/operators/onnx__Sigmoid.html#sigmoid-1 "Online Documentation")
 
 
@@ -3438,6 +3476,7 @@ class Opset1(Opset):
     def Slice(
         self,
         data: T,
+        *,
         axes: Optional[Sequence[int]] = None,
         ends: Optional[Sequence[int]] = None,
         starts: Optional[Sequence[int]] = None,
@@ -3495,7 +3534,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Softmax(self, input: T, axis: int = 1) -> T:
+    def Softmax(self, input: T, *, axis: int = 1) -> T:
         r"""[🌐 Softmax(1)](https://onnx.ai/onnx/operators/onnx__Softmax.html#softmax-1 "Online Documentation")
 
 
@@ -3583,7 +3622,7 @@ class Opset1(Opset):
         UINT8,
     )
 
-    def SpaceToDepth(self, input: T, blocksize: Optional[int] = None) -> T:
+    def SpaceToDepth(self, input: T, *, blocksize: Optional[int] = None) -> T:
         r"""[🌐 SpaceToDepth(1)](https://onnx.ai/onnx/operators/onnx__SpaceToDepth.html#spacetodepth-1 "Online Documentation")
 
         SpaceToDepth rearranges blocks of spatial data into depth. More specifically,
@@ -3608,6 +3647,7 @@ class Opset1(Opset):
         self,
         input: T,
         split_: Optional[T] = None,
+        *,
         axis: Optional[int] = None,
         split: Optional[Sequence[int]] = None,
     ) -> T:
@@ -3635,7 +3675,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Sqrt(self, X: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
+    def Sqrt(self, X: T, *, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Sqrt(1)](https://onnx.ai/onnx/operators/onnx__Sqrt.html#sqrt-1 "Online Documentation")
 
 
@@ -3673,7 +3713,7 @@ class Opset1(Opset):
         UINT8,
     )
 
-    def Squeeze(self, data: T, axes: Optional[Sequence[int]] = None) -> T:
+    def Squeeze(self, data: T, *, axes: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Squeeze(1)](https://onnx.ai/onnx/operators/onnx__Squeeze.html#squeeze-1 "Online Documentation")
 
 
@@ -3699,6 +3739,7 @@ class Opset1(Opset):
         self,
         A: T,
         B: T,
+        *,
         axis: Optional[int] = None,
         broadcast: int = 0,
         consumed_inputs: Optional[Sequence[int]] = None,
@@ -3772,7 +3813,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Tanh(self, input: T, consumed_inputs: Optional[Sequence[int]] = None) -> T:
+    def Tanh(self, input: T, *, consumed_inputs: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Tanh(1)](https://onnx.ai/onnx/operators/onnx__Tanh.html#tanh-1 "Online Documentation")
 
 
@@ -3812,7 +3853,7 @@ class Opset1(Opset):
 
     I = TypeVar("I", bound=INT64)
 
-    def TopK(self, X: T, axis: int = -1, k: Optional[int] = None) -> Tuple[T, I]:
+    def TopK(self, X: T, *, axis: int = -1, k: Optional[int] = None) -> Tuple[T, I]:
         r"""[🌐 TopK(1)](https://onnx.ai/onnx/operators/onnx__TopK.html#topk-1 "Online Documentation")
 
 
@@ -3858,7 +3899,7 @@ class Opset1(Opset):
         UINT8,
     )
 
-    def Transpose(self, data: T, perm: Optional[Sequence[int]] = None) -> T:
+    def Transpose(self, data: T, *, perm: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Transpose(1)](https://onnx.ai/onnx/operators/onnx__Transpose.html#transpose-1 "Online Documentation")
 
 
@@ -3897,7 +3938,7 @@ class Opset1(Opset):
         UINT8,
     )
 
-    def Unsqueeze(self, data: T, axes: Optional[Sequence[int]] = None) -> T:
+    def Unsqueeze(self, data: T, *, axes: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Unsqueeze(1)](https://onnx.ai/onnx/operators/onnx__Unsqueeze.html#unsqueeze-1 "Online Documentation")
 
 
@@ -3923,6 +3964,7 @@ class Opset1(Opset):
     def Upsample(
         self,
         X: T,
+        *,
         height_scale: Optional[float] = None,
         mode: str = "nearest",
         width_scale: Optional[float] = None,
@@ -3977,7 +4019,7 @@ class Opset1(Opset):
 
     T1 = TypeVar("T1", bound=BOOL)
 
-    def Xor(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T1:
+    def Xor(self, A: T, B: T, *, axis: Optional[int] = None, broadcast: int = 0) -> T1:
         r"""[🌐 Xor(1)](https://onnx.ai/onnx/operators/onnx__Xor.html#xor-1 "Online Documentation")
 
 

--- a/onnxscript/onnx_opset/_impl/opset1.py
+++ b/onnxscript/onnx_opset/_impl/opset1.py
@@ -209,7 +209,7 @@ class Opset1(Opset):
         X: T,
         *,
         auto_pad: str = "NOTSET",
-        kernel_shape: Optional[Sequence[int]] = None,
+        kernel_shape: Sequence[int],
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
     ) -> T:
@@ -291,7 +291,7 @@ class Opset1(Opset):
         mean: T,
         var: T,
         *,
-        consumed_inputs: Optional[Sequence[int]] = None,
+        consumed_inputs: Sequence[int],
         epsilon: float = 9.999999747378752e-06,
         is_test: int = 0,
         momentum: float = 0.8999999761581421,
@@ -381,7 +381,7 @@ class Opset1(Opset):
         UINT8,
     )
 
-    def Cast(self, input: T1, *, to: Optional[str] = None) -> T2:
+    def Cast(self, input: T1, *, to: str) -> T2:
         r"""[🌐 Cast(1)](https://onnx.ai/onnx/operators/onnx__Cast.html#cast-1 "Online Documentation")
 
 
@@ -480,7 +480,7 @@ class Opset1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Constant(self, *, value: Optional[TensorProto] = None) -> T:
+    def Constant(self, *, value: TensorProto) -> T:
         r"""[🌐 Constant(1)](https://onnx.ai/onnx/operators/onnx__Constant.html#constant-1 "Online Documentation")
 
         A constant tensor.
@@ -696,7 +696,7 @@ class Opset1(Opset):
         UINT8,
     )
 
-    def DepthToSpace(self, input: T, *, blocksize: Optional[int] = None) -> T:
+    def DepthToSpace(self, input: T, *, blocksize: int) -> T:
         r"""[🌐 DepthToSpace(1)](https://onnx.ai/onnx/operators/onnx__DepthToSpace.html#depthtospace-1 "Online Documentation")
 
         DepthToSpace rearranges (permutes) data from depth into blocks of spatial data.
@@ -1466,13 +1466,7 @@ class Opset1(Opset):
         UINT8,
     )
 
-    def If(
-        self,
-        cond: B,
-        *,
-        else_branch: Optional[GraphProto] = None,
-        then_branch: Optional[GraphProto] = None,
-    ) -> V:
+    def If(self, cond: B, *, else_branch: GraphProto, then_branch: GraphProto) -> V:
         r"""[🌐 If(1)](https://onnx.ai/onnx/operators/onnx__If.html#if-1 "Online Documentation")
 
         If conditional
@@ -1549,7 +1543,7 @@ class Opset1(Opset):
         alpha: float = 9.999999747378752e-05,
         beta: float = 0.75,
         bias: float = 1.0,
-        size: Optional[int] = None,
+        size: int,
     ) -> T:
         r"""[🌐 LRN(1)](https://onnx.ai/onnx/operators/onnx__LRN.html#lrn-1 "Online Documentation")
 
@@ -1915,13 +1909,7 @@ class Opset1(Opset):
         UINT8,
     )
 
-    def Loop(
-        self,
-        M: Optional[I],
-        cond: Optional[B],
-        *v_initial: V,
-        body: Optional[GraphProto] = None,
-    ) -> V:
+    def Loop(self, M: Optional[I], cond: Optional[B], *v_initial: V, body: GraphProto) -> V:
         r"""[🌐 Loop(1)](https://onnx.ai/onnx/operators/onnx__Loop.html#loop-1 "Online Documentation")
 
 
@@ -2194,7 +2182,7 @@ class Opset1(Opset):
         X: T,
         *,
         auto_pad: str = "NOTSET",
-        kernel_shape: Optional[Sequence[int]] = None,
+        kernel_shape: Sequence[int],
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
     ) -> T:
@@ -2269,12 +2257,7 @@ class Opset1(Opset):
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def MaxRoiPool(
-        self,
-        X: T,
-        rois: T,
-        *,
-        pooled_shape: Optional[Sequence[int]] = None,
-        spatial_scale: float = 1.0,
+        self, X: T, rois: T, *, pooled_shape: Sequence[int], spatial_scale: float = 1.0
     ) -> T:
         r"""[🌐 MaxRoiPool(1)](https://onnx.ai/onnx/operators/onnx__MaxRoiPool.html#maxroipool-1 "Online Documentation")
 
@@ -2502,12 +2485,7 @@ class Opset1(Opset):
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def Pad(
-        self,
-        data: T,
-        *,
-        mode: str = "constant",
-        paddings: Optional[Sequence[int]] = None,
-        value: float = 0.0,
+        self, data: T, *, mode: str = "constant", paddings: Sequence[int], value: float = 0.0
     ) -> T:
         r"""[🌐 Pad(1)](https://onnx.ai/onnx/operators/onnx__Pad.html#pad-1 "Online Documentation")
 
@@ -2757,7 +2735,7 @@ class Opset1(Opset):
         mean: float = 0.0,
         scale: float = 1.0,
         seed: Optional[float] = None,
-        shape: Optional[Sequence[int]] = None,
+        shape: Sequence[int],
     ) -> T:
         r"""[🌐 RandomNormal(1)](https://onnx.ai/onnx/operators/onnx__RandomNormal.html#randomnormal-1 "Online Documentation")
 
@@ -2864,7 +2842,7 @@ class Opset1(Opset):
         high: float = 1.0,
         low: float = 0.0,
         seed: Optional[float] = None,
-        shape: Optional[Sequence[int]] = None,
+        shape: Sequence[int],
     ) -> T:
         r"""[🌐 RandomUniform(1)](https://onnx.ai/onnx/operators/onnx__RandomUniform.html#randomuniform-1 "Online Documentation")
 
@@ -3478,8 +3456,8 @@ class Opset1(Opset):
         data: T,
         *,
         axes: Optional[Sequence[int]] = None,
-        ends: Optional[Sequence[int]] = None,
-        starts: Optional[Sequence[int]] = None,
+        ends: Sequence[int],
+        starts: Sequence[int],
     ) -> T:
         r"""[🌐 Slice(1)](https://onnx.ai/onnx/operators/onnx__Slice.html#slice-1 "Online Documentation")
 
@@ -3622,7 +3600,7 @@ class Opset1(Opset):
         UINT8,
     )
 
-    def SpaceToDepth(self, input: T, *, blocksize: Optional[int] = None) -> T:
+    def SpaceToDepth(self, input: T, *, blocksize: int) -> T:
         r"""[🌐 SpaceToDepth(1)](https://onnx.ai/onnx/operators/onnx__SpaceToDepth.html#spacetodepth-1 "Online Documentation")
 
         SpaceToDepth rearranges blocks of spatial data into depth. More specifically,
@@ -3853,7 +3831,7 @@ class Opset1(Opset):
 
     I = TypeVar("I", bound=INT64)
 
-    def TopK(self, X: T, *, axis: int = -1, k: Optional[int] = None) -> Tuple[T, I]:
+    def TopK(self, X: T, *, axis: int = -1, k: int) -> Tuple[T, I]:
         r"""[🌐 TopK(1)](https://onnx.ai/onnx/operators/onnx__TopK.html#topk-1 "Online Documentation")
 
 
@@ -3938,7 +3916,7 @@ class Opset1(Opset):
         UINT8,
     )
 
-    def Unsqueeze(self, data: T, *, axes: Optional[Sequence[int]] = None) -> T:
+    def Unsqueeze(self, data: T, *, axes: Sequence[int]) -> T:
         r"""[🌐 Unsqueeze(1)](https://onnx.ai/onnx/operators/onnx__Unsqueeze.html#unsqueeze-1 "Online Documentation")
 
 
@@ -3962,12 +3940,7 @@ class Opset1(Opset):
     T = TypeVar("T", BOOL, DOUBLE, FLOAT, FLOAT16, INT32, INT64)
 
     def Upsample(
-        self,
-        X: T,
-        *,
-        height_scale: Optional[float] = None,
-        mode: str = "nearest",
-        width_scale: Optional[float] = None,
+        self, X: T, *, height_scale: float, mode: str = "nearest", width_scale: float
     ) -> T:
         r"""[🌐 Upsample(1)](https://onnx.ai/onnx/operators/onnx__Upsample.html#upsample-1 "Online Documentation")
 

--- a/onnxscript/onnx_opset/_impl/opset10.py
+++ b/onnxscript/onnx_opset/_impl/opset10.py
@@ -50,7 +50,7 @@ class Opset10(Opset9):
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         count_include_pad: int = 0,
-        kernel_shape: Optional[Sequence[int]] = None,
+        kernel_shape: Sequence[int],
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
     ) -> T:
@@ -380,7 +380,7 @@ class Opset10(Opset9):
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         dilations: Optional[Sequence[int]] = None,
-        kernel_shape: Optional[Sequence[int]] = None,
+        kernel_shape: Sequence[int],
         pads: Optional[Sequence[int]] = None,
         storage_order: int = 0,
         strides: Optional[Sequence[int]] = None,

--- a/onnxscript/onnx_opset/_impl/opset10.py
+++ b/onnxscript/onnx_opset/_impl/opset10.py
@@ -46,6 +46,7 @@ class Opset10(Opset9):
     def AveragePool(
         self,
         X: T,
+        *,
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         count_include_pad: int = 0,
@@ -148,6 +149,7 @@ class Opset10(Opset9):
         w: T2,
         x_zero_point: Optional[T1] = None,
         w_zero_point: Optional[T2] = None,
+        *,
         auto_pad: str = "NOTSET",
         dilations: Optional[Sequence[int]] = None,
         group: int = 1,
@@ -270,7 +272,7 @@ class Opset10(Opset9):
 
     T1 = TypeVar("T1", bound=BOOL)
 
-    def Dropout(self, data: T, ratio: float = 0.5) -> Tuple[T, T1]:
+    def Dropout(self, data: T, *, ratio: float = 0.5) -> Tuple[T, T1]:
         r"""[🌐 Dropout(10)](https://onnx.ai/onnx/operators/onnx__Dropout.html#dropout-10 "Online Documentation")
 
 
@@ -296,7 +298,7 @@ class Opset10(Opset9):
 
     T2 = TypeVar("T2", bound=BOOL)
 
-    def IsInf(self, X: T1, detect_negative: int = 1, detect_positive: int = 1) -> T2:
+    def IsInf(self, X: T1, *, detect_negative: int = 1, detect_positive: int = 1) -> T2:
         r"""[🌐 IsInf(10)](https://onnx.ai/onnx/operators/onnx__IsInf.html#isinf-10 "Online Documentation")
 
         Map infinity to true and other values to false.
@@ -374,6 +376,7 @@ class Opset10(Opset9):
     def MaxPool(
         self,
         X: T,
+        *,
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         dilations: Optional[Sequence[int]] = None,
@@ -472,7 +475,7 @@ class Opset10(Opset9):
         "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
     )
 
-    def Mod(self, A: T, B: T, fmod: int = 0) -> T:
+    def Mod(self, A: T, B: T, *, fmod: int = 0) -> T:
         r"""[🌐 Mod(10)](https://onnx.ai/onnx/operators/onnx__Mod.html#mod-10 "Online Documentation")
 
 
@@ -511,6 +514,7 @@ class Opset10(Opset9):
         max_output_boxes_per_class: Optional[INT64] = None,
         iou_threshold: Optional[FLOAT] = None,
         score_threshold: Optional[FLOAT] = None,
+        *,
         center_point_box: int = 0,
     ) -> INT64:
         r"""[🌐 NonMaxSuppression(10)](https://onnx.ai/onnx/operators/onnx__NonMaxSuppression.html#nonmaxsuppression-10 "Online Documentation")
@@ -585,6 +589,7 @@ class Opset10(Opset9):
         y_scale: FLOAT,
         y_zero_point: T3,
         B: Optional[T4] = None,
+        *,
         auto_pad: str = "NOTSET",
         dilations: Optional[Sequence[int]] = None,
         group: int = 1,
@@ -820,7 +825,7 @@ class Opset10(Opset9):
         UINT8,
     )
 
-    def Resize(self, X: T, scales: FLOAT, mode: str = "nearest") -> T:
+    def Resize(self, X: T, scales: FLOAT, *, mode: str = "nearest") -> T:
         r"""[🌐 Resize(10)](https://onnx.ai/onnx/operators/onnx__Resize.html#resize-10 "Online Documentation")
 
 
@@ -865,7 +870,7 @@ class Opset10(Opset9):
     )
 
     def ReverseSequence(
-        self, input: T, sequence_lens: INT64, batch_axis: int = 1, time_axis: int = 0
+        self, input: T, sequence_lens: INT64, *, batch_axis: int = 1, time_axis: int = 0
     ) -> T:
         r"""[🌐 ReverseSequence(10)](https://onnx.ai/onnx/operators/onnx__ReverseSequence.html#reversesequence-10 "Online Documentation")
 
@@ -935,6 +940,7 @@ class Opset10(Opset9):
         X: T1,
         rois: T1,
         batch_indices: T2,
+        *,
         mode: str = "avg",
         output_height: int = 1,
         output_width: int = 1,
@@ -1089,6 +1095,7 @@ class Opset10(Opset9):
     def StringNormalizer(
         self,
         X: STRING,
+        *,
         case_change_action: str = "NONE",
         is_case_sensitive: int = 0,
         locale: Optional[str] = None,
@@ -1137,7 +1144,7 @@ class Opset10(Opset9):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def ThresholdedRelu(self, X: T, alpha: float = 1.0) -> T:
+    def ThresholdedRelu(self, X: T, *, alpha: float = 1.0) -> T:
         r"""[🌐 ThresholdedRelu(10)](https://onnx.ai/onnx/operators/onnx__ThresholdedRelu.html#thresholdedrelu-10 "Online Documentation")
 
 
@@ -1160,7 +1167,7 @@ class Opset10(Opset9):
 
     I = TypeVar("I", bound=INT64)
 
-    def TopK(self, X: T, K: INT64, axis: int = -1) -> Tuple[T, I]:
+    def TopK(self, X: T, K: INT64, *, axis: int = -1) -> Tuple[T, I]:
         r"""[🌐 TopK(10)](https://onnx.ai/onnx/operators/onnx__TopK.html#topk-10 "Online Documentation")
 
 

--- a/onnxscript/onnx_opset/_impl/opset11.py
+++ b/onnxscript/onnx_opset/_impl/opset11.py
@@ -46,7 +46,7 @@ class Opset11(Opset10):
         "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
     )
 
-    def ArgMax(self, data: T, axis: int = 0, keepdims: int = 1) -> INT64:
+    def ArgMax(self, data: T, *, axis: int = 0, keepdims: int = 1) -> INT64:
         r"""[🌐 ArgMax(11)](https://onnx.ai/onnx/operators/onnx__ArgMax.html#argmax-11 "Online Documentation")
 
 
@@ -73,7 +73,7 @@ class Opset11(Opset10):
         "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
     )
 
-    def ArgMin(self, data: T, axis: int = 0, keepdims: int = 1) -> INT64:
+    def ArgMin(self, data: T, *, axis: int = 0, keepdims: int = 1) -> INT64:
         r"""[🌐 ArgMin(11)](https://onnx.ai/onnx/operators/onnx__ArgMin.html#argmin-11 "Online Documentation")
 
 
@@ -101,6 +101,7 @@ class Opset11(Opset10):
     def AveragePool(
         self,
         X: T,
+        *,
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         count_include_pad: int = 0,
@@ -196,7 +197,7 @@ class Opset11(Opset10):
 
     T = TypeVar("T", UINT16, UINT32, UINT64, UINT8)
 
-    def BitShift(self, X: T, Y: T, direction: Optional[str] = None) -> T:
+    def BitShift(self, X: T, Y: T, *, direction: Optional[str] = None) -> T:
         r"""[🌐 BitShift(11)](https://onnx.ai/onnx/operators/onnx__BitShift.html#bitshift-11 "Online Documentation")
 
 
@@ -272,7 +273,7 @@ class Opset11(Opset10):
 
     T1 = TypeVar("T1", bound=BOOL)
 
-    def Compress(self, input: T, condition: T1, axis: Optional[int] = None) -> T:
+    def Compress(self, input: T, condition: T1, *, axis: Optional[int] = None) -> T:
         r"""[🌐 Compress(11)](https://onnx.ai/onnx/operators/onnx__Compress.html#compress-11 "Online Documentation")
 
 
@@ -374,7 +375,7 @@ class Opset11(Opset10):
     )
 
     def ConcatFromSequence(
-        self, input_sequence: S, axis: Optional[int] = None, new_axis: int = 0
+        self, input_sequence: S, *, axis: Optional[int] = None, new_axis: int = 0
     ) -> T:
         r"""[🌐 ConcatFromSequence(11)](https://onnx.ai/onnx/operators/onnx__ConcatFromSequence.html#concatfromsequence-11 "Online Documentation")
 
@@ -421,6 +422,7 @@ class Opset11(Opset10):
 
     def Constant(
         self,
+        *,
         sparse_value: Optional[SparseTensorProto] = None,
         value: Optional[TensorProto] = None,
     ) -> T:
@@ -449,6 +451,7 @@ class Opset11(Opset10):
         X: T,
         W: T,
         B: Optional[T] = None,
+        *,
         auto_pad: str = "NOTSET",
         dilations: Optional[Sequence[int]] = None,
         group: int = 1,
@@ -538,6 +541,7 @@ class Opset11(Opset10):
         X: T,
         W: T,
         B: Optional[T] = None,
+        *,
         auto_pad: str = "NOTSET",
         dilations: Optional[Sequence[int]] = None,
         group: int = 1,
@@ -646,7 +650,7 @@ class Opset11(Opset10):
 
     T2 = TypeVar("T2", INT32, INT64)
 
-    def CumSum(self, x: T, axis: T2, exclusive: int = 0, reverse: int = 0) -> T:
+    def CumSum(self, x: T, axis: T2, *, exclusive: int = 0, reverse: int = 0) -> T:
         r"""[🌐 CumSum(11)](https://onnx.ai/onnx/operators/onnx__CumSum.html#cumsum-11 "Online Documentation")
 
 
@@ -710,7 +714,9 @@ class Opset11(Opset10):
         UINT8,
     )
 
-    def DepthToSpace(self, input: T, blocksize: Optional[int] = None, mode: str = "DCR") -> T:
+    def DepthToSpace(
+        self, input: T, *, blocksize: Optional[int] = None, mode: str = "DCR"
+    ) -> T:
         r"""[🌐 DepthToSpace(11)](https://onnx.ai/onnx/operators/onnx__DepthToSpace.html#depthtospace-11 "Online Documentation")
 
         DepthToSpace rearranges (permutes) data from depth into blocks of spatial data.
@@ -885,7 +891,7 @@ class Opset11(Opset10):
         UINT8,
     )
 
-    def Flatten(self, input: T, axis: int = 1) -> T:
+    def Flatten(self, input: T, *, axis: int = 1) -> T:
         r"""[🌐 Flatten(11)](https://onnx.ai/onnx/operators/onnx__Flatten.html#flatten-11 "Online Documentation")
 
 
@@ -930,7 +936,7 @@ class Opset11(Opset10):
 
     Tind = TypeVar("Tind", INT32, INT64)
 
-    def Gather(self, data: T, indices: Tind, axis: int = 0) -> T:
+    def Gather(self, data: T, indices: Tind, *, axis: int = 0) -> T:
         r"""[🌐 Gather(11)](https://onnx.ai/onnx/operators/onnx__Gather.html#gather-11 "Online Documentation")
 
 
@@ -1031,7 +1037,7 @@ class Opset11(Opset10):
 
     Tind = TypeVar("Tind", INT32, INT64)
 
-    def GatherElements(self, data: T, indices: Tind, axis: int = 0) -> T:
+    def GatherElements(self, data: T, indices: Tind, *, axis: int = 0) -> T:
         r"""[🌐 GatherElements(11)](https://onnx.ai/onnx/operators/onnx__GatherElements.html#gatherelements-11 "Online Documentation")
 
 
@@ -1223,6 +1229,7 @@ class Opset11(Opset10):
         A: T,
         B: T,
         C: Optional[T] = None,
+        *,
         alpha: float = 1.0,
         beta: float = 1.0,
         transA: int = 0,
@@ -1277,7 +1284,7 @@ class Opset11(Opset10):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Hardmax(self, input: T, axis: int = 1) -> T:
+    def Hardmax(self, input: T, *, axis: int = 1) -> T:
         r"""[🌐 Hardmax(11)](https://onnx.ai/onnx/operators/onnx__Hardmax.html#hardmax-11 "Online Documentation")
 
 
@@ -1335,6 +1342,7 @@ class Opset11(Opset10):
     def If(
         self,
         cond: B,
+        *,
         else_branch: Optional[GraphProto] = None,
         then_branch: Optional[GraphProto] = None,
     ) -> V:
@@ -1364,7 +1372,7 @@ class Opset11(Opset10):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def LogSoftmax(self, input: T, axis: int = 1) -> T:
+    def LogSoftmax(self, input: T, *, axis: int = 1) -> T:
         r"""[🌐 LogSoftmax(11)](https://onnx.ai/onnx/operators/onnx__LogSoftmax.html#logsoftmax-11 "Online Documentation")
 
 
@@ -1594,6 +1602,7 @@ class Opset11(Opset10):
     def LpPool(
         self,
         X: T,
+        *,
         auto_pad: str = "NOTSET",
         kernel_shape: Optional[Sequence[int]] = None,
         p: int = 2,
@@ -1661,6 +1670,7 @@ class Opset11(Opset10):
     def MaxPool(
         self,
         X: T,
+        *,
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         dilations: Optional[Sequence[int]] = None,
@@ -1766,6 +1776,7 @@ class Opset11(Opset10):
         X: T1,
         I: T2,
         output_shape: Optional[T2] = None,
+        *,
         kernel_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
@@ -1848,6 +1859,7 @@ class Opset11(Opset10):
         max_output_boxes_per_class: Optional[INT64] = None,
         iou_threshold: Optional[FLOAT] = None,
         score_threshold: Optional[FLOAT] = None,
+        *,
         center_point_box: int = 0,
     ) -> INT64:
         r"""[🌐 NonMaxSuppression(11)](https://onnx.ai/onnx/operators/onnx__NonMaxSuppression.html#nonmaxsuppression-11 "Online Documentation")
@@ -1930,7 +1942,7 @@ class Opset11(Opset10):
         UINT8,
     )
 
-    def OneHot(self, indices: T1, depth: T2, values: T3, axis: int = -1) -> T3:
+    def OneHot(self, indices: T1, depth: T2, values: T3, *, axis: int = -1) -> T3:
         r"""[🌐 OneHot(11)](https://onnx.ai/onnx/operators/onnx__OneHot.html#onehot-11 "Online Documentation")
 
 
@@ -1991,7 +2003,12 @@ class Opset11(Opset10):
     )
 
     def Pad(
-        self, data: T, pads: INT64, constant_value: Optional[T] = None, mode: str = "constant"
+        self,
+        data: T,
+        pads: INT64,
+        constant_value: Optional[T] = None,
+        *,
+        mode: str = "constant",
     ) -> T:
         r"""[🌐 Pad(11)](https://onnx.ai/onnx/operators/onnx__Pad.html#pad-11 "Online Documentation")
 
@@ -2154,7 +2171,9 @@ class Opset11(Opset10):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
-    def ReduceL1(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
+    def ReduceL1(
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceL1(11)](https://onnx.ai/onnx/operators/onnx__ReduceL1.html#reducel1-11 "Online Documentation")
 
 
@@ -2182,7 +2201,9 @@ class Opset11(Opset10):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
-    def ReduceL2(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
+    def ReduceL2(
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceL2(11)](https://onnx.ai/onnx/operators/onnx__ReduceL2.html#reducel2-11 "Online Documentation")
 
 
@@ -2211,7 +2232,7 @@ class Opset11(Opset10):
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def ReduceLogSum(
-        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
     ) -> T:
         r"""[🌐 ReduceLogSum(11)](https://onnx.ai/onnx/operators/onnx__ReduceLogSum.html#reducelogsum-11 "Online Documentation")
 
@@ -2241,7 +2262,7 @@ class Opset11(Opset10):
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def ReduceLogSumExp(
-        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
     ) -> T:
         r"""[🌐 ReduceLogSumExp(11)](https://onnx.ai/onnx/operators/onnx__ReduceLogSumExp.html#reducelogsumexp-11 "Online Documentation")
 
@@ -2270,7 +2291,9 @@ class Opset11(Opset10):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
-    def ReduceMax(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
+    def ReduceMax(
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceMax(11)](https://onnx.ai/onnx/operators/onnx__ReduceMax.html#reducemax-11 "Online Documentation")
 
 
@@ -2299,7 +2322,7 @@ class Opset11(Opset10):
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def ReduceMean(
-        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
     ) -> T:
         r"""[🌐 ReduceMean(11)](https://onnx.ai/onnx/operators/onnx__ReduceMean.html#reducemean-11 "Online Documentation")
 
@@ -2328,7 +2351,9 @@ class Opset11(Opset10):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
-    def ReduceMin(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
+    def ReduceMin(
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceMin(11)](https://onnx.ai/onnx/operators/onnx__ReduceMin.html#reducemin-11 "Online Documentation")
 
 
@@ -2357,7 +2382,7 @@ class Opset11(Opset10):
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def ReduceProd(
-        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
     ) -> T:
         r"""[🌐 ReduceProd(11)](https://onnx.ai/onnx/operators/onnx__ReduceProd.html#reduceprod-11 "Online Documentation")
 
@@ -2386,7 +2411,9 @@ class Opset11(Opset10):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
-    def ReduceSum(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
+    def ReduceSum(
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceSum(11)](https://onnx.ai/onnx/operators/onnx__ReduceSum.html#reducesum-11 "Online Documentation")
 
 
@@ -2415,7 +2442,7 @@ class Opset11(Opset10):
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def ReduceSumSquare(
-        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
     ) -> T:
         r"""[🌐 ReduceSumSquare(11)](https://onnx.ai/onnx/operators/onnx__ReduceSumSquare.html#reducesumsquare-11 "Online Documentation")
 
@@ -2469,6 +2496,7 @@ class Opset11(Opset10):
         roi: T2,
         scales: FLOAT,
         sizes: Optional[INT64] = None,
+        *,
         coordinate_transformation_mode: str = "half_pixel",
         cubic_coeff_a: float = -0.75,
         exclude_outside: int = 0,
@@ -2842,7 +2870,7 @@ class Opset11(Opset10):
 
     Tind = TypeVar("Tind", INT32, INT64)
 
-    def ScatterElements(self, data: T, indices: Tind, updates: T, axis: int = 0) -> T:
+    def ScatterElements(self, data: T, indices: Tind, updates: T, *, axis: int = 0) -> T:
         r"""[🌐 ScatterElements(11)](https://onnx.ai/onnx/operators/onnx__ScatterElements.html#scatterelements-11 "Online Documentation")
 
 
@@ -3156,7 +3184,7 @@ class Opset11(Opset10):
         Sequence[UINT8],
     )
 
-    def SequenceEmpty(self, dtype: Optional[int] = None) -> S:
+    def SequenceEmpty(self, *, dtype: Optional[int] = None) -> S:
         r"""[🌐 SequenceEmpty(11)](https://onnx.ai/onnx/operators/onnx__SequenceEmpty.html#sequenceempty-11 "Online Documentation")
 
 
@@ -3414,7 +3442,7 @@ class Opset11(Opset10):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Softmax(self, input: T, axis: int = 1) -> T:
+    def Softmax(self, input: T, *, axis: int = 1) -> T:
         r"""[🌐 Softmax(11)](https://onnx.ai/onnx/operators/onnx__Softmax.html#softmax-11 "Online Documentation")
 
 
@@ -3467,7 +3495,7 @@ class Opset11(Opset10):
         UINT8,
     )
 
-    def Split(self, input: T, axis: int = 0, split: Optional[Sequence[int]] = None) -> T:
+    def Split(self, input: T, *, axis: int = 0, split: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Split(11)](https://onnx.ai/onnx/operators/onnx__Split.html#split-11 "Online Documentation")
 
         Split a tensor into a list of tensors, along the specified
@@ -3529,7 +3557,7 @@ class Opset11(Opset10):
     )
 
     def SplitToSequence(
-        self, input: T, split: Optional[I] = None, axis: int = 0, keepdims: int = 1
+        self, input: T, split: Optional[I] = None, *, axis: int = 0, keepdims: int = 1
     ) -> S:
         r"""[🌐 SplitToSequence(11)](https://onnx.ai/onnx/operators/onnx__SplitToSequence.html#splittosequence-11 "Online Documentation")
 
@@ -3585,7 +3613,7 @@ class Opset11(Opset10):
         UINT8,
     )
 
-    def Squeeze(self, data: T, axes: Optional[Sequence[int]] = None) -> T:
+    def Squeeze(self, data: T, *, axes: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Squeeze(11)](https://onnx.ai/onnx/operators/onnx__Squeeze.html#squeeze-11 "Online Documentation")
 
 
@@ -3614,7 +3642,7 @@ class Opset11(Opset10):
     I = TypeVar("I", bound=INT64)
 
     def TopK(
-        self, X: T, K: INT64, axis: int = -1, largest: int = 1, sorted: int = 1
+        self, X: T, K: INT64, *, axis: int = -1, largest: int = 1, sorted: int = 1
     ) -> Tuple[T, I]:
         r"""[🌐 TopK(11)](https://onnx.ai/onnx/operators/onnx__TopK.html#topk-11 "Online Documentation")
 
@@ -3677,7 +3705,7 @@ class Opset11(Opset10):
     )
 
     def Unique(
-        self, X: T, axis: Optional[int] = None, sorted: int = 1
+        self, X: T, *, axis: Optional[int] = None, sorted: int = 1
     ) -> Tuple[T, INT64, INT64, INT64]:
         r"""[🌐 Unique(11)](https://onnx.ai/onnx/operators/onnx__Unique.html#unique-11 "Online Documentation")
 
@@ -3838,7 +3866,7 @@ class Opset11(Opset10):
         UINT8,
     )
 
-    def Unsqueeze(self, data: T, axes: Optional[Sequence[int]] = None) -> T:
+    def Unsqueeze(self, data: T, *, axes: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Unsqueeze(11)](https://onnx.ai/onnx/operators/onnx__Unsqueeze.html#unsqueeze-11 "Online Documentation")
 
 

--- a/onnxscript/onnx_opset/_impl/opset11.py
+++ b/onnxscript/onnx_opset/_impl/opset11.py
@@ -105,7 +105,7 @@ class Opset11(Opset10):
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         count_include_pad: int = 0,
-        kernel_shape: Optional[Sequence[int]] = None,
+        kernel_shape: Sequence[int],
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
     ) -> T:
@@ -197,7 +197,7 @@ class Opset11(Opset10):
 
     T = TypeVar("T", UINT16, UINT32, UINT64, UINT8)
 
-    def BitShift(self, X: T, Y: T, *, direction: Optional[str] = None) -> T:
+    def BitShift(self, X: T, Y: T, *, direction: str) -> T:
         r"""[🌐 BitShift(11)](https://onnx.ai/onnx/operators/onnx__BitShift.html#bitshift-11 "Online Documentation")
 
 
@@ -320,7 +320,7 @@ class Opset11(Opset10):
         UINT8,
     )
 
-    def Concat(self, *inputs: T, axis: Optional[int] = None) -> T:
+    def Concat(self, *inputs: T, axis: int) -> T:
         r"""[🌐 Concat(11)](https://onnx.ai/onnx/operators/onnx__Concat.html#concat-11 "Online Documentation")
 
         Concatenate a list of tensors into a single tensor. All input tensors must have the same shape, except for the dimension size of the axis to concatenate on.
@@ -374,9 +374,7 @@ class Opset11(Opset10):
         UINT8,
     )
 
-    def ConcatFromSequence(
-        self, input_sequence: S, *, axis: Optional[int] = None, new_axis: int = 0
-    ) -> T:
+    def ConcatFromSequence(self, input_sequence: S, *, axis: int, new_axis: int = 0) -> T:
         r"""[🌐 ConcatFromSequence(11)](https://onnx.ai/onnx/operators/onnx__ConcatFromSequence.html#concatfromsequence-11 "Online Documentation")
 
 
@@ -714,9 +712,7 @@ class Opset11(Opset10):
         UINT8,
     )
 
-    def DepthToSpace(
-        self, input: T, *, blocksize: Optional[int] = None, mode: str = "DCR"
-    ) -> T:
+    def DepthToSpace(self, input: T, *, blocksize: int, mode: str = "DCR") -> T:
         r"""[🌐 DepthToSpace(11)](https://onnx.ai/onnx/operators/onnx__DepthToSpace.html#depthtospace-11 "Online Documentation")
 
         DepthToSpace rearranges (permutes) data from depth into blocks of spatial data.
@@ -1339,13 +1335,7 @@ class Opset11(Opset10):
         UINT8,
     )
 
-    def If(
-        self,
-        cond: B,
-        *,
-        else_branch: Optional[GraphProto] = None,
-        then_branch: Optional[GraphProto] = None,
-    ) -> V:
+    def If(self, cond: B, *, else_branch: GraphProto, then_branch: GraphProto) -> V:
         r"""[🌐 If(11)](https://onnx.ai/onnx/operators/onnx__If.html#if-11 "Online Documentation")
 
         If conditional
@@ -1429,13 +1419,7 @@ class Opset11(Opset10):
         UINT8,
     )
 
-    def Loop(
-        self,
-        M: Optional[I],
-        cond: Optional[B],
-        *v_initial: V,
-        body: Optional[GraphProto] = None,
-    ) -> V:
+    def Loop(self, M: Optional[I], cond: Optional[B], *v_initial: V, body: GraphProto) -> V:
         r"""[🌐 Loop(11)](https://onnx.ai/onnx/operators/onnx__Loop.html#loop-11 "Online Documentation")
 
 
@@ -1604,7 +1588,7 @@ class Opset11(Opset10):
         X: T,
         *,
         auto_pad: str = "NOTSET",
-        kernel_shape: Optional[Sequence[int]] = None,
+        kernel_shape: Sequence[int],
         p: int = 2,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
@@ -1674,7 +1658,7 @@ class Opset11(Opset10):
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         dilations: Optional[Sequence[int]] = None,
-        kernel_shape: Optional[Sequence[int]] = None,
+        kernel_shape: Sequence[int],
         pads: Optional[Sequence[int]] = None,
         storage_order: int = 0,
         strides: Optional[Sequence[int]] = None,
@@ -1777,7 +1761,7 @@ class Opset11(Opset10):
         I: T2,
         output_shape: Optional[T2] = None,
         *,
-        kernel_shape: Optional[Sequence[int]] = None,
+        kernel_shape: Sequence[int],
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
     ) -> T1:
@@ -1974,12 +1958,12 @@ class Opset11(Opset10):
                 values in the output tensor.In case 'indices' is of non-integer type,
                 the values will be casted to int64 before use.
 
-            depth: (non-differentiable) Scalar specifying the number of classes in
-                one-hot tensor. This is also the size of the one-hot dimension
-                (specified by 'axis' attribute) added on in the output tensor. The
-                values in the 'indices' input tensor are expected to be in the range
-                [-depth, depth-1]. In case 'depth' is of non-integer type, it will be
-                casted to int64 before use.
+            depth: (non-differentiable) Scalar or Rank 1 tensor containing exactly one
+                element, specifying the number of classes in one-hot tensor. This is
+                also the size of the one-hot dimension (specified by 'axis' attribute)
+                added on in the output tensor. The values in the 'indices' input tensor
+                are expected to be in the range [-depth, depth-1]. In case 'depth' is of
+                non-integer type, it will be casted to int64 before use.
 
             values: (non-differentiable) Rank 1 tensor containing exactly two elements,
                 in the format [off_value, on_value], where 'on_value' is the value used
@@ -2665,8 +2649,8 @@ class Opset11(Opset10):
     def Scan(
         self,
         *initial_state_and_scan_inputs: V,
-        body: Optional[GraphProto] = None,
-        num_scan_inputs: Optional[int] = None,
+        body: GraphProto,
+        num_scan_inputs: int,
         scan_input_axes: Optional[Sequence[int]] = None,
         scan_input_directions: Optional[Sequence[int]] = None,
         scan_output_axes: Optional[Sequence[int]] = None,
@@ -3866,7 +3850,7 @@ class Opset11(Opset10):
         UINT8,
     )
 
-    def Unsqueeze(self, data: T, *, axes: Optional[Sequence[int]] = None) -> T:
+    def Unsqueeze(self, data: T, *, axes: Sequence[int]) -> T:
         r"""[🌐 Unsqueeze(11)](https://onnx.ai/onnx/operators/onnx__Unsqueeze.html#unsqueeze-11 "Online Documentation")
 
 

--- a/onnxscript/onnx_opset/_impl/opset12.py
+++ b/onnxscript/onnx_opset/_impl/opset12.py
@@ -314,7 +314,7 @@ class Opset12(Opset11):
         "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
     )
 
-    def Einsum(self, *Inputs: T, equation: Optional[str] = None) -> T:
+    def Einsum(self, *Inputs: T, equation: str) -> T:
         r"""[🌐 Einsum(12)](https://onnx.ai/onnx/operators/onnx__Einsum.html#einsum-12 "Online Documentation")
 
 
@@ -572,7 +572,7 @@ class Opset12(Opset11):
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         dilations: Optional[Sequence[int]] = None,
-        kernel_shape: Optional[Sequence[int]] = None,
+        kernel_shape: Sequence[int],
         pads: Optional[Sequence[int]] = None,
         storage_order: int = 0,
         strides: Optional[Sequence[int]] = None,

--- a/onnxscript/onnx_opset/_impl/opset12.py
+++ b/onnxscript/onnx_opset/_impl/opset12.py
@@ -47,7 +47,7 @@ class Opset12(Opset11):
     )
 
     def ArgMax(
-        self, data: T, axis: int = 0, keepdims: int = 1, select_last_index: int = 0
+        self, data: T, *, axis: int = 0, keepdims: int = 1, select_last_index: int = 0
     ) -> INT64:
         r"""[🌐 ArgMax(12)](https://onnx.ai/onnx/operators/onnx__ArgMax.html#argmax-12 "Online Documentation")
 
@@ -87,7 +87,7 @@ class Opset12(Opset11):
     )
 
     def ArgMin(
-        self, data: T, axis: int = 0, keepdims: int = 1, select_last_index: int = 0
+        self, data: T, *, axis: int = 0, keepdims: int = 1, select_last_index: int = 0
     ) -> INT64:
         r"""[🌐 ArgMin(12)](https://onnx.ai/onnx/operators/onnx__ArgMin.html#argmin-12 "Online Documentation")
 
@@ -124,7 +124,7 @@ class Opset12(Opset11):
 
     T = TypeVar("T", bound=FLOAT)
 
-    def Celu(self, X: T, alpha: float = 1.0) -> T:
+    def Celu(self, X: T, *, alpha: float = 1.0) -> T:
         r"""[🌐 Celu(12)](https://onnx.ai/onnx/operators/onnx__Celu.html#celu-12 "Online Documentation")
 
 
@@ -198,6 +198,7 @@ class Opset12(Opset11):
 
     def Constant(
         self,
+        *,
         sparse_value: Optional[SparseTensorProto] = None,
         value: Optional[TensorProto] = None,
         value_float: Optional[float] = None,
@@ -262,6 +263,7 @@ class Opset12(Opset11):
         data: T,
         ratio: Optional[T1] = None,
         training_mode: Optional[T2] = None,
+        *,
         seed: Optional[int] = None,
     ) -> Tuple[T, T2]:
         r"""[🌐 Dropout(12)](https://onnx.ai/onnx/operators/onnx__Dropout.html#dropout-12 "Online Documentation")
@@ -374,7 +376,7 @@ class Opset12(Opset11):
         UINT8,
     )
 
-    def GatherND(self, data: T, indices: INT64, batch_dims: int = 0) -> T:
+    def GatherND(self, data: T, indices: INT64, *, batch_dims: int = 0) -> T:
         r"""[🌐 GatherND(12)](https://onnx.ai/onnx/operators/onnx__GatherND.html#gathernd-12 "Online Documentation")
 
 
@@ -566,6 +568,7 @@ class Opset12(Opset11):
     def MaxPool(
         self,
         X: T,
+        *,
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         dilations: Optional[Sequence[int]] = None,
@@ -691,6 +694,7 @@ class Opset12(Opset11):
         input: T,
         target: Tind,
         weight: Optional[T] = None,
+        *,
         ignore_index: Optional[int] = None,
         reduction: str = "mean",
     ) -> T:
@@ -820,7 +824,9 @@ class Opset12(Opset11):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8)
 
-    def ReduceMax(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
+    def ReduceMax(
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceMax(12)](https://onnx.ai/onnx/operators/onnx__ReduceMax.html#reducemax-12 "Online Documentation")
 
 
@@ -848,7 +854,9 @@ class Opset12(Opset11):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8)
 
-    def ReduceMin(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
+    def ReduceMin(
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceMin(12)](https://onnx.ai/onnx/operators/onnx__ReduceMin.html#reducemin-12 "Online Documentation")
 
 
@@ -883,6 +891,7 @@ class Opset12(Opset11):
         scores: T,
         labels: Tind,
         weights: Optional[T] = None,
+        *,
         ignore_index: Optional[int] = None,
         reduction: str = "mean",
     ) -> Tuple[T, T]:

--- a/onnxscript/onnx_opset/_impl/opset13.py
+++ b/onnxscript/onnx_opset/_impl/opset13.py
@@ -114,7 +114,7 @@ class Opset13(Opset12):
     )
 
     def ArgMax(
-        self, data: T, axis: int = 0, keepdims: int = 1, select_last_index: int = 0
+        self, data: T, *, axis: int = 0, keepdims: int = 1, select_last_index: int = 0
     ) -> INT64:
         r"""[🌐 ArgMax(13)](https://onnx.ai/onnx/operators/onnx__ArgMax.html#argmax-13 "Online Documentation")
 
@@ -166,7 +166,7 @@ class Opset13(Opset12):
     )
 
     def ArgMin(
-        self, data: T, axis: int = 0, keepdims: int = 1, select_last_index: int = 0
+        self, data: T, *, axis: int = 0, keepdims: int = 1, select_last_index: int = 0
     ) -> INT64:
         r"""[🌐 ArgMin(13)](https://onnx.ai/onnx/operators/onnx__ArgMin.html#argmin-13 "Online Documentation")
 
@@ -237,7 +237,7 @@ class Opset13(Opset12):
         UINT8,
     )
 
-    def Cast(self, input: T1, to: Optional[int] = None) -> T2:
+    def Cast(self, input: T1, *, to: Optional[int] = None) -> T2:
         r"""[🌐 Cast(13)](https://onnx.ai/onnx/operators/onnx__Cast.html#cast-13 "Online Documentation")
 
 
@@ -405,6 +405,7 @@ class Opset13(Opset12):
 
     def Constant(
         self,
+        *,
         sparse_value: Optional[SparseTensorProto] = None,
         value: Optional[TensorProto] = None,
         value_float: Optional[float] = None,
@@ -478,7 +479,9 @@ class Opset13(Opset12):
         UINT8,
     )
 
-    def DepthToSpace(self, input: T, blocksize: Optional[int] = None, mode: str = "DCR") -> T:
+    def DepthToSpace(
+        self, input: T, *, blocksize: Optional[int] = None, mode: str = "DCR"
+    ) -> T:
         r"""[🌐 DepthToSpace(13)](https://onnx.ai/onnx/operators/onnx__DepthToSpace.html#depthtospace-13 "Online Documentation")
 
         DepthToSpace rearranges (permutes) data from depth into blocks of spatial data.
@@ -527,7 +530,7 @@ class Opset13(Opset12):
     T = TypeVar("T", INT32, INT8, UINT8)
 
     def DequantizeLinear(
-        self, x: T, x_scale: FLOAT, x_zero_point: Optional[T] = None, axis: int = 1
+        self, x: T, x_scale: FLOAT, x_zero_point: Optional[T] = None, *, axis: int = 1
     ) -> FLOAT:
         r"""[🌐 DequantizeLinear(13)](https://onnx.ai/onnx/operators/onnx__DequantizeLinear.html#dequantizelinear-13 "Online Documentation")
 
@@ -591,6 +594,7 @@ class Opset13(Opset12):
         data: T,
         ratio: Optional[T1] = None,
         training_mode: Optional[T2] = None,
+        *,
         seed: Optional[int] = None,
     ) -> Tuple[T, T2]:
         r"""[🌐 Dropout(13)](https://onnx.ai/onnx/operators/onnx__Dropout.html#dropout-13 "Online Documentation")
@@ -791,7 +795,7 @@ class Opset13(Opset12):
         UINT8,
     )
 
-    def Flatten(self, input: T, axis: int = 1) -> T:
+    def Flatten(self, input: T, *, axis: int = 1) -> T:
         r"""[🌐 Flatten(13)](https://onnx.ai/onnx/operators/onnx__Flatten.html#flatten-13 "Online Documentation")
 
 
@@ -856,7 +860,7 @@ class Opset13(Opset12):
 
     Tind = TypeVar("Tind", INT32, INT64)
 
-    def Gather(self, data: T, indices: Tind, axis: int = 0) -> T:
+    def Gather(self, data: T, indices: Tind, *, axis: int = 0) -> T:
         r"""[🌐 Gather(13)](https://onnx.ai/onnx/operators/onnx__Gather.html#gather-13 "Online Documentation")
 
 
@@ -951,7 +955,7 @@ class Opset13(Opset12):
 
     Tind = TypeVar("Tind", INT32, INT64)
 
-    def GatherElements(self, data: T, indices: Tind, axis: int = 0) -> T:
+    def GatherElements(self, data: T, indices: Tind, *, axis: int = 0) -> T:
         r"""[🌐 GatherElements(13)](https://onnx.ai/onnx/operators/onnx__GatherElements.html#gatherelements-13 "Online Documentation")
 
 
@@ -1051,7 +1055,7 @@ class Opset13(Opset12):
         UINT8,
     )
 
-    def GatherND(self, data: T, indices: INT64, batch_dims: int = 0) -> T:
+    def GatherND(self, data: T, indices: INT64, *, batch_dims: int = 0) -> T:
         r"""[🌐 GatherND(13)](https://onnx.ai/onnx/operators/onnx__GatherND.html#gathernd-13 "Online Documentation")
 
 
@@ -1170,6 +1174,7 @@ class Opset13(Opset12):
         A: T,
         B: T,
         C: Optional[T] = None,
+        *,
         alpha: float = 1.0,
         beta: float = 1.0,
         transA: int = 0,
@@ -1261,7 +1266,7 @@ class Opset13(Opset12):
 
     T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
 
-    def Hardmax(self, input: T, axis: int = -1) -> T:
+    def Hardmax(self, input: T, *, axis: int = -1) -> T:
         r"""[🌐 Hardmax(13)](https://onnx.ai/onnx/operators/onnx__Hardmax.html#hardmax-13 "Online Documentation")
 
 
@@ -1361,6 +1366,7 @@ class Opset13(Opset12):
     def If(
         self,
         cond: B,
+        *,
         else_branch: Optional[GraphProto] = None,
         then_branch: Optional[GraphProto] = None,
     ) -> V:
@@ -1410,6 +1416,7 @@ class Opset13(Opset12):
     def LRN(
         self,
         X: T,
+        *,
         alpha: float = 9.999999747378752e-05,
         beta: float = 0.75,
         bias: float = 1.0,
@@ -1510,7 +1517,7 @@ class Opset13(Opset12):
 
     T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
 
-    def LogSoftmax(self, input: T, axis: int = -1) -> T:
+    def LogSoftmax(self, input: T, *, axis: int = -1) -> T:
         r"""[🌐 LogSoftmax(13)](https://onnx.ai/onnx/operators/onnx__LogSoftmax.html#logsoftmax-13 "Online Documentation")
 
 
@@ -1819,7 +1826,7 @@ class Opset13(Opset12):
 
     T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
 
-    def MeanVarianceNormalization(self, X: T, axes: Sequence[int] = (0, 2, 3)) -> T:
+    def MeanVarianceNormalization(self, X: T, *, axes: Sequence[int] = (0, 2, 3)) -> T:
         r"""[🌐 MeanVarianceNormalization(13)](https://onnx.ai/onnx/operators/onnx__MeanVarianceNormalization.html#meanvariancenormalization-13 "Online Documentation")
 
 
@@ -1889,7 +1896,7 @@ class Opset13(Opset12):
         UINT8,
     )
 
-    def Mod(self, A: T, B: T, fmod: int = 0) -> T:
+    def Mod(self, A: T, B: T, *, fmod: int = 0) -> T:
         r"""[🌐 Mod(13)](https://onnx.ai/onnx/operators/onnx__Mod.html#mod-13 "Online Documentation")
 
 
@@ -1970,6 +1977,7 @@ class Opset13(Opset12):
         input: T,
         target: Tind,
         weight: Optional[T] = None,
+        *,
         ignore_index: Optional[int] = None,
         reduction: str = "mean",
     ) -> T:
@@ -2185,7 +2193,12 @@ class Opset13(Opset12):
     )
 
     def Pad(
-        self, data: T, pads: INT64, constant_value: Optional[T] = None, mode: str = "constant"
+        self,
+        data: T,
+        pads: INT64,
+        constant_value: Optional[T] = None,
+        *,
+        mode: str = "constant",
     ) -> T:
         r"""[🌐 Pad(13)](https://onnx.ai/onnx/operators/onnx__Pad.html#pad-13 "Online Documentation")
 
@@ -2319,7 +2332,7 @@ class Opset13(Opset12):
     T2 = TypeVar("T2", INT8, UINT8)
 
     def QuantizeLinear(
-        self, x: T1, y_scale: FLOAT, y_zero_point: Optional[T2] = None, axis: int = 1
+        self, x: T1, y_scale: FLOAT, y_zero_point: Optional[T2] = None, *, axis: int = 1
     ) -> T2:
         r"""[🌐 QuantizeLinear(13)](https://onnx.ai/onnx/operators/onnx__QuantizeLinear.html#quantizelinear-13 "Online Documentation")
 
@@ -2373,7 +2386,9 @@ class Opset13(Opset12):
 
     T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
-    def ReduceL1(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
+    def ReduceL1(
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceL1(13)](https://onnx.ai/onnx/operators/onnx__ReduceL1.html#reducel1-13 "Online Documentation")
 
 
@@ -2402,7 +2417,9 @@ class Opset13(Opset12):
 
     T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
-    def ReduceL2(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
+    def ReduceL2(
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceL2(13)](https://onnx.ai/onnx/operators/onnx__ReduceL2.html#reducel2-13 "Online Documentation")
 
 
@@ -2432,7 +2449,7 @@ class Opset13(Opset12):
     T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def ReduceLogSum(
-        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
     ) -> T:
         r"""[🌐 ReduceLogSum(13)](https://onnx.ai/onnx/operators/onnx__ReduceLogSum.html#reducelogsum-13 "Online Documentation")
 
@@ -2463,7 +2480,7 @@ class Opset13(Opset12):
     T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def ReduceLogSumExp(
-        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
     ) -> T:
         r"""[🌐 ReduceLogSumExp(13)](https://onnx.ai/onnx/operators/onnx__ReduceLogSumExp.html#reducelogsumexp-13 "Online Documentation")
 
@@ -2495,7 +2512,9 @@ class Opset13(Opset12):
         "T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8
     )
 
-    def ReduceMax(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
+    def ReduceMax(
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceMax(13)](https://onnx.ai/onnx/operators/onnx__ReduceMax.html#reducemax-13 "Online Documentation")
 
 
@@ -2525,7 +2544,7 @@ class Opset13(Opset12):
     T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def ReduceMean(
-        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
     ) -> T:
         r"""[🌐 ReduceMean(13)](https://onnx.ai/onnx/operators/onnx__ReduceMean.html#reducemean-13 "Online Documentation")
 
@@ -2557,7 +2576,9 @@ class Opset13(Opset12):
         "T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, INT8, UINT32, UINT64, UINT8
     )
 
-    def ReduceMin(self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1) -> T:
+    def ReduceMin(
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+    ) -> T:
         r"""[🌐 ReduceMin(13)](https://onnx.ai/onnx/operators/onnx__ReduceMin.html#reducemin-13 "Online Documentation")
 
 
@@ -2587,7 +2608,7 @@ class Opset13(Opset12):
     T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def ReduceProd(
-        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
     ) -> T:
         r"""[🌐 ReduceProd(13)](https://onnx.ai/onnx/operators/onnx__ReduceProd.html#reduceprod-13 "Online Documentation")
 
@@ -2621,6 +2642,7 @@ class Opset13(Opset12):
         self,
         data: T,
         axes: Optional[INT64] = None,
+        *,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
     ) -> T:
@@ -2664,7 +2686,7 @@ class Opset13(Opset12):
     T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
     def ReduceSumSquare(
-        self, data: T, axes: Optional[Sequence[int]] = None, keepdims: int = 1
+        self, data: T, *, axes: Optional[Sequence[int]] = None, keepdims: int = 1
     ) -> T:
         r"""[🌐 ReduceSumSquare(13)](https://onnx.ai/onnx/operators/onnx__ReduceSumSquare.html#reducesumsquare-13 "Online Documentation")
 
@@ -2781,6 +2803,7 @@ class Opset13(Opset12):
         roi: Optional[T2] = None,
         scales: Optional[FLOAT] = None,
         sizes: Optional[INT64] = None,
+        *,
         coordinate_transformation_mode: str = "half_pixel",
         cubic_coeff_a: float = -0.75,
         exclude_outside: int = 0,
@@ -2918,7 +2941,7 @@ class Opset13(Opset12):
 
     Tind = TypeVar("Tind", INT32, INT64)
 
-    def ScatterElements(self, data: T, indices: Tind, updates: T, axis: int = 0) -> T:
+    def ScatterElements(self, data: T, indices: Tind, updates: T, *, axis: int = 0) -> T:
         r"""[🌐 ScatterElements(13)](https://onnx.ai/onnx/operators/onnx__ScatterElements.html#scatterelements-13 "Online Documentation")
 
 
@@ -3350,7 +3373,7 @@ class Opset13(Opset12):
 
     T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
 
-    def Softmax(self, input: T, axis: int = -1) -> T:
+    def Softmax(self, input: T, *, axis: int = -1) -> T:
         r"""[🌐 Softmax(13)](https://onnx.ai/onnx/operators/onnx__Softmax.html#softmax-13 "Online Documentation")
 
 
@@ -3387,6 +3410,7 @@ class Opset13(Opset12):
         scores: T,
         labels: Tind,
         weights: Optional[T] = None,
+        *,
         ignore_index: Optional[int] = None,
         reduction: str = "mean",
     ) -> Tuple[T, T]:
@@ -3495,7 +3519,7 @@ class Opset13(Opset12):
         UINT8,
     )
 
-    def SpaceToDepth(self, input: T, blocksize: Optional[int] = None) -> T:
+    def SpaceToDepth(self, input: T, *, blocksize: Optional[int] = None) -> T:
         r"""[🌐 SpaceToDepth(13)](https://onnx.ai/onnx/operators/onnx__SpaceToDepth.html#spacetodepth-13 "Online Documentation")
 
         SpaceToDepth rearranges blocks of spatial data into depth. More specifically,
@@ -3534,7 +3558,7 @@ class Opset13(Opset12):
         UINT8,
     )
 
-    def Split(self, input: T, split: Optional[INT64] = None, axis: int = 0) -> T:
+    def Split(self, input: T, split: Optional[INT64] = None, *, axis: int = 0) -> T:
         r"""[🌐 Split(13)](https://onnx.ai/onnx/operators/onnx__Split.html#split-13 "Online Documentation")
 
         Split a tensor into a list of tensors, along the specified
@@ -3737,7 +3761,7 @@ class Opset13(Opset12):
         UINT8,
     )
 
-    def Transpose(self, data: T, perm: Optional[Sequence[int]] = None) -> T:
+    def Transpose(self, data: T, *, perm: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Transpose(13)](https://onnx.ai/onnx/operators/onnx__Transpose.html#transpose-13 "Online Documentation")
 
 

--- a/onnxscript/onnx_opset/_impl/opset13.py
+++ b/onnxscript/onnx_opset/_impl/opset13.py
@@ -237,7 +237,7 @@ class Opset13(Opset12):
         UINT8,
     )
 
-    def Cast(self, input: T1, *, to: Optional[int] = None) -> T2:
+    def Cast(self, input: T1, *, to: int) -> T2:
         r"""[🌐 Cast(13)](https://onnx.ai/onnx/operators/onnx__Cast.html#cast-13 "Online Documentation")
 
 
@@ -367,7 +367,7 @@ class Opset13(Opset12):
         UINT8,
     )
 
-    def Concat(self, *inputs: T, axis: Optional[int] = None) -> T:
+    def Concat(self, *inputs: T, axis: int) -> T:
         r"""[🌐 Concat(13)](https://onnx.ai/onnx/operators/onnx__Concat.html#concat-13 "Online Documentation")
 
         Concatenate a list of tensors into a single tensor. All input tensors must have the same shape, except for the dimension size of the axis to concatenate on.
@@ -479,9 +479,7 @@ class Opset13(Opset12):
         UINT8,
     )
 
-    def DepthToSpace(
-        self, input: T, *, blocksize: Optional[int] = None, mode: str = "DCR"
-    ) -> T:
+    def DepthToSpace(self, input: T, *, blocksize: int, mode: str = "DCR") -> T:
         r"""[🌐 DepthToSpace(13)](https://onnx.ai/onnx/operators/onnx__DepthToSpace.html#depthtospace-13 "Online Documentation")
 
         DepthToSpace rearranges (permutes) data from depth into blocks of spatial data.
@@ -1363,13 +1361,7 @@ class Opset13(Opset12):
         UINT8,
     )
 
-    def If(
-        self,
-        cond: B,
-        *,
-        else_branch: Optional[GraphProto] = None,
-        then_branch: Optional[GraphProto] = None,
-    ) -> V:
+    def If(self, cond: B, *, else_branch: GraphProto, then_branch: GraphProto) -> V:
         r"""[🌐 If(13)](https://onnx.ai/onnx/operators/onnx__If.html#if-13 "Online Documentation")
 
         If conditional
@@ -1420,7 +1412,7 @@ class Opset13(Opset12):
         alpha: float = 9.999999747378752e-05,
         beta: float = 0.75,
         bias: float = 1.0,
-        size: Optional[int] = None,
+        size: int,
     ) -> T:
         r"""[🌐 LRN(13)](https://onnx.ai/onnx/operators/onnx__LRN.html#lrn-13 "Online Documentation")
 
@@ -1583,13 +1575,7 @@ class Opset13(Opset12):
         UINT8,
     )
 
-    def Loop(
-        self,
-        M: Optional[I],
-        cond: Optional[B],
-        *v_initial: V,
-        body: Optional[GraphProto] = None,
-    ) -> V:
+    def Loop(self, M: Optional[I], cond: Optional[B], *v_initial: V, body: GraphProto) -> V:
         r"""[🌐 Loop(13)](https://onnx.ai/onnx/operators/onnx__Loop.html#loop-13 "Online Documentation")
 
 
@@ -3519,7 +3505,7 @@ class Opset13(Opset12):
         UINT8,
     )
 
-    def SpaceToDepth(self, input: T, *, blocksize: Optional[int] = None) -> T:
+    def SpaceToDepth(self, input: T, *, blocksize: int) -> T:
         r"""[🌐 SpaceToDepth(13)](https://onnx.ai/onnx/operators/onnx__SpaceToDepth.html#spacetodepth-13 "Online Documentation")
 
         SpaceToDepth rearranges blocks of spatial data into depth. More specifically,

--- a/onnxscript/onnx_opset/_impl/opset14.py
+++ b/onnxscript/onnx_opset/_impl/opset14.py
@@ -90,6 +90,7 @@ class Opset14(Opset13):
         B: T,
         input_mean: U,
         input_var: U,
+        *,
         epsilon: float = 9.999999747378752e-06,
         momentum: float = 0.8999999761581421,
         training_mode: int = 0,
@@ -182,7 +183,7 @@ class Opset14(Opset13):
 
     T2 = TypeVar("T2", INT32, INT64)
 
-    def CumSum(self, x: T, axis: T2, exclusive: int = 0, reverse: int = 0) -> T:
+    def CumSum(self, x: T, axis: T2, *, exclusive: int = 0, reverse: int = 0) -> T:
         r"""[🌐 CumSum(14)](https://onnx.ai/onnx/operators/onnx__CumSum.html#cumsum-14 "Online Documentation")
 
 
@@ -276,6 +277,7 @@ class Opset14(Opset13):
         B: Optional[T] = None,
         sequence_lens: Optional[T1] = None,
         initial_h: Optional[T] = None,
+        *,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Optional[Sequence[str]] = None,
@@ -497,6 +499,7 @@ class Opset14(Opset13):
         initial_h: Optional[T] = None,
         initial_c: Optional[T] = None,
         P: Optional[T] = None,
+        *,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Optional[Sequence[str]] = None,
@@ -698,6 +701,7 @@ class Opset14(Opset13):
         B: Optional[T] = None,
         sequence_lens: Optional[T1] = None,
         initial_h: Optional[T] = None,
+        *,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Sequence[str] = ("Tanh", "Tanh"),
@@ -863,7 +867,7 @@ class Opset14(Opset13):
         UINT8,
     )
 
-    def Reshape(self, data: T, shape: INT64, allowzero: int = 0) -> T:
+    def Reshape(self, data: T, shape: INT64, *, allowzero: int = 0) -> T:
         r"""[🌐 Reshape(14)](https://onnx.ai/onnx/operators/onnx__Reshape.html#reshape-14 "Online Documentation")
 
 
@@ -955,7 +959,7 @@ class Opset14(Opset13):
         UINT8,
     )
 
-    def Trilu(self, input: T, k: Optional[INT64] = None, upper: int = 1) -> T:
+    def Trilu(self, input: T, k: Optional[INT64] = None, *, upper: int = 1) -> T:
         r"""[🌐 Trilu(14)](https://onnx.ai/onnx/operators/onnx__Trilu.html#trilu-14 "Online Documentation")
 
 

--- a/onnxscript/onnx_opset/_impl/opset15.py
+++ b/onnxscript/onnx_opset/_impl/opset15.py
@@ -57,6 +57,7 @@ class Opset15(Opset14):
         B: T1,
         input_mean: T2,
         input_var: T2,
+        *,
         epsilon: float = 9.999999747378752e-06,
         momentum: float = 0.8999999761581421,
         training_mode: int = 0,
@@ -167,7 +168,7 @@ class Opset15(Opset14):
     )
 
     def Bernoulli(
-        self, input: T1, dtype: _Optional[int] = None, seed: _Optional[float] = None
+        self, input: T1, *, dtype: _Optional[int] = None, seed: _Optional[float] = None
     ) -> T2:
         r"""[🌐 Bernoulli(15)](https://onnx.ai/onnx/operators/onnx__Bernoulli.html#bernoulli-15 "Online Documentation")
 
@@ -318,7 +319,7 @@ class Opset15(Opset14):
         _Optional[UINT8],
     )
 
-    def Optional(self, input: _Optional[V] = None, type: _Optional[TypeProto] = None) -> O:
+    def Optional(self, input: _Optional[V] = None, *, type: _Optional[TypeProto] = None) -> O:
         r"""[🌐 Optional(15)](https://onnx.ai/onnx/operators/onnx__Optional.html#optional-15 "Online Documentation")
 
 
@@ -530,7 +531,7 @@ class Opset15(Opset14):
 
     T1 = TypeVar("T1", bound=INT64)
 
-    def Shape(self, data: T, end: _Optional[int] = None, start: int = 0) -> T1:
+    def Shape(self, data: T, *, end: _Optional[int] = None, start: int = 0) -> T1:
         r"""[🌐 Shape(15)](https://onnx.ai/onnx/operators/onnx__Shape.html#shape-15 "Online Documentation")
 
 

--- a/onnxscript/onnx_opset/_impl/opset16.py
+++ b/onnxscript/onnx_opset/_impl/opset16.py
@@ -318,13 +318,7 @@ class Opset16(Opset15):
         UINT8,
     )
 
-    def If(
-        self,
-        cond: B,
-        *,
-        else_branch: Optional[GraphProto] = None,
-        then_branch: Optional[GraphProto] = None,
-    ) -> V:
+    def If(self, cond: B, *, else_branch: GraphProto, then_branch: GraphProto) -> V:
         r"""[🌐 If(16)](https://onnx.ai/onnx/operators/onnx__If.html#if-16 "Online Documentation")
 
         If conditional
@@ -480,13 +474,7 @@ class Opset16(Opset15):
         UINT8,
     )
 
-    def Loop(
-        self,
-        M: Optional[I],
-        cond: Optional[B],
-        *v_initial: V,
-        body: Optional[GraphProto] = None,
-    ) -> V:
+    def Loop(self, M: Optional[I], cond: Optional[B], *v_initial: V, body: GraphProto) -> V:
         r"""[🌐 Loop(16)](https://onnx.ai/onnx/operators/onnx__Loop.html#loop-16 "Online Documentation")
 
 
@@ -779,8 +767,8 @@ class Opset16(Opset15):
     def Scan(
         self,
         *initial_state_and_scan_inputs: V,
-        body: Optional[GraphProto] = None,
-        num_scan_inputs: Optional[int] = None,
+        body: GraphProto,
+        num_scan_inputs: int,
         scan_input_axes: Optional[Sequence[int]] = None,
         scan_input_directions: Optional[Sequence[int]] = None,
         scan_output_axes: Optional[Sequence[int]] = None,

--- a/onnxscript/onnx_opset/_impl/opset16.py
+++ b/onnxscript/onnx_opset/_impl/opset16.py
@@ -106,6 +106,7 @@ class Opset16(Opset15):
         self,
         X: T1,
         grid: T2,
+        *,
         align_corners: int = 0,
         mode: str = "bilinear",
         padding_mode: str = "zeros",
@@ -320,6 +321,7 @@ class Opset16(Opset15):
     def If(
         self,
         cond: B,
+        *,
         else_branch: Optional[GraphProto] = None,
         then_branch: Optional[GraphProto] = None,
     ) -> V:
@@ -349,7 +351,7 @@ class Opset16(Opset15):
 
     T = TypeVar("T", BFLOAT16, DOUBLE, FLOAT, FLOAT16)
 
-    def LeakyRelu(self, X: T, alpha: float = 0.009999999776482582) -> T:
+    def LeakyRelu(self, X: T, *, alpha: float = 0.009999999776482582) -> T:
         r"""[🌐 LeakyRelu(16)](https://onnx.ai/onnx/operators/onnx__LeakyRelu.html#leakyrelu-16 "Online Documentation")
 
 
@@ -680,6 +682,7 @@ class Opset16(Opset15):
         X: T1,
         rois: T1,
         batch_indices: T2,
+        *,
         coordinate_transformation_mode: str = "half_pixel",
         mode: str = "avg",
         output_height: int = 1,
@@ -983,7 +986,7 @@ class Opset16(Opset15):
     Tind = TypeVar("Tind", INT32, INT64)
 
     def ScatterElements(
-        self, data: T, indices: Tind, updates: T, axis: int = 0, reduction: str = "none"
+        self, data: T, indices: Tind, updates: T, *, axis: int = 0, reduction: str = "none"
     ) -> T:
         r"""[🌐 ScatterElements(16)](https://onnx.ai/onnx/operators/onnx__ScatterElements.html#scatterelements-16 "Online Documentation")
 
@@ -1107,7 +1110,7 @@ class Opset16(Opset15):
         UINT8,
     )
 
-    def ScatterND(self, data: T, indices: INT64, updates: T, reduction: str = "none") -> T:
+    def ScatterND(self, data: T, indices: INT64, updates: T, *, reduction: str = "none") -> T:
         r"""[🌐 ScatterND(16)](https://onnx.ai/onnx/operators/onnx__ScatterND.html#scatternd-16 "Online Documentation")
 
 

--- a/onnxscript/onnx_opset/_impl/opset17.py
+++ b/onnxscript/onnx_opset/_impl/opset17.py
@@ -61,7 +61,7 @@ class Opset17(Opset16):
         UINT8,
     )
 
-    def BlackmanWindow(self, size: T1, output_datatype: int = 1, periodic: int = 1) -> T2:
+    def BlackmanWindow(self, size: T1, *, output_datatype: int = 1, periodic: int = 1) -> T2:
         r"""[🌐 BlackmanWindow(17)](https://onnx.ai/onnx/operators/onnx__BlackmanWindow.html#blackmanwindow-17 "Online Documentation")
 
 
@@ -98,6 +98,7 @@ class Opset17(Opset16):
         self,
         input: T1,
         dft_length: Optional[T2] = None,
+        *,
         axis: int = 1,
         inverse: int = 0,
         onesided: int = 0,
@@ -163,7 +164,7 @@ class Opset17(Opset16):
         UINT8,
     )
 
-    def HammingWindow(self, size: T1, output_datatype: int = 1, periodic: int = 1) -> T2:
+    def HammingWindow(self, size: T1, *, output_datatype: int = 1, periodic: int = 1) -> T2:
         r"""[🌐 HammingWindow(17)](https://onnx.ai/onnx/operators/onnx__HammingWindow.html#hammingwindow-17 "Online Documentation")
 
 
@@ -210,7 +211,7 @@ class Opset17(Opset16):
         UINT8,
     )
 
-    def HannWindow(self, size: T1, output_datatype: int = 1, periodic: int = 1) -> T2:
+    def HannWindow(self, size: T1, *, output_datatype: int = 1, periodic: int = 1) -> T2:
         r"""[🌐 HannWindow(17)](https://onnx.ai/onnx/operators/onnx__HannWindow.html#hannwindow-17 "Online Documentation")
 
 
@@ -248,6 +249,7 @@ class Opset17(Opset16):
         X: T,
         Scale: T,
         B: Optional[T] = None,
+        *,
         axis: int = -1,
         epsilon: float = 9.999999747378752e-06,
         stash_type: int = 1,
@@ -349,6 +351,7 @@ class Opset17(Opset16):
         sample_rate: T1,
         lower_edge_hertz: T2,
         upper_edge_hertz: T2,
+        *,
         output_datatype: int = 1,
     ) -> T3:
         r"""[🌐 MelWeightMatrix(17)](https://onnx.ai/onnx/operators/onnx__MelWeightMatrix.html#melweightmatrix-17 "Online Documentation")
@@ -413,6 +416,7 @@ class Opset17(Opset16):
         frame_step: T2,
         window: Optional[T1] = None,
         frame_length: Optional[T2] = None,
+        *,
         onesided: int = 1,
     ) -> T1:
         r"""[🌐 STFT(17)](https://onnx.ai/onnx/operators/onnx__STFT.html#stft-17 "Online Documentation")

--- a/onnxscript/onnx_opset/_impl/opset17.py
+++ b/onnxscript/onnx_opset/_impl/opset17.py
@@ -512,9 +512,7 @@ class Opset17(Opset16):
         UINT8,
     )
 
-    def SequenceMap(
-        self, input_sequence: S, *additional_inputs: V, body: Optional[GraphProto] = None
-    ) -> S:
+    def SequenceMap(self, input_sequence: S, *additional_inputs: V, body: GraphProto) -> S:
         r"""[🌐 SequenceMap(17)](https://onnx.ai/onnx/operators/onnx__SequenceMap.html#sequencemap-17 "Online Documentation")
 
 

--- a/onnxscript/onnx_opset/_impl/opset18.py
+++ b/onnxscript/onnx_opset/_impl/opset18.py
@@ -281,7 +281,7 @@ class Opset18(Opset17):
         bias: T,
         *,
         epsilon: float = 9.999999747378752e-06,
-        num_groups: Optional[int] = None,
+        num_groups: int,
     ) -> T:
         r"""[🌐 GroupNormalization(18)](https://onnx.ai/onnx/operators/onnx__GroupNormalization.html#groupnormalization-18 "Online Documentation")
 
@@ -340,7 +340,7 @@ class Opset18(Opset17):
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         dilations: Optional[Sequence[int]] = None,
-        kernel_shape: Optional[Sequence[int]] = None,
+        kernel_shape: Sequence[int],
         p: int = 2,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,

--- a/onnxscript/onnx_opset/_impl/opset18.py
+++ b/onnxscript/onnx_opset/_impl/opset18.py
@@ -148,7 +148,7 @@ class Opset18(Opset17):
     Tind = TypeVar("Tind", INT32, INT64)
 
     def CenterCropPad(
-        self, input_data: T, shape: Tind, axes: Optional[Sequence[int]] = None
+        self, input_data: T, shape: Tind, *, axes: Optional[Sequence[int]] = None
     ) -> T:
         r"""[🌐 CenterCropPad(18)](https://onnx.ai/onnx/operators/onnx__CenterCropPad.html#centercroppad-18 "Online Documentation")
 
@@ -205,6 +205,7 @@ class Opset18(Opset17):
         input: T,
         image_shape: INT64,
         block_shape: INT64,
+        *,
         dilations: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
@@ -278,6 +279,7 @@ class Opset18(Opset17):
         X: T,
         scale: T,
         bias: T,
+        *,
         epsilon: float = 9.999999747378752e-06,
         num_groups: Optional[int] = None,
     ) -> T:
@@ -334,6 +336,7 @@ class Opset18(Opset17):
     def LpPool(
         self,
         X: T,
+        *,
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         dilations: Optional[Sequence[int]] = None,
@@ -673,6 +676,7 @@ class Opset18(Opset17):
         pads: INT64,
         constant_value: Optional[T] = None,
         axes: Optional[Tind] = None,
+        *,
         mode: str = "constant",
     ) -> T:
         r"""[🌐 Pad(18)](https://onnx.ai/onnx/operators/onnx__Pad.html#pad-18 "Online Documentation")
@@ -797,6 +801,7 @@ class Opset18(Opset17):
         self,
         data: T,
         axes: Optional[INT64] = None,
+        *,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
     ) -> T:
@@ -843,6 +848,7 @@ class Opset18(Opset17):
         self,
         data: T,
         axes: Optional[INT64] = None,
+        *,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
     ) -> T:
@@ -889,6 +895,7 @@ class Opset18(Opset17):
         self,
         data: T,
         axes: Optional[INT64] = None,
+        *,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
     ) -> T:
@@ -935,6 +942,7 @@ class Opset18(Opset17):
         self,
         data: T,
         axes: Optional[INT64] = None,
+        *,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
     ) -> T:
@@ -983,6 +991,7 @@ class Opset18(Opset17):
         self,
         data: T,
         axes: Optional[INT64] = None,
+        *,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
     ) -> T:
@@ -1029,6 +1038,7 @@ class Opset18(Opset17):
         self,
         data: T,
         axes: Optional[INT64] = None,
+        *,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
     ) -> T:
@@ -1077,6 +1087,7 @@ class Opset18(Opset17):
         self,
         data: T,
         axes: Optional[INT64] = None,
+        *,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
     ) -> T:
@@ -1123,6 +1134,7 @@ class Opset18(Opset17):
         self,
         data: T,
         axes: Optional[INT64] = None,
+        *,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
     ) -> T:
@@ -1169,6 +1181,7 @@ class Opset18(Opset17):
         self,
         data: T,
         axes: Optional[INT64] = None,
+        *,
         keepdims: int = 1,
         noop_with_empty_axes: int = 0,
     ) -> T:
@@ -1237,6 +1250,7 @@ class Opset18(Opset17):
         roi: Optional[T2] = None,
         scales: Optional[FLOAT] = None,
         sizes: Optional[INT64] = None,
+        *,
         antialias: int = 0,
         axes: Optional[Sequence[int]] = None,
         coordinate_transformation_mode: str = "half_pixel",
@@ -1427,7 +1441,7 @@ class Opset18(Opset17):
     Tind = TypeVar("Tind", INT32, INT64)
 
     def ScatterElements(
-        self, data: T, indices: Tind, updates: T, axis: int = 0, reduction: str = "none"
+        self, data: T, indices: Tind, updates: T, *, axis: int = 0, reduction: str = "none"
     ) -> T:
         r"""[🌐 ScatterElements(18)](https://onnx.ai/onnx/operators/onnx__ScatterElements.html#scatterelements-18 "Online Documentation")
 
@@ -1553,7 +1567,7 @@ class Opset18(Opset17):
         UINT8,
     )
 
-    def ScatterND(self, data: T, indices: INT64, updates: T, reduction: str = "none") -> T:
+    def ScatterND(self, data: T, indices: INT64, updates: T, *, reduction: str = "none") -> T:
         r"""[🌐 ScatterND(18)](https://onnx.ai/onnx/operators/onnx__ScatterND.html#scatternd-18 "Online Documentation")
 
 
@@ -1684,6 +1698,7 @@ class Opset18(Opset17):
         self,
         input: T,
         split: Optional[INT64] = None,
+        *,
         axis: int = 0,
         num_outputs: Optional[int] = None,
     ) -> T:

--- a/onnxscript/onnx_opset/_impl/opset19.py
+++ b/onnxscript/onnx_opset/_impl/opset19.py
@@ -57,7 +57,7 @@ class Opset19(Opset18):
         ceil_mode: int = 0,
         count_include_pad: int = 0,
         dilations: Optional[Sequence[int]] = None,
-        kernel_shape: Optional[Sequence[int]] = None,
+        kernel_shape: Sequence[int],
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
     ) -> T:
@@ -191,7 +191,7 @@ class Opset19(Opset18):
         UINT8,
     )
 
-    def Cast(self, input: T1, *, saturate: int = 1, to: Optional[int] = None) -> T2:
+    def Cast(self, input: T1, *, saturate: int = 1, to: int) -> T2:
         r"""[🌐 Cast(19)](https://onnx.ai/onnx/operators/onnx__Cast.html#cast-19 "Online Documentation")
 
 
@@ -758,13 +758,7 @@ class Opset19(Opset18):
         UINT8,
     )
 
-    def If(
-        self,
-        cond: B,
-        *,
-        else_branch: Optional[GraphProto] = None,
-        then_branch: Optional[GraphProto] = None,
-    ) -> V:
+    def If(self, cond: B, *, else_branch: GraphProto, then_branch: GraphProto) -> V:
         r"""[🌐 If(19)](https://onnx.ai/onnx/operators/onnx__If.html#if-19 "Online Documentation")
 
         If conditional
@@ -873,13 +867,7 @@ class Opset19(Opset18):
         UINT8,
     )
 
-    def Loop(
-        self,
-        M: Optional[I],
-        cond: Optional[B],
-        *v_initial: V,
-        body: Optional[GraphProto] = None,
-    ) -> V:
+    def Loop(self, M: Optional[I], cond: Optional[B], *v_initial: V, body: GraphProto) -> V:
         r"""[🌐 Loop(19)](https://onnx.ai/onnx/operators/onnx__Loop.html#loop-19 "Online Documentation")
 
 
@@ -1604,8 +1592,8 @@ class Opset19(Opset18):
     def Scan(
         self,
         *initial_state_and_scan_inputs: V,
-        body: Optional[GraphProto] = None,
-        num_scan_inputs: Optional[int] = None,
+        body: GraphProto,
+        num_scan_inputs: int,
         scan_input_axes: Optional[Sequence[int]] = None,
         scan_input_directions: Optional[Sequence[int]] = None,
         scan_output_axes: Optional[Sequence[int]] = None,

--- a/onnxscript/onnx_opset/_impl/opset19.py
+++ b/onnxscript/onnx_opset/_impl/opset19.py
@@ -52,6 +52,7 @@ class Opset19(Opset18):
     def AveragePool(
         self,
         X: T,
+        *,
         auto_pad: str = "NOTSET",
         ceil_mode: int = 0,
         count_include_pad: int = 0,
@@ -190,7 +191,7 @@ class Opset19(Opset18):
         UINT8,
     )
 
-    def Cast(self, input: T1, saturate: int = 1, to: Optional[int] = None) -> T2:
+    def Cast(self, input: T1, *, saturate: int = 1, to: Optional[int] = None) -> T2:
         r"""[🌐 Cast(19)](https://onnx.ai/onnx/operators/onnx__Cast.html#cast-19 "Online Documentation")
 
 
@@ -321,7 +322,7 @@ class Opset19(Opset18):
         UINT8,
     )
 
-    def CastLike(self, input: T1, target_type: T2, saturate: int = 1) -> T2:
+    def CastLike(self, input: T1, target_type: T2, *, saturate: int = 1) -> T2:
         r"""[🌐 CastLike(19)](https://onnx.ai/onnx/operators/onnx__CastLike.html#castlike-19 "Online Documentation")
 
 
@@ -373,6 +374,7 @@ class Opset19(Opset18):
 
     def Constant(
         self,
+        *,
         sparse_value: Optional[SparseTensorProto] = None,
         value: Optional[TensorProto] = None,
         value_float: Optional[float] = None,
@@ -435,6 +437,7 @@ class Opset19(Opset18):
         offset: T,
         B: Optional[T] = None,
         mask: Optional[T] = None,
+        *,
         dilations: Optional[Sequence[int]] = None,
         group: int = 1,
         kernel_shape: Optional[Sequence[int]] = None,
@@ -517,7 +520,7 @@ class Opset19(Opset18):
     T2 = TypeVar("T2", BFLOAT16, FLOAT, FLOAT16)
 
     def DequantizeLinear(
-        self, x: T1, x_scale: T2, x_zero_point: Optional[T1] = None, axis: int = 1
+        self, x: T1, x_scale: T2, x_zero_point: Optional[T1] = None, *, axis: int = 1
     ) -> T2:
         r"""[🌐 DequantizeLinear(19)](https://onnx.ai/onnx/operators/onnx__DequantizeLinear.html#dequantizelinear-19 "Online Documentation")
 
@@ -758,6 +761,7 @@ class Opset19(Opset18):
     def If(
         self,
         cond: B,
+        *,
         else_branch: Optional[GraphProto] = None,
         then_branch: Optional[GraphProto] = None,
     ) -> V:
@@ -1067,6 +1071,7 @@ class Opset19(Opset18):
         pads: INT64,
         constant_value: Optional[T] = None,
         axes: Optional[Tind] = None,
+        *,
         mode: str = "constant",
     ) -> T:
         r"""[🌐 Pad(19)](https://onnx.ai/onnx/operators/onnx__Pad.html#pad-19 "Online Documentation")
@@ -1221,6 +1226,7 @@ class Opset19(Opset18):
         x: T1,
         y_scale: T1,
         y_zero_point: Optional[T2] = None,
+        *,
         axis: int = 1,
         saturate: int = 1,
     ) -> T2:
@@ -1293,7 +1299,7 @@ class Opset19(Opset18):
         UINT8,
     )
 
-    def Reshape(self, data: T, shape: INT64, allowzero: int = 0) -> T:
+    def Reshape(self, data: T, shape: INT64, *, allowzero: int = 0) -> T:
         r"""[🌐 Reshape(19)](https://onnx.ai/onnx/operators/onnx__Reshape.html#reshape-19 "Online Documentation")
 
 
@@ -1356,6 +1362,7 @@ class Opset19(Opset18):
         roi: Optional[T2] = None,
         scales: Optional[FLOAT] = None,
         sizes: Optional[INT64] = None,
+        *,
         antialias: int = 0,
         axes: Optional[Sequence[int]] = None,
         coordinate_transformation_mode: str = "half_pixel",
@@ -1807,7 +1814,7 @@ class Opset19(Opset18):
 
     T1 = TypeVar("T1", bound=INT64)
 
-    def Shape(self, data: T, end: Optional[int] = None, start: int = 0) -> T1:
+    def Shape(self, data: T, *, end: Optional[int] = None, start: int = 0) -> T1:
         r"""[🌐 Shape(19)](https://onnx.ai/onnx/operators/onnx__Shape.html#shape-19 "Online Documentation")
 
 

--- a/onnxscript/onnx_opset/_impl/opset2.py
+++ b/onnxscript/onnx_opset/_impl/opset2.py
@@ -43,7 +43,7 @@ class Opset2(Opset1):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def GlobalLpPool(self, X: T, p: int = 2) -> T:
+    def GlobalLpPool(self, X: T, *, p: int = 2) -> T:
         r"""[🌐 GlobalLpPool(2)](https://onnx.ai/onnx/operators/onnx__GlobalLpPool.html#globallppool-2 "Online Documentation")
 
 
@@ -70,6 +70,7 @@ class Opset2(Opset1):
     def LpPool(
         self,
         X: T,
+        *,
         auto_pad: str = "NOTSET",
         kernel_shape: Optional[Sequence[int]] = None,
         p: int = 2,
@@ -132,6 +133,7 @@ class Opset2(Opset1):
     def Pad(
         self,
         data: T,
+        *,
         mode: str = "constant",
         pads: Optional[Sequence[int]] = None,
         value: float = 0.0,
@@ -196,7 +198,7 @@ class Opset2(Opset1):
         UINT8,
     )
 
-    def Split(self, input: T, axis: int = 0, split: Optional[Sequence[int]] = None) -> T:
+    def Split(self, input: T, *, axis: int = 0, split: Optional[Sequence[int]] = None) -> T:
         r"""[🌐 Split(2)](https://onnx.ai/onnx/operators/onnx__Split.html#split-2 "Online Documentation")
 
         Split a tensor into a list of tensors, along the specified

--- a/onnxscript/onnx_opset/_impl/opset2.py
+++ b/onnxscript/onnx_opset/_impl/opset2.py
@@ -72,7 +72,7 @@ class Opset2(Opset1):
         X: T,
         *,
         auto_pad: str = "NOTSET",
-        kernel_shape: Optional[Sequence[int]] = None,
+        kernel_shape: Sequence[int],
         p: int = 2,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
@@ -131,12 +131,7 @@ class Opset2(Opset1):
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def Pad(
-        self,
-        data: T,
-        *,
-        mode: str = "constant",
-        pads: Optional[Sequence[int]] = None,
-        value: float = 0.0,
+        self, data: T, *, mode: str = "constant", pads: Sequence[int], value: float = 0.0
     ) -> T:
         r"""[🌐 Pad(2)](https://onnx.ai/onnx/operators/onnx__Pad.html#pad-2 "Online Documentation")
 

--- a/onnxscript/onnx_opset/_impl/opset3.py
+++ b/onnxscript/onnx_opset/_impl/opset3.py
@@ -37,6 +37,7 @@ class Opset3(Opset2):
         B: Optional[T] = None,
         sequence_lens: Optional[T1] = None,
         initial_h: Optional[T] = None,
+        *,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Optional[Sequence[str]] = None,

--- a/onnxscript/onnx_opset/_impl/opset4.py
+++ b/onnxscript/onnx_opset/_impl/opset4.py
@@ -12,7 +12,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, TypeVar
+from typing import TypeVar
 
 from onnx.defs import get_schema
 
@@ -60,7 +60,7 @@ class Opset4(Opset3):
         UINT8,
     )
 
-    def Concat(self, *inputs: T, axis: Optional[int] = None) -> T:
+    def Concat(self, *inputs: T, axis: int) -> T:
         r"""[🌐 Concat(4)](https://onnx.ai/onnx/operators/onnx__Concat.html#concat-4 "Online Documentation")
 
         Concatenate a list of tensors into a single tensor

--- a/onnxscript/onnx_opset/_impl/opset6.py
+++ b/onnxscript/onnx_opset/_impl/opset6.py
@@ -205,7 +205,7 @@ class Opset6(Opset5):
         UINT8,
     )
 
-    def Cast(self, input: T1, *, to: Optional[int] = None) -> T2:
+    def Cast(self, input: T1, *, to: int) -> T2:
         r"""[🌐 Cast(6)](https://onnx.ai/onnx/operators/onnx__Cast.html#cast-6 "Online Documentation")
 
 

--- a/onnxscript/onnx_opset/_impl/opset6.py
+++ b/onnxscript/onnx_opset/_impl/opset6.py
@@ -64,7 +64,7 @@ class Opset6(Opset5):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
-    def Add(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T:
+    def Add(self, A: T, B: T, *, axis: Optional[int] = None, broadcast: int = 0) -> T:
         r"""[🌐 Add(6)](https://onnx.ai/onnx/operators/onnx__Add.html#add-6 "Online Documentation")
 
 
@@ -114,6 +114,7 @@ class Opset6(Opset5):
         B: T,
         mean: T,
         var: T,
+        *,
         epsilon: float = 9.999999747378752e-06,
         is_test: int = 0,
         momentum: float = 0.8999999761581421,
@@ -204,7 +205,7 @@ class Opset6(Opset5):
         UINT8,
     )
 
-    def Cast(self, input: T1, to: Optional[int] = None) -> T2:
+    def Cast(self, input: T1, *, to: Optional[int] = None) -> T2:
         r"""[🌐 Cast(6)](https://onnx.ai/onnx/operators/onnx__Cast.html#cast-6 "Online Documentation")
 
 
@@ -248,7 +249,11 @@ class Opset6(Opset5):
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def Clip(
-        self, input: T, max: float = 3.4028234663852886e38, min: float = -3.4028234663852886e38
+        self,
+        input: T,
+        *,
+        max: float = 3.4028234663852886e38,
+        min: float = -3.4028234663852886e38,
     ) -> T:
         r"""[🌐 Clip(6)](https://onnx.ai/onnx/operators/onnx__Clip.html#clip-6 "Online Documentation")
 
@@ -272,7 +277,7 @@ class Opset6(Opset5):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
-    def Div(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T:
+    def Div(self, A: T, B: T, *, axis: Optional[int] = None, broadcast: int = 0) -> T:
         r"""[🌐 Div(6)](https://onnx.ai/onnx/operators/onnx__Div.html#div-6 "Online Documentation")
 
 
@@ -315,7 +320,7 @@ class Opset6(Opset5):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Dropout(self, data: T, is_test: int = 0, ratio: float = 0.5) -> Tuple[T, T]:
+    def Dropout(self, data: T, *, is_test: int = 0, ratio: float = 0.5) -> Tuple[T, T]:
         r"""[🌐 Dropout(6)](https://onnx.ai/onnx/operators/onnx__Dropout.html#dropout-6 "Online Documentation")
 
 
@@ -341,7 +346,7 @@ class Opset6(Opset5):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Elu(self, X: T, alpha: float = 1.0) -> T:
+    def Elu(self, X: T, *, alpha: float = 1.0) -> T:
         r"""[🌐 Elu(6)](https://onnx.ai/onnx/operators/onnx__Elu.html#elu-6 "Online Documentation")
 
 
@@ -404,6 +409,7 @@ class Opset6(Opset5):
         A: T,
         B: T,
         C: T,
+        *,
         alpha: float = 1.0,
         beta: float = 1.0,
         broadcast: int = 0,
@@ -454,7 +460,7 @@ class Opset6(Opset5):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def HardSigmoid(self, X: T, alpha: float = 0.20000000298023224, beta: float = 0.5) -> T:
+    def HardSigmoid(self, X: T, *, alpha: float = 0.20000000298023224, beta: float = 0.5) -> T:
         r"""[🌐 HardSigmoid(6)](https://onnx.ai/onnx/operators/onnx__HardSigmoid.html#hardsigmoid-6 "Online Documentation")
 
 
@@ -478,7 +484,7 @@ class Opset6(Opset5):
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def InstanceNormalization(
-        self, input: T, scale: T, B: T, epsilon: float = 9.999999747378752e-06
+        self, input: T, scale: T, B: T, *, epsilon: float = 9.999999747378752e-06
     ) -> T:
         r"""[🌐 InstanceNormalization(6)](https://onnx.ai/onnx/operators/onnx__InstanceNormalization.html#instancenormalization-6 "Online Documentation")
 
@@ -511,7 +517,7 @@ class Opset6(Opset5):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def LeakyRelu(self, X: T, alpha: float = 0.009999999776482582) -> T:
+    def LeakyRelu(self, X: T, *, alpha: float = 0.009999999776482582) -> T:
         r"""[🌐 LeakyRelu(6)](https://onnx.ai/onnx/operators/onnx__LeakyRelu.html#leakyrelu-6 "Online Documentation")
 
 
@@ -603,7 +609,7 @@ class Opset6(Opset5):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
-    def Mul(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T:
+    def Mul(self, A: T, B: T, *, axis: Optional[int] = None, broadcast: int = 0) -> T:
         r"""[🌐 Mul(6)](https://onnx.ai/onnx/operators/onnx__Mul.html#mul-6 "Online Documentation")
 
 
@@ -728,7 +734,7 @@ class Opset6(Opset5):
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
     def Selu(
-        self, X: T, alpha: float = 1.6732631921768188, gamma: float = 1.0507010221481323
+        self, X: T, *, alpha: float = 1.6732631921768188, gamma: float = 1.0507010221481323
     ) -> T:
         r"""[🌐 Selu(6)](https://onnx.ai/onnx/operators/onnx__Selu.html#selu-6 "Online Documentation")
 
@@ -793,7 +799,7 @@ class Opset6(Opset5):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16, INT32, INT64, UINT32, UINT64)
 
-    def Sub(self, A: T, B: T, axis: Optional[int] = None, broadcast: int = 0) -> T:
+    def Sub(self, A: T, B: T, *, axis: Optional[int] = None, broadcast: int = 0) -> T:
         r"""[🌐 Sub(6)](https://onnx.ai/onnx/operators/onnx__Sub.html#sub-6 "Online Documentation")
 
 

--- a/onnxscript/onnx_opset/_impl/opset7.py
+++ b/onnxscript/onnx_opset/_impl/opset7.py
@@ -145,7 +145,7 @@ class Opset7(Opset6):
         *,
         auto_pad: str = "NOTSET",
         count_include_pad: int = 0,
-        kernel_shape: Optional[Sequence[int]] = None,
+        kernel_shape: Sequence[int],
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
     ) -> T:
@@ -1179,9 +1179,7 @@ class Opset7(Opset6):
         UINT8,
     )
 
-    def Upsample(
-        self, X: T, *, mode: str = "nearest", scales: Optional[Sequence[float]] = None
-    ) -> T:
+    def Upsample(self, X: T, *, mode: str = "nearest", scales: Sequence[float]) -> T:
         r"""[🌐 Upsample(7)](https://onnx.ai/onnx/operators/onnx__Upsample.html#upsample-7 "Online Documentation")
 
 

--- a/onnxscript/onnx_opset/_impl/opset7.py
+++ b/onnxscript/onnx_opset/_impl/opset7.py
@@ -142,6 +142,7 @@ class Opset7(Opset6):
     def AveragePool(
         self,
         X: T,
+        *,
         auto_pad: str = "NOTSET",
         count_include_pad: int = 0,
         kernel_shape: Optional[Sequence[int]] = None,
@@ -229,6 +230,7 @@ class Opset7(Opset6):
         B: T,
         mean: T,
         var: T,
+        *,
         epsilon: float = 9.999999747378752e-06,
         momentum: float = 0.8999999761581421,
         spatial: int = 1,
@@ -327,7 +329,7 @@ class Opset7(Opset6):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def Dropout(self, data: T, ratio: float = 0.5) -> Tuple[T, T]:
+    def Dropout(self, data: T, *, ratio: float = 0.5) -> Tuple[T, T]:
         r"""[🌐 Dropout(7)](https://onnx.ai/onnx/operators/onnx__Dropout.html#dropout-7 "Online Documentation")
 
 
@@ -385,6 +387,7 @@ class Opset7(Opset6):
         B: Optional[T] = None,
         sequence_lens: Optional[T1] = None,
         initial_h: Optional[T] = None,
+        *,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Optional[Sequence[str]] = None,
@@ -546,6 +549,7 @@ class Opset7(Opset6):
         A: T,
         B: T,
         C: T,
+        *,
         alpha: float = 1.0,
         beta: float = 1.0,
         transA: int = 0,
@@ -633,6 +637,7 @@ class Opset7(Opset6):
         initial_h: Optional[T] = None,
         initial_c: Optional[T] = None,
         P: Optional[T] = None,
+        *,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Optional[Sequence[str]] = None,
@@ -852,7 +857,7 @@ class Opset7(Opset6):
     T2 = TypeVar("T2", INT32, INT64)
 
     def Multinomial(
-        self, input: T1, dtype: int = 6, sample_size: int = 1, seed: Optional[float] = None
+        self, input: T1, *, dtype: int = 6, sample_size: int = 1, seed: Optional[float] = None
     ) -> T2:
         r"""[🌐 Multinomial(7)](https://onnx.ai/onnx/operators/onnx__Multinomial.html#multinomial-7 "Online Documentation")
 
@@ -964,6 +969,7 @@ class Opset7(Opset6):
         B: Optional[T] = None,
         sequence_lens: Optional[T1] = None,
         initial_h: Optional[T] = None,
+        *,
         activation_alpha: Optional[Sequence[float]] = None,
         activation_beta: Optional[Sequence[float]] = None,
         activations: Sequence[str] = ("Tanh", "Tanh"),
@@ -1174,7 +1180,7 @@ class Opset7(Opset6):
     )
 
     def Upsample(
-        self, X: T, mode: str = "nearest", scales: Optional[Sequence[float]] = None
+        self, X: T, *, mode: str = "nearest", scales: Optional[Sequence[float]] = None
     ) -> T:
         r"""[🌐 Upsample(7)](https://onnx.ai/onnx/operators/onnx__Upsample.html#upsample-7 "Online Documentation")
 

--- a/onnxscript/onnx_opset/_impl/opset8.py
+++ b/onnxscript/onnx_opset/_impl/opset8.py
@@ -112,6 +112,7 @@ class Opset8(Opset7):
     def MaxPool(
         self,
         X: T,
+        *,
         auto_pad: str = "NOTSET",
         kernel_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,

--- a/onnxscript/onnx_opset/_impl/opset8.py
+++ b/onnxscript/onnx_opset/_impl/opset8.py
@@ -114,7 +114,7 @@ class Opset8(Opset7):
         X: T,
         *,
         auto_pad: str = "NOTSET",
-        kernel_shape: Optional[Sequence[int]] = None,
+        kernel_shape: Sequence[int],
         pads: Optional[Sequence[int]] = None,
         storage_order: int = 0,
         strides: Optional[Sequence[int]] = None,
@@ -254,9 +254,9 @@ class Opset8(Opset7):
         self,
         sequence_lens: Optional[I],
         *initial_state_and_scan_inputs: V,
-        body: Optional[GraphProto] = None,
+        body: GraphProto,
         directions: Optional[Sequence[int]] = None,
-        num_scan_inputs: Optional[int] = None,
+        num_scan_inputs: int,
     ) -> V:
         r"""[🌐 Scan(8)](https://onnx.ai/onnx/operators/onnx__Scan.html#scan-8 "Online Documentation")
 

--- a/onnxscript/onnx_opset/_impl/opset9.py
+++ b/onnxscript/onnx_opset/_impl/opset9.py
@@ -102,6 +102,7 @@ class Opset9(Opset8):
         B: T,
         mean: T,
         var: T,
+        *,
         epsilon: float = 9.999999747378752e-06,
         momentum: float = 0.8999999761581421,
     ) -> Tuple[T, T, T, T, T]:
@@ -186,7 +187,7 @@ class Opset9(Opset8):
         UINT8,
     )
 
-    def Cast(self, input: T1, to: Optional[int] = None) -> T2:
+    def Cast(self, input: T1, *, to: Optional[int] = None) -> T2:
         r"""[🌐 Cast(9)](https://onnx.ai/onnx/operators/onnx__Cast.html#cast-9 "Online Documentation")
 
 
@@ -243,7 +244,7 @@ class Opset9(Opset8):
 
     T1 = TypeVar("T1", bound=BOOL)
 
-    def Compress(self, input: T, condition: T1, axis: Optional[int] = None) -> T:
+    def Compress(self, input: T, condition: T1, *, axis: Optional[int] = None) -> T:
         r"""[🌐 Compress(9)](https://onnx.ai/onnx/operators/onnx__Compress.html#compress-9 "Online Documentation")
 
 
@@ -288,7 +289,7 @@ class Opset9(Opset8):
         UINT8,
     )
 
-    def Constant(self, value: Optional[TensorProto] = None) -> T:
+    def Constant(self, *, value: Optional[TensorProto] = None) -> T:
         r"""[🌐 Constant(9)](https://onnx.ai/onnx/operators/onnx__Constant.html#constant-9 "Online Documentation")
 
         A constant tensor.
@@ -319,7 +320,7 @@ class Opset9(Opset8):
         UINT8,
     )
 
-    def ConstantOfShape(self, input: T1, value: Optional[TensorProto] = None) -> T2:
+    def ConstantOfShape(self, input: T1, *, value: Optional[TensorProto] = None) -> T2:
         r"""[🌐 ConstantOfShape(9)](https://onnx.ai/onnx/operators/onnx__ConstantOfShape.html#constantofshape-9 "Online Documentation")
 
 
@@ -407,7 +408,7 @@ class Opset9(Opset8):
         UINT8,
     )
 
-    def EyeLike(self, input: T1, dtype: Optional[int] = None, k: int = 0) -> T2:
+    def EyeLike(self, input: T1, *, dtype: Optional[int] = None, k: int = 0) -> T2:
         r"""[🌐 EyeLike(9)](https://onnx.ai/onnx/operators/onnx__EyeLike.html#eyelike-9 "Online Documentation")
 
 
@@ -456,7 +457,7 @@ class Opset9(Opset8):
         UINT8,
     )
 
-    def Flatten(self, input: T, axis: int = 1) -> T:
+    def Flatten(self, input: T, *, axis: int = 1) -> T:
         r"""[🌐 Flatten(9)](https://onnx.ai/onnx/operators/onnx__Flatten.html#flatten-9 "Online Documentation")
 
 
@@ -486,6 +487,7 @@ class Opset9(Opset8):
         A: T,
         B: T,
         C: T,
+        *,
         alpha: float = 1.0,
         beta: float = 1.0,
         transA: int = 0,
@@ -632,6 +634,7 @@ class Opset9(Opset8):
         X: T1,
         I: T2,
         output_shape: Optional[T2] = None,
+        *,
         kernel_shape: Optional[Sequence[int]] = None,
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
@@ -708,7 +711,7 @@ class Opset9(Opset8):
 
     T = TypeVar("T", DOUBLE, FLOAT, FLOAT16)
 
-    def MeanVarianceNormalization(self, X: T, axes: Sequence[int] = (0, 2, 3)) -> T:
+    def MeanVarianceNormalization(self, X: T, *, axes: Sequence[int] = (0, 2, 3)) -> T:
         r"""[🌐 MeanVarianceNormalization(9)](https://onnx.ai/onnx/operators/onnx__MeanVarianceNormalization.html#meanvariancenormalization-9 "Online Documentation")
 
 
@@ -794,7 +797,7 @@ class Opset9(Opset8):
         UINT8,
     )
 
-    def OneHot(self, indices: T1, depth: T2, values: T3, axis: int = -1) -> T3:
+    def OneHot(self, indices: T1, depth: T2, values: T3, *, axis: int = -1) -> T3:
         r"""[🌐 OneHot(9)](https://onnx.ai/onnx/operators/onnx__OneHot.html#onehot-9 "Online Documentation")
 
 
@@ -1088,7 +1091,7 @@ class Opset9(Opset8):
 
     Tind = TypeVar("Tind", INT32, INT64)
 
-    def Scatter(self, data: T, indices: Tind, updates: T, axis: int = 0) -> T:
+    def Scatter(self, data: T, indices: Tind, updates: T, *, axis: int = 0) -> T:
         r"""[🌐 Scatter(9)](https://onnx.ai/onnx/operators/onnx__Scatter.html#scatter-9 "Online Documentation")
 
 
@@ -1144,7 +1147,7 @@ class Opset9(Opset8):
         "T", DOUBLE, FLOAT, FLOAT16, INT16, INT32, INT64, INT8, UINT16, UINT32, UINT64, UINT8
     )
 
-    def Shrink(self, input: T, bias: float = 0.0, lambd: float = 0.5) -> T:
+    def Shrink(self, input: T, *, bias: float = 0.0, lambd: float = 0.5) -> T:
         r"""[🌐 Shrink(9)](https://onnx.ai/onnx/operators/onnx__Shrink.html#shrink-9 "Online Documentation")
 
 
@@ -1210,6 +1213,7 @@ class Opset9(Opset8):
     def TfIdfVectorizer(
         self,
         X: T,
+        *,
         max_gram_length: Optional[int] = None,
         max_skip_count: Optional[int] = None,
         min_gram_length: Optional[int] = None,
@@ -1337,7 +1341,7 @@ class Opset9(Opset8):
         UINT8,
     )
 
-    def Upsample(self, X: T, scales: FLOAT, mode: str = "nearest") -> T:
+    def Upsample(self, X: T, scales: FLOAT, *, mode: str = "nearest") -> T:
         r"""[🌐 Upsample(9)](https://onnx.ai/onnx/operators/onnx__Upsample.html#upsample-9 "Online Documentation")
 
 

--- a/onnxscript/onnx_opset/_impl/opset9.py
+++ b/onnxscript/onnx_opset/_impl/opset9.py
@@ -187,7 +187,7 @@ class Opset9(Opset8):
         UINT8,
     )
 
-    def Cast(self, input: T1, *, to: Optional[int] = None) -> T2:
+    def Cast(self, input: T1, *, to: int) -> T2:
         r"""[🌐 Cast(9)](https://onnx.ai/onnx/operators/onnx__Cast.html#cast-9 "Online Documentation")
 
 
@@ -289,7 +289,7 @@ class Opset9(Opset8):
         UINT8,
     )
 
-    def Constant(self, *, value: Optional[TensorProto] = None) -> T:
+    def Constant(self, *, value: TensorProto) -> T:
         r"""[🌐 Constant(9)](https://onnx.ai/onnx/operators/onnx__Constant.html#constant-9 "Online Documentation")
 
         A constant tensor.
@@ -635,7 +635,7 @@ class Opset9(Opset8):
         I: T2,
         output_shape: Optional[T2] = None,
         *,
-        kernel_shape: Optional[Sequence[int]] = None,
+        kernel_shape: Sequence[int],
         pads: Optional[Sequence[int]] = None,
         strides: Optional[Sequence[int]] = None,
     ) -> T1:
@@ -822,11 +822,12 @@ class Opset9(Opset8):
                 'off_value' values in the output tensor.In case 'indices' is of
                 non-integer type, the values will be casted to int64 before use.
 
-            depth: Scalar specifying the number of classes in one-hot tensor. This is
-                also the size of the one-hot dimension (specified by 'axis' attribute)
-                added on in the output tensor. The values in the 'indices' input tensor
-                are expected to be in the range [0, depth). In case 'depth' is of
-                non-integer type, it will be casted to int64 before use.
+            depth: Scalar or rank 1 tensor containing exactly one element, specifying
+                the number of classes in one-hot tensor. This is also the size of the
+                one-hot dimension (specified by 'axis' attribute) added on in the output
+                tensor. The values in the 'indices' input tensor are expected to be in
+                the range [0, depth). In case 'depth' is of non-integer type, it will be
+                casted to int64 before use.
 
             values: Rank 1 tensor containing exactly two elements, in the format
                 [off_value, on_value], where 'on_value' is the value used for filling
@@ -888,8 +889,8 @@ class Opset9(Opset8):
     def Scan(
         self,
         *initial_state_and_scan_inputs: V,
-        body: Optional[GraphProto] = None,
-        num_scan_inputs: Optional[int] = None,
+        body: GraphProto,
+        num_scan_inputs: int,
         scan_input_axes: Optional[Sequence[int]] = None,
         scan_input_directions: Optional[Sequence[int]] = None,
         scan_output_axes: Optional[Sequence[int]] = None,
@@ -1214,12 +1215,12 @@ class Opset9(Opset8):
         self,
         X: T,
         *,
-        max_gram_length: Optional[int] = None,
-        max_skip_count: Optional[int] = None,
-        min_gram_length: Optional[int] = None,
-        mode: Optional[str] = None,
-        ngram_counts: Optional[Sequence[int]] = None,
-        ngram_indexes: Optional[Sequence[int]] = None,
+        max_gram_length: int,
+        max_skip_count: int,
+        min_gram_length: int,
+        mode: str,
+        ngram_counts: Sequence[int],
+        ngram_indexes: Sequence[int],
         pool_int64s: Optional[Sequence[int]] = None,
         pool_strings: Optional[Sequence[str]] = None,
         weights: Optional[Sequence[float]] = None,

--- a/onnxscript/onnx_opset/_impl/opset_ai_onnx_ml1.py
+++ b/onnxscript/onnx_opset/_impl/opset_ai_onnx_ml1.py
@@ -358,7 +358,7 @@ class Opset_ai_onnx_ml1(Opset):
         *,
         classlabels_ints: Optional[Sequence[int]] = None,
         classlabels_strings: Optional[Sequence[str]] = None,
-        coefficients: Optional[Sequence[float]] = None,
+        coefficients: Sequence[float],
         intercepts: Optional[Sequence[float]] = None,
         multi_class: int = 0,
         post_transform: str = "NONE",

--- a/onnxscript/onnx_opset/_impl/opset_ai_onnx_ml1.py
+++ b/onnxscript/onnx_opset/_impl/opset_ai_onnx_ml1.py
@@ -47,7 +47,7 @@ class Opset_ai_onnx_ml1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, INT32, INT64)
 
-    def Binarizer(self, X: T, threshold: float = 0.0) -> T:
+    def Binarizer(self, X: T, *, threshold: float = 0.0) -> T:
         r"""[🌐 ai.onnx.ml::Binarizer(1)](https://onnx.ai/onnx/operators/onnx_aionnxml_Binarizer.html#binarizer-1 "Online Documentation")
 
 
@@ -69,7 +69,7 @@ class Opset_ai_onnx_ml1(Opset):
     T2 = TypeVar("T2", FLOAT, INT64, STRING)
 
     def CastMap(
-        self, X: T1, cast_to: str = "TO_FLOAT", map_form: str = "DENSE", max_map: int = 1
+        self, X: T1, *, cast_to: str = "TO_FLOAT", map_form: str = "DENSE", max_map: int = 1
     ) -> T2:
         r"""[🌐 ai.onnx.ml::CastMap(1)](https://onnx.ai/onnx/operators/onnx_aionnxml_CastMap.html#castmap-1 "Online Documentation")
 
@@ -111,6 +111,7 @@ class Opset_ai_onnx_ml1(Opset):
     def CategoryMapper(
         self,
         X: T1,
+        *,
         cats_int64s: Optional[Sequence[int]] = None,
         cats_strings: Optional[Sequence[str]] = None,
         default_int64: int = -1,
@@ -175,6 +176,7 @@ class Opset_ai_onnx_ml1(Opset):
     def DictVectorizer(
         self,
         X: T1,
+        *,
         int64_vocabulary: Optional[Sequence[int]] = None,
         string_vocabulary: Optional[Sequence[str]] = None,
     ) -> T2:
@@ -247,6 +249,7 @@ class Opset_ai_onnx_ml1(Opset):
     def Imputer(
         self,
         X: T,
+        *,
         imputed_value_floats: Optional[Sequence[float]] = None,
         imputed_value_int64s: Optional[Sequence[int]] = None,
         replaced_value_float: float = 0.0,
@@ -298,6 +301,7 @@ class Opset_ai_onnx_ml1(Opset):
     def LabelEncoder(
         self,
         X: T1,
+        *,
         classes_strings: Optional[Sequence[str]] = None,
         default_int64: int = -1,
         default_string: str = "_Unused",
@@ -351,6 +355,7 @@ class Opset_ai_onnx_ml1(Opset):
     def LinearClassifier(
         self,
         X: T1,
+        *,
         classlabels_ints: Optional[Sequence[int]] = None,
         classlabels_strings: Optional[Sequence[str]] = None,
         coefficients: Optional[Sequence[float]] = None,
@@ -402,6 +407,7 @@ class Opset_ai_onnx_ml1(Opset):
     def LinearRegressor(
         self,
         X: T,
+        *,
         coefficients: Optional[Sequence[float]] = None,
         intercepts: Optional[Sequence[float]] = None,
         post_transform: str = "NONE",
@@ -447,7 +453,7 @@ class Opset_ai_onnx_ml1(Opset):
 
     T = TypeVar("T", DOUBLE, FLOAT, INT32, INT64)
 
-    def Normalizer(self, X: T, norm: str = "MAX") -> FLOAT:
+    def Normalizer(self, X: T, *, norm: str = "MAX") -> FLOAT:
         r"""[🌐 ai.onnx.ml::Normalizer(1)](https://onnx.ai/onnx/operators/onnx_aionnxml_Normalizer.html#normalizer-1 "Online Documentation")
 
 
@@ -484,6 +490,7 @@ class Opset_ai_onnx_ml1(Opset):
     def OneHotEncoder(
         self,
         X: T,
+        *,
         cats_int64s: Optional[Sequence[int]] = None,
         cats_strings: Optional[Sequence[str]] = None,
         zeros: int = 1,
@@ -533,6 +540,7 @@ class Opset_ai_onnx_ml1(Opset):
     def SVMClassifier(
         self,
         X: T1,
+        *,
         classlabels_ints: Optional[Sequence[int]] = None,
         classlabels_strings: Optional[Sequence[str]] = None,
         coefficients: Optional[Sequence[float]] = None,
@@ -597,6 +605,7 @@ class Opset_ai_onnx_ml1(Opset):
     def SVMRegressor(
         self,
         X: T,
+        *,
         coefficients: Optional[Sequence[float]] = None,
         kernel_params: Optional[Sequence[float]] = None,
         kernel_type: str = "LINEAR",
@@ -651,6 +660,7 @@ class Opset_ai_onnx_ml1(Opset):
     def Scaler(
         self,
         X: T,
+        *,
         offset: Optional[Sequence[float]] = None,
         scale: Optional[Sequence[float]] = None,
     ) -> FLOAT:
@@ -683,6 +693,7 @@ class Opset_ai_onnx_ml1(Opset):
     def TreeEnsembleClassifier(
         self,
         X: T1,
+        *,
         base_values: Optional[Sequence[float]] = None,
         class_ids: Optional[Sequence[int]] = None,
         class_nodeids: Optional[Sequence[int]] = None,
@@ -797,6 +808,7 @@ class Opset_ai_onnx_ml1(Opset):
     def TreeEnsembleRegressor(
         self,
         X: T,
+        *,
         aggregate_function: str = "SUM",
         base_values: Optional[Sequence[float]] = None,
         n_targets: Optional[int] = None,
@@ -914,6 +926,7 @@ class Opset_ai_onnx_ml1(Opset):
     def ZipMap(
         self,
         X: FLOAT,
+        *,
         classlabels_int64s: Optional[Sequence[int]] = None,
         classlabels_strings: Optional[Sequence[str]] = None,
     ) -> T:

--- a/onnxscript/onnx_opset/_impl/opset_ai_onnx_ml2.py
+++ b/onnxscript/onnx_opset/_impl/opset_ai_onnx_ml2.py
@@ -32,6 +32,7 @@ class Opset_ai_onnx_ml2(Opset_ai_onnx_ml1):
     def LabelEncoder(
         self,
         X: T1,
+        *,
         default_float: float = -0.0,
         default_int64: int = -1,
         default_string: str = "_Unused",

--- a/onnxscript/onnx_opset/_impl/opset_ai_onnx_ml3.py
+++ b/onnxscript/onnx_opset/_impl/opset_ai_onnx_ml3.py
@@ -33,6 +33,7 @@ class Opset_ai_onnx_ml3(Opset_ai_onnx_ml2):
     def TreeEnsembleClassifier(
         self,
         X: T1,
+        *,
         base_values: Optional[Sequence[float]] = None,
         base_values_as_tensor: Optional[TensorProto] = None,
         class_ids: Optional[Sequence[int]] = None,
@@ -168,6 +169,7 @@ class Opset_ai_onnx_ml3(Opset_ai_onnx_ml2):
     def TreeEnsembleRegressor(
         self,
         X: T,
+        *,
         aggregate_function: str = "SUM",
         base_values: Optional[Sequence[float]] = None,
         base_values_as_tensor: Optional[TensorProto] = None,

--- a/onnxscript/onnx_opset/_impl/opset_ai_onnx_preview_training1.py
+++ b/onnxscript/onnx_opset/_impl/opset_ai_onnx_preview_training1.py
@@ -287,11 +287,7 @@ class Opset_ai_onnx_preview_training1(Opset):
     T2 = TypeVar("T2", DOUBLE, FLOAT, FLOAT16)
 
     def Gradient(
-        self,
-        *Inputs: T1,
-        xs: Optional[Sequence[str]] = None,
-        y: Optional[str] = None,
-        zs: Optional[Sequence[str]] = None,
+        self, *Inputs: T1, xs: Sequence[str], y: str, zs: Optional[Sequence[str]] = None
     ) -> T2:
         r"""[🌐 ai.onnx.preview.training::Gradient(1)](https://onnx.ai/onnx/operators/onnx_aionnxpreviewtraining_Gradient.html#gradient-1 "Online Documentation")
 
@@ -471,10 +467,10 @@ class Opset_ai_onnx_preview_training1(Opset):
         R: T1,
         T: T2,
         *inputs: T3,
-        alpha: Optional[float] = None,
-        beta: Optional[float] = None,
-        mode: Optional[str] = None,
-        norm_coefficient: Optional[float] = None,
+        alpha: float,
+        beta: float,
+        mode: str,
+        norm_coefficient: float,
     ) -> T3:
         r"""[🌐 ai.onnx.preview.training::Momentum(1)](https://onnx.ai/onnx/operators/onnx_aionnxpreviewtraining_Momentum.html#momentum-1 "Online Documentation")
 

--- a/onnxscript/tests/eager_mode_test.py
+++ b/onnxscript/tests/eager_mode_test.py
@@ -45,7 +45,7 @@ class TestEagerModeArguments(unittest.TestCase):
     def test_op_attribute_by_positional_args(self):
         data = np.array([1, 2, 3, 4, 5, 6], dtype=np.int32)
         axes = np.array([0], dtype=np.int64)
-        self.assertEqual(op.ReduceSum(data, axes, True), 21)
+        self.assertEqual(op.ReduceSum(data, axes, keepdims=True), 21)
 
     def test_op_input_and_attribute_by_kwargs_out_of_order(self):
         data = np.array([1, 2, 3, 4, 5, 6], dtype=np.int32)

--- a/opgen/onnx_opset_builder.py
+++ b/opgen/onnx_opset_builder.py
@@ -514,9 +514,7 @@ class OpsetsBuilder:
             attr_type = parse_attr_type(attr.type)
             default_value = None
 
-            if attr.required:
-                pass
-            elif attr.default_value.name:
+            if attr.default_value.name:
                 default_value = get_attribute_value(attr.default_value)
 
                 def fmt(value: Any) -> str:
@@ -531,7 +529,7 @@ class OpsetsBuilder:
             else:
                 default_value = None
 
-            if default_value is None:
+            if not attr.required and default_value is None:
                 attr_type = cg.TypingRefs.Optional(attr_type)
 
             if generate_kwonly_sentinel and not any(
@@ -543,7 +541,7 @@ class OpsetsBuilder:
             yield cg.Arg(
                 attr.name,
                 type=attr_type,
-                default_value=cg.Constant(default_value),
+                default_value=None if attr.required else cg.Constant(default_value),
                 doc=attr.description,
                 is_kwarg=True,
             )


### PR DESCRIPTION
> ⚠️🚨🔥 ***Note:*** this is an API break since all attributes are now keyword-only, so positional usage is no longer allowed. Our tests uncovered a handful of places where we were specifing attributes as positional arguments.

By explicitly projecting all OpSchema attributes to keyword-only arguments in Python, we do not need to reorder attributes based on whether or not they have default values. This allows the Python API to express the same ordering as the op itself for inputs and attributes.

This also makes attribute specification consistent with variadic input ops which already have that implicit requirement.