### PR TITLE
Properly check and guard overloading initializer name | fix(graph_building)

### DIFF
--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -404,7 +404,7 @@ class TorchScriptGraph:
             # NOTE: Previously it raises when `name` is already set. This is relaxed
             # because this will be invoked multiple times when submodule is called
             # multiple times.
-            if name in self._initializers and self._initializers[name] != value:
+            if name in self._initializers and self._initializers[name] is not value:
                 raise ValueError(
                     f"Initializer '{name}' exists already with a different value."
                 )

--- a/onnxscript/function_libs/torch_lib/graph_building_test.py
+++ b/onnxscript/function_libs/torch_lib/graph_building_test.py
@@ -118,6 +118,7 @@ class TestTorchScriptTracingEvaluator(unittest.TestCase):
         expected = outer.to_model_proto()
         onnxscript.testing.assert_isomorphic(traced, expected)
 
+
 class TestTorchScriptGraph(unittest.TestCase):
     def test_add_initializer_raises_when_the_same_name_used_for_different_tensors(self):
         graph = graph_building.TorchScriptGraph()

--- a/onnxscript/function_libs/torch_lib/graph_building_test.py
+++ b/onnxscript/function_libs/torch_lib/graph_building_test.py
@@ -118,6 +118,18 @@ class TestTorchScriptTracingEvaluator(unittest.TestCase):
         expected = outer.to_model_proto()
         onnxscript.testing.assert_isomorphic(traced, expected)
 
+    def test_adding_different_tensors_using_same_initializer_name_raises(self):
+        graph = graph_building.TorchScriptGraph()
+        graph.add_initializer("x", torch.ones((1, 2, 3), dtype=torch.float32))
+        with self.assertRaises(ValueError):
+            graph.add_initializer("x", torch.ones((1, 2, 3), dtype=torch.float32))
+
+    def test_adding_same_tensors_using_same_initializer_name_passes(self):
+        graph = graph_building.TorchScriptGraph()
+        x_tensor = torch.ones((1, 2, 3), dtype=torch.float32)
+        graph.add_initializer("x", x_tensor)
+        graph.add_initializer("x", x_tensor)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/onnxscript/function_libs/torch_lib/graph_building_test.py
+++ b/onnxscript/function_libs/torch_lib/graph_building_test.py
@@ -118,13 +118,14 @@ class TestTorchScriptTracingEvaluator(unittest.TestCase):
         expected = outer.to_model_proto()
         onnxscript.testing.assert_isomorphic(traced, expected)
 
-    def test_adding_different_tensors_using_same_initializer_name_raises(self):
+class TestTorchScriptGraph(unittest.TestCase):
+    def test_add_initializer_raises_when_the_same_name_used_for_different_tensors(self):
         graph = graph_building.TorchScriptGraph()
         graph.add_initializer("x", torch.ones((1, 2, 3), dtype=torch.float32))
         with self.assertRaises(ValueError):
             graph.add_initializer("x", torch.ones((1, 2, 3), dtype=torch.float32))
 
-    def test_adding_same_tensors_using_same_initializer_name_passes(self):
+    def test_add_initializer_allows_adding_the_same_tensor_twice_using_same_name(self):
         graph = graph_building.TorchScriptGraph()
         x_tensor = torch.ones((1, 2, 3), dtype=torch.float32)
         graph.add_initializer("x", x_tensor)


### PR DESCRIPTION
Previously the code path is never triggered due to another bug in exporter that initializers are always added with unique names.