### PR TITLE
Rename extra opinfo names and simplify the OpInfos | test(torchlib)

### DIFF
--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -603,7 +603,7 @@ OP_DB: List[opinfo_core.OpInfo] = [
         supports_out=False,
     ),
     opinfo_core.OpInfo(
-        "ops.aten.conv3d",
+        "nn.functional.conv3d",
         aten_name="conv3d",
         dtypes=common_dtype.floating_and_complex_types_and(torch.int64, torch.bfloat16),
         sample_inputs_func=sample_inputs_conv3d,
@@ -662,21 +662,21 @@ OP_DB: List[opinfo_core.OpInfo] = [
         supports_out=False,
     ),
     opinfo_core.OpInfo(
-        "ops.aten.max_pool1d_with_indices",
+        "nn.functional.max_pool1d_with_indices",
         aten_name="max_pool1d_with_indices",
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
         sample_inputs_func=sample_inputs_max_pool1d_with_indices,
         supports_out=False,
     ),
     opinfo_core.OpInfo(
-        "ops.aten.max_pool2d_with_indices",
+        "nn.functional.max_pool2d_with_indices",
         aten_name="max_pool2d_with_indices",
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
         sample_inputs_func=sample_inputs_max_pool2d_with_indices,
         supports_out=False,
     ),
     opinfo_core.OpInfo(
-        "ops.aten.max_pool3d_with_indices",
+        "nn.functional.max_pool3d_with_indices",
         aten_name="max_pool3d_with_indices",
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
         sample_inputs_func=sample_inputs_max_pool3d_with_indices,

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -553,173 +553,133 @@ def sample_inputs_bernoulli_p_deterministic(op_info, device, dtype, requires_gra
             yield opinfo_core.SampleInput(t, kwargs={"p": p})
 
 
+# NOTE: How to create an OpInfo:
+# 1. Create a function that generates sample inputs for the op.
+#    This function should yield SampleInputs.
+#    Use `sample_inputs_col2im` as an example.
+# 2. Specify dtypes that the op supports.
+# 3. Use how you would call the op in PyTorch as the name of the OpInfo.
+#    For example, `torch.ops.aten.col2im` should be named "ops.aten.col2im".
+#    This way OpInfo knows to use `torch.ops.aten.col2im` as the op.
+#    See the docstring of OpInfo for more details.
+#
+#    This name is used as the unique ID to connect `TorchLibOpInfo("unique_name", ...)``
+#    in ops_test_data.py and opinfo_core.OpInfo("unique_name", ...)
+#    To avoid name duplication, it is possible to rename the OpInfo and specify
+#    the `op` field explicitly.
 OP_DB: List[opinfo_core.OpInfo] = [
     opinfo_core.OpInfo(
-        "aten._local_scalar_dense",
-        op=torch.ops.aten._local_scalar_dense,  # pylint: disable=protected-access
+        "ops.aten._local_scalar_dense",
         aten_name="_local_scalar_dense",
         dtypes=common_dtype.all_types(),
         sample_inputs_func=sample_inputs__local_scalar_dense,
     ),
     opinfo_core.OpInfo(
-        "col2im",
-        op=torch.ops.aten.col2im,
+        "ops.aten.col2im",
         aten_name="col2im",
         dtypes=common_dtype.floating_and_complex_types_and(torch.half, torch.bfloat16),
         sample_inputs_func=sample_inputs_col2im,
-        supports_out=False,
     ),
     opinfo_core.OpInfo(
-        "convolution",
-        aliases=("convolution",),
+        "ops.aten.convolution",
         aten_name="convolution",
         dtypes=common_dtype.floating_and_complex_types_and(torch.int64, torch.bfloat16),
         sample_inputs_func=sample_inputs_convolution,
-        supports_forward_ad=True,
-        supports_fwgrad_bwgrad=True,
-        gradcheck_nondet_tol=common_utils.GRADCHECK_NONDET_TOL,
-        skips=(),
-        supports_out=False,
     ),
     opinfo_core.OpInfo(
-        "layer_norm",
-        aliases=("layer_norm",),
+        "ops.aten.layer_norm",
         aten_name="layer_norm",
         dtypes=common_dtype.floating_and_complex_types_and(torch.int64, torch.bfloat16),
         sample_inputs_func=sample_inputs_layer_norm,
-        supports_forward_ad=True,
-        supports_fwgrad_bwgrad=True,
-        gradcheck_nondet_tol=common_utils.GRADCHECK_NONDET_TOL,
-        skips=(),
-        supports_out=False,
     ),
     opinfo_core.OpInfo(
-        "native_group_norm",
-        op=torch.ops.aten.native_group_norm,
+        "ops.aten.native_group_norm",
         aten_name="native_group_norm",
         dtypes=common_dtype.floating_and_complex_types_and(torch.half, torch.bfloat16),
         sample_inputs_func=sample_inputs_native_group_norm,
-        supports_out=False,
     ),
     opinfo_core.OpInfo(
-        "max_pool1d",
+        "ops.aten.max_pool1d",
         variant_test_name="empty_strides",
-        op=torch.ops.aten.max_pool1d,
         aten_name="max_pool1d",
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
         sample_inputs_func=sample_inputs_max_pool_empty_strides,
     ),
     opinfo_core.OpInfo(
-        "max_pool2d",
+        "ops.aten.max_pool2d",
         variant_test_name="empty_strides",
-        op=torch.ops.aten.max_pool2d,
         aten_name="max_pool2d",
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
         sample_inputs_func=sample_inputs_max_pool_empty_strides,
     ),
     opinfo_core.OpInfo(
-        "max_pool3d",
+        "ops.aten.max_pool3d",
         variant_test_name="empty_strides",
-        op=torch.ops.aten.max_pool3d,
         aten_name="max_pool3d",
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
         sample_inputs_func=sample_inputs_max_pool_empty_strides,
     ),
     opinfo_core.OpInfo(
-        "nn.functional.conv3d",
-        aliases=("conv3d",),
+        "ops.aten.conv3d",
         aten_name="conv3d",
         dtypes=common_dtype.floating_and_complex_types_and(torch.int64, torch.bfloat16),
         sample_inputs_func=sample_inputs_conv3d,
-        supports_forward_ad=True,
-        supports_fwgrad_bwgrad=True,
-        gradcheck_nondet_tol=common_utils.GRADCHECK_NONDET_TOL,
-        skips=(),
-        supports_out=False,
     ),
     opinfo_core.OpInfo(
-        "nn.functional.max_pool1d_with_indices",
+        "ops.aten.max_pool1d_with_indices",
         aten_name="max_pool1d_with_indices",
-        supports_forward_ad=True,
-        supports_fwgrad_bwgrad=True,
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
-        skips=(),
         sample_inputs_func=sample_inputs_max_pool1d_with_indices,
     ),
     opinfo_core.OpInfo(
-        "nn.functional.max_pool2d_with_indices",
+        "ops.aten.max_pool2d_with_indices",
         aten_name="max_pool2d_with_indices",
-        supports_forward_ad=True,
-        supports_fwgrad_bwgrad=True,
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
-        skips=(),
         sample_inputs_func=sample_inputs_max_pool2d_with_indices,
     ),
     opinfo_core.OpInfo(
-        "nn.functional.max_pool3d_with_indices",
+        "ops.aten.max_pool3d_with_indices",
         aten_name="max_pool3d_with_indices",
-        supports_forward_ad=True,
-        supports_fwgrad_bwgrad=True,
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
-        skips=(),
         sample_inputs_func=sample_inputs_max_pool3d_with_indices,
     ),
     # NOTE: torch.STFT has pre-padding and it's not supported by aten::stft
     # This custom OpInfo uses aten::stft directly.
     opinfo_core.OpInfo(
-        "aten.stft",
+        "ops.aten.stft",
         aten_name="stft",
-        op=torch.ops.aten.stft,
         dtypes=common_dtype.floating_and_complex_types_and(torch.half, torch.bfloat16),
         sample_inputs_func=sample_inputs_stft,
-        # Runs very slowly on slow gradcheck - alternatively reduce input sizes
-        gradcheck_fast_mode=True,
-        supports_forward_ad=True,
-        supports_fwgrad_bwgrad=True,
-        check_batched_forward_grad=False,
-        check_batched_grad=False,
-        check_batched_gradgrad=False,
-        supports_out=False,
-        gradcheck_nondet_tol=common_utils.GRADCHECK_NONDET_TOL,
     ),
     opinfo_core.OpInfo(
-        "aten.tensor.bool",
+        "ops.aten.tensor.bool",
         aten_name="tensor.bool",
-        op=torch.ops.aten.tensor.bool,
         dtypes=common_dtype.all_types_and(torch.half, torch.bfloat16),
         sample_inputs_func=sample_inputs_tensor_bool,
     ),
     opinfo_core.OpInfo(
-        "aten.tensor.float",
+        "ops.aten.tensor.float",
         aten_name="tensor.float",
-        op=torch.ops.aten.tensor.float,
         dtypes=common_dtype.all_types_and(torch.half, torch.bfloat16),
         sample_inputs_func=sample_inputs_tensor_float,
     ),
     opinfo_core.OpInfo(
-        "aten.tensor.int",
+        "ops.aten.tensor.int",
         aten_name="tensor.int",
-        op=torch.ops.aten.tensor.int,
         dtypes=common_dtype.all_types_and(torch.half, torch.bfloat16),
         sample_inputs_func=sample_inputs_tensor_int,
     ),
     opinfo_core.OpInfo(
-        # Unique ID used to connect
-        #  TorchLibOpInfo("aten.bernoulli.p", ...)
-        # and
-        #  opinfo_core.OpInfo("aten.bernoulli.p", ...)
-        "aten.bernoulli.p",
+        "ops.aten.bernoulli.p",
         aten_name="bernoulli.p",
-        op=torch.ops.aten.bernoulli.p,
         # dtypes can be a tuple of (torch.float, torch.double).
         dtypes=common_dtype.all_types(),
         sample_inputs_func=sample_inputs_bernoulli_p,
     ),
     opinfo_core.OpInfo(
         # Deterministic bernoulli sampling where p is either 0 or 1
-        "aten.bernoulli.p_deterministic",
+        "ops.aten.bernoulli.p_deterministic",
         aten_name="bernoulli.p",
-        op=torch.ops.aten.bernoulli.p,
         dtypes=common_dtype.all_types(),
         sample_inputs_func=sample_inputs_bernoulli_p_deterministic,
     ),

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -305,9 +305,9 @@ def sample_inputs_max_pool_empty_strides(op_info, device, dtype, requires_grad, 
     # FIXME: (RuntimeError: non-empty 3D or 4D (batch mode) tensor expected for input)
 
     params_generator_type_dict = {
-        "max_pool1d": _TestParamsMaxPool1dEmptyStride,
-        "max_pool2d": _TestParamsMaxPool2dEmptyStride,
-        "max_pool3d": _TestParamsMaxPool3dEmptyStride,
+        "ops.aten.max_pool1d": _TestParamsMaxPool1dEmptyStride,
+        "ops.aten.max_pool2d": _TestParamsMaxPool2dEmptyStride,
+        "ops.aten.max_pool3d": _TestParamsMaxPool3dEmptyStride,
     }
 
     params_generator = params_generator_type_dict[op_info.name]()

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -9,10 +9,7 @@ from typing import Any, List
 
 import torch
 from torch import testing as torch_testing
-from torch.testing._internal import (
-    common_dtype,
-    common_methods_invocations,
-)
+from torch.testing._internal import common_dtype, common_methods_invocations
 from torch.testing._internal.opinfo import core as opinfo_core
 
 
@@ -572,30 +569,35 @@ OP_DB: List[opinfo_core.OpInfo] = [
         aten_name="_local_scalar_dense",
         dtypes=common_dtype.all_types(),
         sample_inputs_func=sample_inputs__local_scalar_dense,
+        supports_out=False,
     ),
     opinfo_core.OpInfo(
         "ops.aten.col2im",
         aten_name="col2im",
         dtypes=common_dtype.floating_and_complex_types_and(torch.half, torch.bfloat16),
         sample_inputs_func=sample_inputs_col2im,
+        supports_out=False,
     ),
     opinfo_core.OpInfo(
         "ops.aten.convolution",
         aten_name="convolution",
         dtypes=common_dtype.floating_and_complex_types_and(torch.int64, torch.bfloat16),
         sample_inputs_func=sample_inputs_convolution,
+        supports_out=False,
     ),
     opinfo_core.OpInfo(
         "ops.aten.layer_norm",
         aten_name="layer_norm",
         dtypes=common_dtype.floating_and_complex_types_and(torch.int64, torch.bfloat16),
         sample_inputs_func=sample_inputs_layer_norm,
+        supports_out=False,
     ),
     opinfo_core.OpInfo(
         "ops.aten.native_group_norm",
         aten_name="native_group_norm",
         dtypes=common_dtype.floating_and_complex_types_and(torch.half, torch.bfloat16),
         sample_inputs_func=sample_inputs_native_group_norm,
+        supports_out=False,
     ),
     opinfo_core.OpInfo(
         "ops.aten.max_pool1d",
@@ -603,6 +605,7 @@ OP_DB: List[opinfo_core.OpInfo] = [
         aten_name="max_pool1d",
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
         sample_inputs_func=sample_inputs_max_pool_empty_strides,
+        supports_out=False,
     ),
     opinfo_core.OpInfo(
         "ops.aten.max_pool2d",
@@ -610,6 +613,7 @@ OP_DB: List[opinfo_core.OpInfo] = [
         aten_name="max_pool2d",
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
         sample_inputs_func=sample_inputs_max_pool_empty_strides,
+        supports_out=False,
     ),
     opinfo_core.OpInfo(
         "ops.aten.max_pool3d",
@@ -617,30 +621,35 @@ OP_DB: List[opinfo_core.OpInfo] = [
         aten_name="max_pool3d",
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
         sample_inputs_func=sample_inputs_max_pool_empty_strides,
+        supports_out=False,
     ),
     opinfo_core.OpInfo(
         "ops.aten.conv3d",
         aten_name="conv3d",
         dtypes=common_dtype.floating_and_complex_types_and(torch.int64, torch.bfloat16),
         sample_inputs_func=sample_inputs_conv3d,
+        supports_out=False,
     ),
     opinfo_core.OpInfo(
         "ops.aten.max_pool1d_with_indices",
         aten_name="max_pool1d_with_indices",
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
         sample_inputs_func=sample_inputs_max_pool1d_with_indices,
+        supports_out=False,
     ),
     opinfo_core.OpInfo(
         "ops.aten.max_pool2d_with_indices",
         aten_name="max_pool2d_with_indices",
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
         sample_inputs_func=sample_inputs_max_pool2d_with_indices,
+        supports_out=False,
     ),
     opinfo_core.OpInfo(
         "ops.aten.max_pool3d_with_indices",
         aten_name="max_pool3d_with_indices",
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
         sample_inputs_func=sample_inputs_max_pool3d_with_indices,
+        supports_out=False,
     ),
     # NOTE: torch.STFT has pre-padding and it's not supported by aten::stft
     # This custom OpInfo uses aten::stft directly.
@@ -649,24 +658,28 @@ OP_DB: List[opinfo_core.OpInfo] = [
         aten_name="stft",
         dtypes=common_dtype.floating_and_complex_types_and(torch.half, torch.bfloat16),
         sample_inputs_func=sample_inputs_stft,
+        supports_out=False,
     ),
     opinfo_core.OpInfo(
         "ops.aten.tensor.bool",
         aten_name="tensor.bool",
         dtypes=common_dtype.all_types_and(torch.half, torch.bfloat16),
         sample_inputs_func=sample_inputs_tensor_bool,
+        supports_out=False,
     ),
     opinfo_core.OpInfo(
         "ops.aten.tensor.float",
         aten_name="tensor.float",
         dtypes=common_dtype.all_types_and(torch.half, torch.bfloat16),
         sample_inputs_func=sample_inputs_tensor_float,
+        supports_out=False,
     ),
     opinfo_core.OpInfo(
         "ops.aten.tensor.int",
         aten_name="tensor.int",
         dtypes=common_dtype.all_types_and(torch.half, torch.bfloat16),
         sample_inputs_func=sample_inputs_tensor_int,
+        supports_out=False,
     ),
     opinfo_core.OpInfo(
         "ops.aten.bernoulli.p",
@@ -674,6 +687,7 @@ OP_DB: List[opinfo_core.OpInfo] = [
         # dtypes can be a tuple of (torch.float, torch.double).
         dtypes=common_dtype.all_types(),
         sample_inputs_func=sample_inputs_bernoulli_p,
+        supports_out=False,
     ),
     opinfo_core.OpInfo(
         # Deterministic bernoulli sampling where p is either 0 or 1
@@ -682,5 +696,6 @@ OP_DB: List[opinfo_core.OpInfo] = [
         aten_name="bernoulli.p",
         dtypes=common_dtype.all_types(),
         sample_inputs_func=sample_inputs_bernoulli_p_deterministic,
+        supports_out=False,
     ),
 ]

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -12,7 +12,6 @@ from torch import testing as torch_testing
 from torch.testing._internal import (
     common_dtype,
     common_methods_invocations,
-    common_utils,
 )
 from torch.testing._internal.opinfo import core as opinfo_core
 
@@ -679,6 +678,7 @@ OP_DB: List[opinfo_core.OpInfo] = [
     opinfo_core.OpInfo(
         # Deterministic bernoulli sampling where p is either 0 or 1
         "ops.aten.bernoulli.p_deterministic",
+        op=torch.ops.aten.bernoulli.p,
         aten_name="bernoulli.p",
         dtypes=common_dtype.all_types(),
         sample_inputs_func=sample_inputs_bernoulli_p_deterministic,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -409,7 +409,7 @@ def _where_input_wrangler(
 # Find the names of the OpInfos in torch/testing/_internal/common_methods_invocations.py
 TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo(
-        "aten._local_scalar_dense",
+        "ops.aten._local_scalar_dense",
         core_ops.aten__local_scalar_dense,
     ),
     TorchLibOpInfo("all_dim", core_ops.aten_all_dim).xfail(
@@ -504,12 +504,12 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         # This string is a unique ID. In extra_opinfo.py, we
         # also define test data for this ID with
         # `opinfo_core.OpInfo("aten.bernoulli.p", ...)`.
-        "aten.bernoulli.p",
+        "ops.aten.bernoulli.p",
         core_ops.aten_bernoulli_p,
         # Skip comparison for the output of this op because it is a random tensor.
         nondeterministic=True,
     ),
-    TorchLibOpInfo("aten.bernoulli.p_deterministic", core_ops.aten_bernoulli_p),
+    TorchLibOpInfo("ops.aten.bernoulli.p_deterministic", core_ops.aten_bernoulli_p),
     TorchLibOpInfo("bmm", core_ops.aten_bmm),
     TorchLibOpInfo("broadcast_to", core_ops.aten_broadcast_to),
     TorchLibOpInfo("cat", core_ops.aten_cat).skip(
@@ -1224,7 +1224,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ),
     TorchLibOpInfo("clamp", core_ops.aten_clamp, trace_only=True),
     TorchLibOpInfo(
-        "col2im",
+        "ops.aten.col2im",
         nn_ops.aten_col2im,
         trace_only=True,
     ).xfail(
@@ -1234,7 +1234,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo("cumsum", core_ops.aten_cumsum, trace_only=True),
     TorchLibOpInfo("contiguous", core_ops.aten_contiguous),
     TorchLibOpInfo(
-        "convolution",
+        "ops.aten.convolution",
         core_ops.aten_convolution,
         trace_only=True,
         tolerance={torch.float32: (3.7e-5, 1.8e-4)},
@@ -1270,7 +1270,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="fixme: 'bicubic' mode in ORT implemented differently with Torch and only support 4D-tensor",
     ),
     TorchLibOpInfo(
-        "layer_norm",
+        "ops.aten.layer_norm",
         core_ops.aten_layer_norm,
         trace_only=True,
         tolerance={torch.float32: (3.7e-5, 1.8e-4)},
@@ -1301,18 +1301,18 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ),
     TorchLibOpInfo(
         # Custom from extra_opinfo
-        "max_pool1d",
+        "ops.aten.max_pool1d",
         nn_ops.aten_max_pool1d,
         trace_only=True,
     ),
     TorchLibOpInfo(
         # Custom from extra_opinfo
-        "max_pool2d",
+        "ops.aten.max_pool2d",
         nn_ops.aten_max_pool2d,
         trace_only=True,
     ),
     TorchLibOpInfo(
-        "max_pool3d",  # Custom from extra_opinfo
+        "ops.aten.max_pool3d",  # Custom from extra_opinfo
         nn_ops.aten_max_pool3d,
         trace_only=True,
     ).xfail(
@@ -1321,7 +1321,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ),
     TorchLibOpInfo("native_batch_norm", core_ops.aten_native_batch_norm, trace_only=True),
     TorchLibOpInfo(
-        "native_group_norm",
+        "ops.aten.native_group_norm",
         core_ops.aten_native_group_norm,
         trace_only=True,
     ).xfail(
@@ -1361,7 +1361,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="String padding is not accepted by aten::conv2d",
     ),
     TorchLibOpInfo(
-        "nn.functional.conv3d",
+        "ops.aten.conv3d",
         core_ops.aten_conv3d,
         trace_only=True,
         tolerance={torch.float32: (3.7e-5, 1.8e-4)},
@@ -1376,7 +1376,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ),
     TorchLibOpInfo("nn.functional.linear", nn_ops.aten_linear, trace_only=True),
     TorchLibOpInfo(
-        "nn.functional.max_pool1d",
+        "ops.aten.max_pool1d",
         nn_ops.aten_max_pool1d,
         input_wrangler=_max_pool_input_wrangler,
         trace_only=True,
@@ -1385,7 +1385,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="this aten overload assume return_indices=False",
     ),
     TorchLibOpInfo(
-        "nn.functional.max_pool1d_with_indices",
+        "ops.aten.max_pool1d_with_indices",
         nn_ops.aten_max_pool1d_with_indices,
         input_wrangler=_max_pool_input_wrangler,
         trace_only=True,
@@ -1394,7 +1394,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="this aten overload assume return_indices=True",
     ),
     TorchLibOpInfo(
-        "nn.functional.max_pool2d",
+        "ops.aten.max_pool2d",
         nn_ops.aten_max_pool2d,
         input_wrangler=_max_pool_input_wrangler,
         trace_only=True,
@@ -1403,7 +1403,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="this aten overload assume return_indices=False",
     ),
     TorchLibOpInfo(
-        "nn.functional.max_pool2d_with_indices",
+        "ops.aten.max_pool2d_with_indices",
         nn_ops.aten_max_pool2d_with_indices,
         input_wrangler=_max_pool_input_wrangler,
         trace_only=True,
@@ -1412,7 +1412,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="this aten overload assume return_indices=True",
     ),
     TorchLibOpInfo(
-        "nn.functional.max_pool3d",
+        "ops.aten.max_pool3d",
         nn_ops.aten_max_pool3d,
         input_wrangler=_max_pool_input_wrangler,
         trace_only=True,
@@ -1423,12 +1423,12 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="FIXME: After https://github.com/microsoft/onnxruntime/issues/15446 is fixed",
     )
     .skip(
-        "nn.functional.max_pool3d",
+        "ops.aten.max_pool3d",
         matcher=lambda sample: sample.kwargs.get("return_indices") is True,
         reason="this aten overload assume return_indices=False",
     ),
     TorchLibOpInfo(
-        "nn.functional.max_pool3d_with_indices",
+        "ops.aten.max_pool3d_with_indices",
         nn_ops.aten_max_pool3d_with_indices,
         input_wrangler=_max_pool_input_wrangler,
         trace_only=True,
@@ -1439,7 +1439,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="FIXME: After https://github.com/microsoft/onnxruntime/issues/15446 is fixed",
     )
     .skip(
-        "nn.functional.max_pool3d_with_indices",
+        "ops.aten.max_pool3d_with_indices",
         matcher=lambda sample: sample.kwargs.get("return_indices") is False,
         reason="this aten overload assume return_indices=True",
     ),
@@ -1543,7 +1543,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo("slice_scatter", core_ops.aten_slice_scatter, trace_only=True),
     TorchLibOpInfo("slice", core_ops.aten_slice, trace_only=True),
     TorchLibOpInfo(
-        "aten.stft",  # Custom from extra_opinfo
+        "ops.aten.stft",  # Custom from extra_opinfo
         core_ops.aten_stft,
         trace_only=True,
         tolerance={torch.float32: (3.7e-5, 1.8e-4)},
@@ -1557,11 +1557,15 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         input_wrangler=_sum_input_wrangler,
         trace_only=True,
     ),
-    TorchLibOpInfo("aten.tensor.bool", core_ops.aten_tensor_bool),  # Custom from extra_opinfo
     TorchLibOpInfo(
-        "aten.tensor.float", core_ops.aten_tensor_float  # Custom from extra_opinfo
+        "ops.aten.tensor.bool", core_ops.aten_tensor_bool
+    ),  # Custom from extra_opinfo
+    TorchLibOpInfo(
+        "ops.aten.tensor.float", core_ops.aten_tensor_float  # Custom from extra_opinfo
     ),
-    TorchLibOpInfo("aten.tensor.int", core_ops.aten_tensor_int),  # Custom from extra_opinfo
+    TorchLibOpInfo(
+        "ops.aten.tensor.int", core_ops.aten_tensor_int
+    ),  # Custom from extra_opinfo
     TorchLibOpInfo("transpose", core_ops.aten_transpose, trace_only=True),
     TorchLibOpInfo(
         "var_mean",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1361,7 +1361,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="String padding is not accepted by aten::conv2d",
     ),
     TorchLibOpInfo(
-        "ops.aten.conv3d",
+        "nn.functional.conv3d",
         core_ops.aten_conv3d,
         trace_only=True,
         tolerance={torch.float32: (3.7e-5, 1.8e-4)},
@@ -1385,7 +1385,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="this aten overload assume return_indices=False",
     ),
     TorchLibOpInfo(
-        "ops.aten.max_pool1d_with_indices",
+        "nn.functional.max_pool1d_with_indices",
         nn_ops.aten_max_pool1d_with_indices,
         input_wrangler=_max_pool_input_wrangler,
         trace_only=True,
@@ -1403,7 +1403,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="this aten overload assume return_indices=False",
     ),
     TorchLibOpInfo(
-        "ops.aten.max_pool2d_with_indices",
+        "nn.functional.max_pool2d_with_indices",
         nn_ops.aten_max_pool2d_with_indices,
         input_wrangler=_max_pool_input_wrangler,
         trace_only=True,
@@ -1428,7 +1428,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="this aten overload assume return_indices=False",
     ),
     TorchLibOpInfo(
-        "ops.aten.max_pool3d_with_indices",
+        "nn.functional.max_pool3d_with_indices",
         nn_ops.aten_max_pool3d_with_indices,
         input_wrangler=_max_pool_input_wrangler,
         trace_only=True,
@@ -1439,7 +1439,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="FIXME: After https://github.com/microsoft/onnxruntime/issues/15446 is fixed",
     )
     .skip(
-        "ops.aten.max_pool3d_with_indices",
+        "nn.functional.max_pool3d_with_indices",
         matcher=lambda sample: sample.kwargs.get("return_indices") is False,
         reason="this aten overload assume return_indices=True",
     ),

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1376,7 +1376,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ),
     TorchLibOpInfo("nn.functional.linear", nn_ops.aten_linear, trace_only=True),
     TorchLibOpInfo(
-        "ops.aten.max_pool1d",
+        "nn.functional.max_pool1d",
         nn_ops.aten_max_pool1d,
         input_wrangler=_max_pool_input_wrangler,
         trace_only=True,
@@ -1394,7 +1394,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="this aten overload assume return_indices=True",
     ),
     TorchLibOpInfo(
-        "ops.aten.max_pool2d",
+        "nn.functional.max_pool2d",
         nn_ops.aten_max_pool2d,
         input_wrangler=_max_pool_input_wrangler,
         trace_only=True,
@@ -1412,7 +1412,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="this aten overload assume return_indices=True",
     ),
     TorchLibOpInfo(
-        "ops.aten.max_pool3d",
+        "nn.functional.max_pool3d",
         nn_ops.aten_max_pool3d,
         input_wrangler=_max_pool_input_wrangler,
         trace_only=True,
@@ -1423,7 +1423,6 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="FIXME: After https://github.com/microsoft/onnxruntime/issues/15446 is fixed",
     )
     .skip(
-        "ops.aten.max_pool3d",
         matcher=lambda sample: sample.kwargs.get("return_indices") is True,
         reason="this aten overload assume return_indices=False",
     ),
@@ -1439,7 +1438,6 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="FIXME: After https://github.com/microsoft/onnxruntime/issues/15446 is fixed",
     )
     .skip(
-        "nn.functional.max_pool3d_with_indices",
         matcher=lambda sample: sample.kwargs.get("return_indices") is False,
         reason="this aten overload assume return_indices=True",
     ),
@@ -1452,13 +1450,11 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="fixme: ORT crashes on Windows, segfaults randomly on Linux",
     )
     .skip(
-        "nn.functional.scaled_dot_product_attention",
         matcher=lambda sample: (attn_mask := sample.kwargs.get("attn_mask")) is not None
         and attn_mask.dtype == torch.bool,
         reason="this overload takes a non-boolean mask",
     )
     .skip(
-        "nn.functional.scaled_dot_product_attention",
         matcher=lambda sample: sample.kwargs.get("dropout_p") != 0.0,
         reason="dropout is random so the results do not match",
     ),
@@ -1471,13 +1467,11 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="fixme: ORT crashes on Windows, segfaults randomly on Linux",
     )
     .skip(
-        "nn.functional.scaled_dot_product_attention_bool_mask",
         matcher=lambda sample: (attn_mask := sample.kwargs.get("attn_mask")) is not None
         and attn_mask.dtype != torch.bool,
         reason="this overload takes a boolean mask",
     )
     .skip(
-        "nn.functional.scaled_dot_product_attention_bool_mask",
         matcher=lambda sample: sample.kwargs.get("dropout_p") != 0.0,
         reason="dropout is random so the results do not match",
     ),
@@ -1498,7 +1492,6 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         test_class_name="TestOutputConsistencyFullGraph",
     )
     .skip(
-        "nn.functional.upsample_nearest2d",
         # Shape should be [N, C, H, W]
         matcher=lambda sample: len(sample.input.shape) != 2 + 2,
         reason="only test on 2d inputs",
@@ -1519,7 +1512,6 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="ONNX doesn't support reduce='mean' option",
     )
     .skip(
-        "scatter_reduce",
         # ONNX has not include_self parameter and default is include_self=True mode
         matcher=lambda sample: sample.kwargs.get("include_self") is False,
         reason="ONNX does't support include_self=False option",
@@ -1605,7 +1597,6 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="fixme: Inferred shape and existing shape differ in rank",
     )
     .skip(
-        "var_mean_correction",
         # Don't accept input[1]=bool and 'correction' must be in kwargs
         matcher=lambda sample: len(sample.args) > 0 or "correction" not in sample.kwargs,
         reason="this Aten overload only support when correction attribute exists",


### PR DESCRIPTION
Rename all with the `op.aten.` prefix in extra_opinfos. This way OpInfo will find the op automatically without us having to specify the op. Also simplify the custom OpInfo to remove redundant information.

Fixes #870 