### PR TITLE
Simplify bernoulli implementation | fix(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -970,6 +970,7 @@ def aten_bernoulli_p(self: TTensor, p: float) -> TTensor:
 
     Ignore `generator` due to the limit on ONNX expressiveness.
     """
+    # NOTE: We will lose some precision when input is float64 but that's considered insignificant
     self_float = op.Cast(self, to=FLOAT.dtype)
     rands = op.RandomUniformLike(
         self_float,

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -970,10 +970,13 @@ def aten_bernoulli_p(self: TTensor, p: float) -> TTensor:
 
     Ignore `generator` due to the limit on ONNX expressiveness.
     """
-    self_shape = op.Shape(self)
-    p = op.Cast(p, to=FLOAT.dtype)
-    probs = op.Expand(p, self_shape)
-    sampled = op.Bernoulli(probs)
+    self_float = op.Cast(self, to=FLOAT.dtype)
+    rands = op.RandomUniformLike(
+        self_float,
+        high=1.0,
+        low=0.0,
+    )
+    sampled = op.Less(rands, p)
     return op.CastLike(sampled, self)
 
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -955,16 +955,13 @@ def aten_batch_norm_update_stats(
 
 
 @torch_op("aten::bernoulli")
-def aten_bernoulli(self: TTensor) -> TTensor:
+def aten_bernoulli(self: TFloat) -> TFloat:
     """Proximal implementation of aten::bernoulli.default
 
     Note that due to the limitation of ONNX, we ignore the `generator` argument in
       aten::bernoulli.default(Tensor self, *, Generator? generator=None) -> Tensor
     """
-    # NOTE: We will lose some precision when input is float64 but that's considered insignificant
-    self_float = op.Cast(self, to=FLOAT.dtype)
-    sampled = op.Bernoulli(self_float)
-    return op.CastLike(sampled, self)
+    return op.Bernoulli(self)
 
 
 @torch_op("aten::bernoulli.p")
@@ -973,14 +970,10 @@ def aten_bernoulli_p(self: TTensor, p: float) -> TTensor:
 
     Ignore `generator` due to the limit on ONNX expressiveness.
     """
-    # NOTE: We will lose some precision when input is float64 but that's considered insignificant
-    self_float = op.Cast(self, to=FLOAT.dtype)
-    rands = op.RandomUniformLike(
-        self_float,
-        high=1.0,
-        low=0.0,
-    )
-    sampled = op.Less(rands, p)
+    self_shape = op.Shape(self)
+    p = op.Cast(p, to=FLOAT.dtype)
+    probs = op.Expand(p, self_shape)
+    sampled = op.Bernoulli(probs)
     return op.CastLike(sampled, self)
 
 


### PR DESCRIPTION
I tested with 

```python
@torch_op("aten::bernoulli.p")
def aten_bernoulli_p(self: TTensor, p: float) -> TTensor:
    """Proximal implementation of aten::bernoulli.p(Tensor self, float p, *, Generator? generator=None)

    Ignore `generator` due to the limit on ONNX expressiveness.
    """
    self_shape = op.Shape(self)
    p = op.Cast(p, to=FLOAT.dtype)
    probs = op.Expand(p, self_shape)
    sampled = op.Bernoulli(probs)
    return op.CastLike(sampled, self)
```

But the results don't match with torch