### PR TITLE
Add ops (tensor.int, tensor.float, tensor.bool) | feat(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6238,8 +6238,8 @@ def aten_tanh(self: TFloat) -> TFloat:
     return op.Tanh(self)
 
 
-@torch_op("aten::tensor.int")
-def aten_tensor_int(self: int, dtype: int) -> TensorType:
+@torch_op("aten::tensor.bool")
+def aten_tensor_bool(self: bool, dtype: int) -> TensorType:
     tensor = op.Constant(value_int=self)
     return op.Cast(tensor, to=dtype)
 
@@ -6250,8 +6250,8 @@ def aten_tensor_float(self: float, dtype: int) -> TensorType:
     return op.Cast(tensor, to=dtype)
 
 
-@torch_op("aten::tensor.bool")
-def aten_tensor_bool(self: bool, dtype: int) -> TensorType:
+@torch_op("aten::tensor.int")
+def aten_tensor_int(self: int, dtype: int) -> TensorType:
     tensor = op.Constant(value_int=self)
     return op.Cast(tensor, to=dtype)
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6238,6 +6238,24 @@ def aten_tanh(self: TFloat) -> TFloat:
     return op.Tanh(self)
 
 
+@torch_op("aten::tensor.int")
+def aten_tensor_int(self: int, dtype: int) -> TensorType:
+    tensor = op.Constant(value_int=self)
+    return op.Cast(tensor, to=dtype)
+
+
+@torch_op("aten::tensor.float")
+def aten_tensor_float(self: float, dtype: int) -> TensorType:
+    tensor = op.Constant(value_float=self)
+    return op.Cast(tensor, to=dtype)
+
+
+@torch_op("aten::tensor.bool")
+def aten_tensor_bool(self: bool, dtype: int) -> TensorType:
+    tensor = op.Constant(value_int=self)
+    return op.Cast(tensor, to=dtype)
+
+
 def aten_tensordot(
     self: TensorType, other: TensorType, dims_self: Sequence[int], dims_other: Sequence[int]
 ) -> TensorType:

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -449,13 +449,13 @@ def sample_inputs_stft(op_info, device, dtype, requires_grad, **kwargs):
         )
 
 
-def sample_inputs_tensor_int(op_info, device, dtype, requires_grad, **kwargs):
+def sample_inputs_tensor_bool(op_info, device, dtype, requires_grad, **kwargs):
     del op_info
     del device
     del requires_grad
     del kwargs
-    yield opinfo_core.SampleInput(2, dtype=dtype)
-    yield opinfo_core.SampleInput(-5, dtype=dtype)
+    yield opinfo_core.SampleInput(True, dtype=dtype)
+    yield opinfo_core.SampleInput(False, dtype=dtype)
 
 
 def sample_inputs_tensor_float(op_info, device, dtype, requires_grad, **kwargs):
@@ -467,13 +467,13 @@ def sample_inputs_tensor_float(op_info, device, dtype, requires_grad, **kwargs):
     yield opinfo_core.SampleInput(-1.0, dtype=dtype)
 
 
-def sample_inputs_tensor_bool(op_info, device, dtype, requires_grad, **kwargs):
+def sample_inputs_tensor_int(op_info, device, dtype, requires_grad, **kwargs):
     del op_info
     del device
     del requires_grad
     del kwargs
-    yield opinfo_core.SampleInput(True, dtype=dtype)
-    yield opinfo_core.SampleInput(False, dtype=dtype)
+    yield opinfo_core.SampleInput(2, dtype=dtype)
+    yield opinfo_core.SampleInput(-5, dtype=dtype)
 
 
 OP_DB: List[opinfo_core.OpInfo] = [
@@ -599,11 +599,11 @@ OP_DB: List[opinfo_core.OpInfo] = [
         gradcheck_nondet_tol=common_utils.GRADCHECK_NONDET_TOL,
     ),
     opinfo_core.OpInfo(
-        "aten.tensor.int",
-        aten_name="tensor.int",
-        op=torch.ops.aten.tensor.int,
+        "aten.tensor.bool",
+        aten_name="tensor.bool",
+        op=torch.ops.aten.tensor.bool,
         dtypes=common_dtype.all_types_and(torch.half, torch.bfloat16),
-        sample_inputs_func=sample_inputs_tensor_int,
+        sample_inputs_func=sample_inputs_tensor_bool,
     ),
     opinfo_core.OpInfo(
         "aten.tensor.float",
@@ -613,10 +613,10 @@ OP_DB: List[opinfo_core.OpInfo] = [
         sample_inputs_func=sample_inputs_tensor_float,
     ),
     opinfo_core.OpInfo(
-        "aten.tensor.bool",
-        aten_name="tensor.bool",
-        op=torch.ops.aten.tensor.bool,
+        "aten.tensor.int",
+        aten_name="tensor.int",
+        op=torch.ops.aten.tensor.int,
         dtypes=common_dtype.all_types_and(torch.half, torch.bfloat16),
-        sample_inputs_func=sample_inputs_tensor_bool,
+        sample_inputs_func=sample_inputs_tensor_int,
     ),
 ]

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -449,6 +449,33 @@ def sample_inputs_stft(op_info, device, dtype, requires_grad, **kwargs):
         )
 
 
