### PR TITLE
Add support for serialization without initializers

### DIFF
--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -649,7 +649,9 @@ class TorchScriptGraph:
         return onnx_function
 
     @beartype
-    def to_model_proto(self, opset_version: int) -> onnx.ModelProto:
+    def to_model_proto(
+        self, opset_version: int, include_initializers: bool = True
+    ) -> onnx.ModelProto:
         function_proto_dict: Mapping[
             Tuple[str, str], onnx.FunctionProto
         ] = self.fetch_function_proto_dict(opset_version)
@@ -665,7 +667,7 @@ class TorchScriptGraph:
             _,
             _,
         ) = self._torch_graph._export_onnx(  # type: ignore[attr-defined] # pylint: disable=protected-access
-            initializers=self.initializers,
+            initializers=self.initializers if include_initializers else {},
             onnx_opset_version=opset_version,
             # TODO(justinchuby): Figure out how to get the dynamic axes from the inputs
             dynamic_axes={},


### PR DESCRIPTION
Needed by https://github.com/pytorch/pytorch/pull/103865/

When a PyTorch model is traced using `FakeTensor` weights[1], the resulting IR will not actually contain Tensors that can be serialized into protobuf.

In that scenario, the model must be serialized without any initializer to prevent invalid data access on the underlying PyTorch tensor. This PR proposes an optional parameter `include_initializers: bool = True` to `to_model_proto` API for allowing the serializer to ignore any initializer during serialization.

[1] `FakeTensor` is a subclass of `Tensor`, but without the actual data. See below for an example:

```python
{'_param_constant0': Parameter(FakeTensor(..., size=(2, 2), requires_grad=True)),
 '_param_constant1': Parameter(FakeTensor(..., size=(2,), requires_grad=True))}
```