### PR TITLE
Allow functions to be registered to multiple names | feat(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/registration.py
+++ b/onnxscript/function_libs/torch_lib/registration.py
@@ -102,7 +102,7 @@ def torch_op(
         name: Qualified ATen name of the function. E.g. "aten::relu", "aten::add.Tensor".
             Or a tuple of names e.g. ("aten::add.Scalar", "aten::add.Tensor").
             Default overloads should be specified by omitting the overload part,
-            i.e. ""aten::relu" instead of "aten::relu.default".
+            i.e. "aten::relu" instead of "aten::relu.default".
         registry: Registry to register the function to. If None, the default registry is used.
         trace_only: Whether the function should only be traced and not compiled.
         private: Whether the function is private (not directly exposed). It should

--- a/onnxscript/function_libs/torch_lib/registration.py
+++ b/onnxscript/function_libs/torch_lib/registration.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Generator, Optional
 
 import onnxscript
 
-# Regex that will match "aten::add" and "aten::add.Tensor"
+# Regex that will match "<namespace>::<op_name>[.<overload>]"
 _QUALIFIED_OPERATOR_NAME_REGEX = re.compile(
     r"^(?P<namespace>[a-zA-Z0-9_]+)::(?P<name>[a-zA-Z0-9_]+)(?P<overload>\.[a-zA-Z0-9._]+)?$"
 )
@@ -100,7 +100,9 @@ def torch_op(
 
     Args:
         name: Qualified ATen name of the function. E.g. "aten::relu", "aten::add.Tensor".
-            Or a tuple of names ("aten::add.Scalar", "aten::add.Tensor").
+            Or a tuple of names e.g. ("aten::add.Scalar", "aten::add.Tensor").
+            Default overloads should be specified by omitting the overload part,
+            i.e. ""aten::relu" instead of "aten::relu.default".
         registry: Registry to register the function to. If None, the default registry is used.
         trace_only: Whether the function should only be traced and not compiled.
         private: Whether the function is private (not directly exposed). It should

--- a/onnxscript/function_libs/torch_lib/registration.py
+++ b/onnxscript/function_libs/torch_lib/registration.py
@@ -69,7 +69,7 @@ class Registry:
 default_registry = Registry()
 
 
-def _check_and_normalized_names(name: str | tuple[str, ...]) -> tuple[str, ...]:
+def _check_and_normalize_names(name: str | tuple[str, ...]) -> tuple[str, ...]:
     names: tuple[str, ...]
 
     if isinstance(name, str):
@@ -124,7 +124,7 @@ def torch_op(
             processed_func = onnxscript.script(opset=custom_opset)(func)
 
         assert registry is not None
-        for name_ in _check_and_normalized_names(name):
+        for name_ in _check_and_normalize_names(name):
             registry.register(processed_func, name_, private=private, complex=complex)
         return processed_func
 

--- a/onnxscript/function_libs/torch_lib/registration.py
+++ b/onnxscript/function_libs/torch_lib/registration.py
@@ -64,7 +64,7 @@ default_registry = Registry()
 
 
 def torch_op(
-    name,
+    name: str | tuple[str, ...],
     *,
     registry: Optional[Registry] = None,
     trace_only: bool = False,

--- a/onnxscript/function_libs/torch_lib/registration.py
+++ b/onnxscript/function_libs/torch_lib/registration.py
@@ -81,8 +81,8 @@ def _check_and_normalize_names(name: str | tuple[str, ...]) -> tuple[str, ...]:
     for name_ in names:
         if name_.endswith(".default") or not _QUALIFIED_OPERATOR_NAME_REGEX.fullmatch(name_):
             raise ValueError(
-                f"Invalid name '{name_}'. Must be in the form 'namespace::name.overload' "
-                "or 'namespace::name' for default overloads."
+                f"Invalid name '{name_}'. Must be in the form 'namespace::name' for default overloads "
+                "or 'namespace::name.overload' for other overloads."
             )
 
     return names


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #864
* __->__ #863

To support registering aliases and overloads of an op, `torch_op` can now take a tuple. #828 