+def sample_inputs_tensor_int(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del device
+    del requires_grad
+    del kwargs
+    yield opinfo_core.SampleInput(2, dtype=dtype)
+    yield opinfo_core.SampleInput(-5, dtype=dtype)
+
+
+def sample_inputs_tensor_float(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del device
+    del requires_grad
+    del kwargs
+    yield opinfo_core.SampleInput(3.0, dtype=dtype)
+    yield opinfo_core.SampleInput(-1.0, dtype=dtype)
+
+
+def sample_inputs_tensor_bool(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del device
+    del requires_grad
+    del kwargs
+    yield opinfo_core.SampleInput(True, dtype=dtype)
+    yield opinfo_core.SampleInput(False, dtype=dtype)
+
+
 OP_DB: List[opinfo_core.OpInfo] = [
     opinfo_core.OpInfo(
         "col2im",
@@ -570,5 +597,26 @@ OP_DB: List[opinfo_core.OpInfo] = [
         check_batched_gradgrad=False,
         supports_out=False,
         gradcheck_nondet_tol=common_utils.GRADCHECK_NONDET_TOL,
+    ),
+    opinfo_core.OpInfo(
+        "aten.tensor.int",
+        aten_name="tensor.int",
+        op=torch.ops.aten.tensor.int,
+        dtypes=common_dtype.all_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=sample_inputs_tensor_int,
+    ),
+    opinfo_core.OpInfo(
+        "aten.tensor.float",
+        aten_name="tensor.float",
+        op=torch.ops.aten.tensor.float,
+        dtypes=common_dtype.all_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=sample_inputs_tensor_float,
+    ),
+    opinfo_core.OpInfo(
+        "aten.tensor.bool",
+        aten_name="tensor.bool",
+        op=torch.ops.aten.tensor.bool,
+        dtypes=common_dtype.all_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=sample_inputs_tensor_bool,
     ),
 ]

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1464,6 +1464,11 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         input_wrangler=_sum_input_wrangler,
         trace_only=True,
     ),
+    TorchLibOpInfo("aten.tensor.int", core_ops.aten_tensor_int),  # Custom from extra_opinfo
+    TorchLibOpInfo(
+        "aten.tensor.float", core_ops.aten_tensor_float  # Custom from extra_opinfo
+    ),
+    TorchLibOpInfo("aten.tensor.bool", core_ops.aten_tensor_bool),  # Custom from extra_opinfo
     TorchLibOpInfo("transpose", core_ops.aten_transpose, trace_only=True),
     TorchLibOpInfo(
         "var_mean",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1464,11 +1464,11 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         input_wrangler=_sum_input_wrangler,
         trace_only=True,
     ),
-    TorchLibOpInfo("aten.tensor.int", core_ops.aten_tensor_int),  # Custom from extra_opinfo
+    TorchLibOpInfo("aten.tensor.bool", core_ops.aten_tensor_bool),  # Custom from extra_opinfo
     TorchLibOpInfo(
         "aten.tensor.float", core_ops.aten_tensor_float  # Custom from extra_opinfo
     ),
-    TorchLibOpInfo("aten.tensor.bool", core_ops.aten_tensor_bool),  # Custom from extra_opinfo
+    TorchLibOpInfo("aten.tensor.int", core_ops.aten_tensor_int),  # Custom from extra_opinfo
     TorchLibOpInfo("transpose", core_ops.aten_transpose, trace_only=True),
     TorchLibOpInfo(
         "var_mean",


### PR DESCRIPTION
`aten.tensor` is emitted from TypePromotionPass in dynamo onnx exporter.