### PR TITLE
Ensure no duplicate output names

### DIFF
--- a/onnxscript/converter.py
+++ b/onnxscript/converter.py
@@ -993,6 +993,11 @@ class Converter:
                 # In ONNX, a graph-input cannot be an output of the graph.
                 # We need to insert a copy.
                 return_var = self.emit_copy(return_var, preferred_name)
+            for prev_output in self._current_fn.outputs:
+                if prev_output.name == return_var:
+                    # ONNX does not allow duplicate output names.
+                    return_var = self.emit_copy(return_var, f"{return_var}_copy")
+                    break
             if self.returntype is None:
                 t = None
             else:

--- a/onnxscript/converter_test.py
+++ b/onnxscript/converter_test.py
@@ -559,6 +559,18 @@ class TestConverter(testutils.TestBase):
         node = none_as_input.to_function_proto().node[0]
         self.assertEqual(node.input[1], "")
 
+    def test_no_duplicate_output_name(self):
+        """Test that the converter does not generate duplicate output names."""
+
+        @script()
+        def duplicate_output(X):
+            Y = op.Neg(X)
+            return Y, Y
+
+        # The converter should generate distinct names for the two outputs
+        outputs = duplicate_output.to_function_proto().output
+        self.assertNotEqual(outputs[0], outputs[1])
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Fix the translation of `return Y, Y`. Since ONNX does not allow duplicate output names, we need to insert an extra copy via Identity in such cases.

Add test-case for the same.