### PR TITLE
Break aten::max into overloads | fix(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -3929,8 +3929,8 @@ def aten_mean(self: TReal) -> TReal:
 
 
 @torch_op("aten::mean.dim")
-def aten_mean_dim(self: TReal, dim: INT64, keepdim: bool = False) -> TReal:
-    """mean(Tensor self, *, ScalarType? dtype=None) -> Tensor"""
+def aten_mean_dim(self: TReal, dim: int, keepdim: bool = False) -> TReal:
+    """mean.dim(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor"""
 
     if op.Size(op.Shape(self)) == 0:
         result = self

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -3900,7 +3900,7 @@ def aten_max(self: TReal) -> TReal:
 
 
 @torch_op("aten::max.dim")
-def aten_max_dim(self: TReal, dim: int, keepdim: bool = False) -> tuple[TReal, INT64]:
+def aten_max_dim(self: TReal, dim: int, keepdim: bool = False) -> Tuple[TReal, INT64]:
     """max.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)"""
 
     if op.Size(op.Shape(self)) == 0:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -3929,7 +3929,7 @@ def aten_mean(self: TReal) -> TReal:
 
 
 @torch_op("aten::mean.dim")
-def aten_mean_dim(self: TReal, dim: int, keepdim: bool = False) -> TReal:
+def aten_mean_dim(self: TReal, dim: INT64, keepdim: bool = False) -> TReal:
     """mean.dim(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor"""
 
     if op.Size(op.Shape(self)) == 0:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -3903,9 +3903,13 @@ def aten_max(self: TReal) -> TReal:
 def aten_max_dim(self: TReal, dim: int, keepdim: bool = False) -> tuple[TReal, INT64]:
     """max.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)"""
 
-    dims = op.Reshape(dim, op.Constant(value_ints=[-1]))
-    result = op.ReduceMax(self, dims, keepdims=keepdim)
-    indices = op.ArgMax(self, axis=dim, keepdims=keepdim)
+    if op.Size(op.Shape(self)) == 0:
+        result = self
+        indices = op.Constant(value_int=0)
+    else:
+        dims = op.Reshape(dim, op.Constant(value_ints=[-1]))
+        result = op.ReduceMax(self, dims, keepdims=keepdim)
+        indices = op.ArgMax(self, axis=dim, keepdims=keepdim)
     return result, indices
 
 
@@ -3970,13 +3974,7 @@ def aten_min_dim(self: TReal, dim: int, keepdim: bool = False) -> Tuple[TReal, T
     return result, indices
 
 
-@torch_op("aten::min.other")
-def aten_min_other(self: TReal, other: TReal) -> TReal:
-    """min.other(Tensor self, Tensor other) -> Tensor"""
-    return op.Min(self, other)
-
-
-@torch_op("aten::minimum")
+@torch_op(("aten::minimum", "aten::min.other"))
 def aten_minimum(self: TReal, other: TReal) -> TReal:
     """minimum(Tensor self, Tensor other) -> Tensor"""
 


### PR DESCRIPTION
`aten::max` was implemented as a big trace_only function. This change breaks it into multiple overloads like we did for `aten::min`.

- Also merged `aten::max/min.other` with `aten::minimum/maximum` as an alias.
