### PR TITLE
Add ops (view*) | feat(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -28,6 +28,7 @@ from onnxscript.function_libs.torch_lib.tensor_typing import (
     TRealUnlessFloat16OrInt8,
     TRealUnlessInt16OrInt8,
     TTensor,
+    TTensor2,
     TTensorOrString,
 )
 from onnxscript.onnx_opset import opset18 as op
@@ -6759,7 +6760,7 @@ def aten_view(self: TTensor, size: IntType) -> TTensor:
 
 
 @torch_op("aten::view_as")
-def aten_view_as(self: TensorType, other: TensorType) -> TensorType:
+def aten_view_as(self: TTensor, other: TTensor2) -> TTensor:
     """view_as(Tensor(a) self, Tensor other) -> Tensor(a)"""
 
     size = op.Shape(other)
@@ -6767,7 +6768,7 @@ def aten_view_as(self: TensorType, other: TensorType) -> TensorType:
 
 
 @torch_op("aten::view_as_complex")
-def aten_view_as_complex(self: TensorType) -> TensorType:
+def aten_view_as_complex(self: TTensor) -> TTensor:
     """view_as_complex(Tensor(a) self) -> Tensor(a)"""
 
     # We always operate on the real representation of a complex number in torchlib
@@ -6776,7 +6777,7 @@ def aten_view_as_complex(self: TensorType) -> TensorType:
 
 
 @torch_op("aten::view_as_complex_copy")
-def aten_view_as_complex_copy(self: TensorType) -> TensorType:
+def aten_view_as_complex_copy(self: TTensor) -> TTensor:
     """view_as_complex_copy(Tensor self) -> Tensor"""
 
     # We always operate on the real representation of a complex number in torchlib
@@ -6785,7 +6786,7 @@ def aten_view_as_complex_copy(self: TensorType) -> TensorType:
 
 
 @torch_op("aten::view_as_real")
-def aten_view_as_real(self: TensorType) -> TensorType:
+def aten_view_as_real(self: TTensor) -> TTensor:
     """view_as_real(Tensor(a) self) -> Tensor(a)"""
 
     # We always operate on the real representation of a complex number in torchlib
@@ -6794,7 +6795,7 @@ def aten_view_as_real(self: TensorType) -> TensorType:
 
 
 @torch_op("aten::view_as_real_copy")
-def aten_view_as_real_copy(self: TensorType) -> TensorType:
+def aten_view_as_real_copy(self: TTensor) -> TTensor:
     """view_as_real_copy(Tensor self) -> Tensor"""
 
     # We always operate on the real representation of a complex number in torchlib
@@ -6803,7 +6804,7 @@ def aten_view_as_real_copy(self: TensorType) -> TensorType:
 
 
 @torch_op("aten::view_copy")
-def aten_view_copy(self: TensorType, size: IntType) -> TensorType:
+def aten_view_copy(self: TTensor, size: IntType) -> TTensor:
     """view_copy(Tensor self, SymInt[] size) -> Tensor"""
 
     size = op.Cast(size, to=INT64.dtype)  # Reshape only support INT64 as second input

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6764,6 +6764,7 @@ def aten_view_as(self: TensorType, other: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
+@torch_op("aten::view_as_complex")
 def aten_view_as_complex(self: TensorType) -> TensorType:
     """view_as_complex(Tensor(a) self) -> Tensor(a)"""
 
@@ -6772,6 +6773,7 @@ def aten_view_as_complex(self: TensorType) -> TensorType:
     return self
 
 
+@torch_op("aten::view_as_complex_copy")
 def aten_view_as_complex_copy(self: TensorType) -> TensorType:
     """view_as_complex_copy(Tensor self) -> Tensor"""
 
@@ -6780,6 +6782,7 @@ def aten_view_as_complex_copy(self: TensorType) -> TensorType:
     return self
 
 
+@torch_op("aten::view_as_real")
 def aten_view_as_real(self: TensorType) -> TensorType:
     """view_as_real(Tensor(a) self) -> Tensor(a)"""
 
@@ -6788,6 +6791,7 @@ def aten_view_as_real(self: TensorType) -> TensorType:
     return self
 
 
+@torch_op("aten::view_as_real_copy")
 def aten_view_as_real_copy(self: TensorType) -> TensorType:
     """view_as_real_copy(Tensor self) -> Tensor"""
 
@@ -6796,6 +6800,7 @@ def aten_view_as_real_copy(self: TensorType) -> TensorType:
     return self
 
 
+@torch_op("aten::view_copy")
 def aten_view_copy(self: TensorType, size: IntType) -> TensorType:
     """view_copy(Tensor self, SymInt[] size) -> Tensor"""
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6758,10 +6758,12 @@ def aten_view(self: TTensor, size: IntType) -> TTensor:
     return op.Reshape(self, size)
 
 
+@torch_op("aten::view_as")
 def aten_view_as(self: TensorType, other: TensorType) -> TensorType:
     """view_as(Tensor(a) self, Tensor other) -> Tensor(a)"""
 
-    raise NotImplementedError()
+    size = op.Shape(other)
+    return op.Reshape(self, size)
 
 
 @torch_op("aten::view_as_complex")
@@ -6770,7 +6772,7 @@ def aten_view_as_complex(self: TensorType) -> TensorType:
 
     # We always operate on the real representation of a complex number in torchlib
     # So this is a no-op
-    return self
+    return op.Identity(self)
 
 
 @torch_op("aten::view_as_complex_copy")
@@ -6779,7 +6781,7 @@ def aten_view_as_complex_copy(self: TensorType) -> TensorType:
 
     # We always operate on the real representation of a complex number in torchlib
     # So this is a no-op
-    return self
+    return op.Identity(self)
 
 
 @torch_op("aten::view_as_real")
@@ -6788,7 +6790,7 @@ def aten_view_as_real(self: TensorType) -> TensorType:
 
     # We always operate on the real representation of a complex number in torchlib
     # So this is a no-op
-    return self
+    return op.Identity(self)
 
 
 @torch_op("aten::view_as_real_copy")
@@ -6797,7 +6799,7 @@ def aten_view_as_real_copy(self: TensorType) -> TensorType:
 
     # We always operate on the real representation of a complex number in torchlib
     # So this is a no-op
-    return self
+    return op.Identity(self)
 
 
 @torch_op("aten::view_copy")

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6768,6 +6768,7 @@ def aten_view_as_complex(self: TensorType) -> TensorType:
     """view_as_complex(Tensor(a) self) -> Tensor(a)"""
 
     # We always operate on the real representation of a complex number in torchlib
+    # So this is a no-op
     return self
 
 
@@ -6775,6 +6776,7 @@ def aten_view_as_complex_copy(self: TensorType) -> TensorType:
     """view_as_complex_copy(Tensor self) -> Tensor"""
 
     # We always operate on the real representation of a complex number in torchlib
+    # So this is a no-op
     return self
 
 
@@ -6782,6 +6784,7 @@ def aten_view_as_real(self: TensorType) -> TensorType:
     """view_as_real(Tensor(a) self) -> Tensor(a)"""
 
     # We always operate on the real representation of a complex number in torchlib
+    # So this is a no-op
     return self
 
 
@@ -6789,6 +6792,7 @@ def aten_view_as_real_copy(self: TensorType) -> TensorType:
     """view_as_real_copy(Tensor self) -> Tensor"""
 
     # We always operate on the real representation of a complex number in torchlib
+    # So this is a no-op
     return self
 
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6767,31 +6767,36 @@ def aten_view_as(self: TensorType, other: TensorType) -> TensorType:
 def aten_view_as_complex(self: TensorType) -> TensorType:
     """view_as_complex(Tensor(a) self) -> Tensor(a)"""
 
-    raise NotImplementedError()
+    # We always operate on the real representation of a complex number in torchlib
+    return self
 
 
 def aten_view_as_complex_copy(self: TensorType) -> TensorType:
     """view_as_complex_copy(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    # We always operate on the real representation of a complex number in torchlib
+    return self
 
 
 def aten_view_as_real(self: TensorType) -> TensorType:
     """view_as_real(Tensor(a) self) -> Tensor(a)"""
 
-    raise NotImplementedError()
+    # We always operate on the real representation of a complex number in torchlib
+    return self
 
 
 def aten_view_as_real_copy(self: TensorType) -> TensorType:
     """view_as_real_copy(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    # We always operate on the real representation of a complex number in torchlib
+    return self
 
 
-def aten_view_copy(self: TensorType, size: INT64) -> TensorType:
+def aten_view_copy(self: TensorType, size: IntType) -> TensorType:
     """view_copy(Tensor self, SymInt[] size) -> Tensor"""
 
-    raise NotImplementedError()
+    size = op.Cast(size, to=INT64.dtype)  # Reshape only support INT64 as second input
+    return op.Reshape(self, size)
 
 
 @torch_op("aten::vstack")

--- a/onnxscript/function_libs/torch_lib/tensor_typing.py
+++ b/onnxscript/function_libs/torch_lib/tensor_typing.py
@@ -56,6 +56,8 @@ RealType = Union[
 ]
 
 TTensor = TypeVar("TTensor", bound=_TensorType)
+# Duplicate TTensor for inputs/outputs that accept the same set of types as TTensor
+# but do not constrain the type to be the same as the other inputs/outputs
 TTensor2 = TypeVar("TTensor2", bound=_TensorType)
 TTensorOrString = TypeVar("TTensorOrString", bound=Union[_TensorType, STRING])
 TFloat = TypeVar("TFloat", bound=_FloatType)

--- a/onnxscript/function_libs/torch_lib/tensor_typing.py
+++ b/onnxscript/function_libs/torch_lib/tensor_typing.py
@@ -56,7 +56,7 @@ RealType = Union[
 ]
 
 TTensor = TypeVar("TTensor", bound=_TensorType)
-TTensor2 = TypeVar("TTensor", bound=_TensorType)
+TTensor2 = TypeVar("TTensor2", bound=_TensorType)
 TTensorOrString = TypeVar("TTensorOrString", bound=Union[_TensorType, STRING])
 TFloat = TypeVar("TFloat", bound=_FloatType)
 TFloatOrBFloat16 = TypeVar("TFloatOrBFloat16", bound=Union[FLOAT16, FLOAT, DOUBLE, BFLOAT16])

--- a/onnxscript/function_libs/torch_lib/tensor_typing.py
+++ b/onnxscript/function_libs/torch_lib/tensor_typing.py
@@ -56,6 +56,7 @@ RealType = Union[
 ]
 
 TTensor = TypeVar("TTensor", bound=_TensorType)
+TTensor2 = TypeVar("TTensor", bound=_TensorType)
 TTensorOrString = TypeVar("TTensorOrString", bound=Union[_TensorType, STRING])
 TFloat = TypeVar("TFloat", bound=_FloatType)
 TFloatOrBFloat16 = TypeVar("TFloatOrBFloat16", bound=Union[FLOAT16, FLOAT, DOUBLE, BFLOAT16])

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1096,7 +1096,9 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo("view", core_ops.aten_view),
     TorchLibOpInfo("view_as", core_ops.aten_view_as),
     TorchLibOpInfo("view_as_complex", core_ops.aten_view_as_complex),
+    TorchLibOpInfo("view_as_complex_copy", core_ops.aten_view_as_complex_copy),
     TorchLibOpInfo("view_as_real", core_ops.aten_view_as_real),
+    TorchLibOpInfo("view_as_real_copy", core_ops.aten_view_as_real_copy),
     TorchLibOpInfo("view_copy", core_ops.aten_view_copy),
     TorchLibOpInfo(
         "vstack",
@@ -1526,43 +1528,22 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
 )
 
 ops_test_common.duplicate_opinfo(OPS_DB, "all", ("all_dim",))
-
 ops_test_common.duplicate_opinfo(OPS_DB, "any", ("any_dim",))
-
-ops_test_common.duplicate_opinfo(
-    OPS_DB,
-    "arange",
-    (
-        "arange_start",
-        "arange_start_step",
-    ),
-)
-
+ops_test_common.duplicate_opinfo(OPS_DB, "arange", ("arange_start", "arange_start_step"))
 ops_test_common.duplicate_opinfo(OPS_DB, "atleast_1d", ("atleast_1d_single_tensor",))
 ops_test_common.duplicate_opinfo(OPS_DB, "atleast_2d", ("atleast_2d_single_tensor",))
 ops_test_common.duplicate_opinfo(OPS_DB, "atleast_3d", ("atleast_3d_single_tensor",))
-
-
 ops_test_common.duplicate_opinfo(OPS_DB, "full_like", ("full_like_dtype",))
-
 ops_test_common.duplicate_opinfo(OPS_DB, "index_put", ("index_put_bool",))
-
 ops_test_common.duplicate_opinfo(OPS_DB, "mean", ("mean_dim",))
-
 ops_test_common.duplicate_opinfo(OPS_DB, "new_empty", ("new_empty_dtype",))
-
 ops_test_common.duplicate_opinfo(OPS_DB, "new_empty_strided", ("new_empty_strided_dtype",))
-
 ops_test_common.duplicate_opinfo(OPS_DB, "new_full", ("new_full_dtype",))
-
 ops_test_common.duplicate_opinfo(OPS_DB, "new_ones", ("new_ones_dtype",))
-
 ops_test_common.duplicate_opinfo(OPS_DB, "new_zeros", ("new_zeros_dtype",))
-
 ops_test_common.duplicate_opinfo(
     OPS_DB, "nn.functional.nll_loss", ("nn.functional.nll_loss_weight",)
 )
-
 ops_test_common.duplicate_opinfo(
     OPS_DB,
     "nn.functional.pad",
@@ -1572,13 +1553,11 @@ ops_test_common.duplicate_opinfo(
         "nn.functional.replication_pad3d",
     ),
 )
-
 ops_test_common.duplicate_opinfo(
     OPS_DB,
     "nn.functional.scaled_dot_product_attention",
     ("nn.functional.scaled_dot_product_attention_bool_mask",),
 )
-
 ops_test_common.duplicate_opinfo(
     OPS_DB,
     "min",
@@ -1587,13 +1566,11 @@ ops_test_common.duplicate_opinfo(
         "min_dim",
     ),
 )
-
 ops_test_common.duplicate_opinfo(
     OPS_DB,
     "nn.functional.upsample_bilinear",
     ("nn.functional.upsample_bilinear2d",),
 )
-
 ops_test_common.duplicate_opinfo(
     OPS_DB,
     "nn.functional.upsample_nearest",
@@ -1603,17 +1580,10 @@ ops_test_common.duplicate_opinfo(
         "nn.functional.upsample_nearest3d",
     ),
 )
-
 ops_test_common.duplicate_opinfo(OPS_DB, "squeeze", ("squeeze_dim",))
-
-ops_test_common.duplicate_opinfo(
-    OPS_DB,
-    "var_mean",
-    (
-        "var_mean_dim",
-        "var_mean_correction",
-    ),
-)
+ops_test_common.duplicate_opinfo(OPS_DB, "var_mean", ("var_mean_dim", "var_mean_correction"))
+ops_test_common.duplicate_opinfo(OPS_DB, "view_as_complex", ("view_as_complex_copy",))
+ops_test_common.duplicate_opinfo(OPS_DB, "view_as_real", ("view_as_real_copy",))
 
 # MARK: End edits here
 

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1097,8 +1097,8 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo("view_as", core_ops.aten_view_as),
     TorchLibOpInfo("view_as_complex", core_ops.aten_view_as_complex),
     TorchLibOpInfo("view_as_complex_copy", core_ops.aten_view_as_complex_copy),
-    TorchLibOpInfo("view_as_real", core_ops.aten_view_as_real),
-    TorchLibOpInfo("view_as_real_copy", core_ops.aten_view_as_real_copy),
+    TorchLibOpInfo("view_as_real", core_ops.aten_view_as_real, complex=True),
+    TorchLibOpInfo("view_as_real_copy", core_ops.aten_view_as_real_copy, complex=True),
     TorchLibOpInfo("view_copy", core_ops.aten_view_copy),
     TorchLibOpInfo(
         "vstack",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1094,6 +1094,10 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ),
     TorchLibOpInfo("unsqueeze", core_ops.aten_unsqueeze),
     TorchLibOpInfo("view", core_ops.aten_view),
+    TorchLibOpInfo("view_as", core_ops.aten_view_as),
+    TorchLibOpInfo("view_as_complex", core_ops.aten_view_as_complex),
+    TorchLibOpInfo("view_as_real", core_ops.aten_view_as_real),
+    TorchLibOpInfo("view_copy", core_ops.aten_view_copy),
     TorchLibOpInfo(
         "vstack",
         core_ops.aten_vstack,


### PR DESCRIPTION
We always operate on the real representation of a complex number in torchlib. So view_as_real/view_as_complex are no-op. This PR additionally implements other view* ops.