### PR TITLE
Fix strides for avg_pool2d when it is empty | fix(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -163,7 +163,8 @@ def aten_avg_pool2d(
     # The strides should be [x, y]
     if isinstance(stride, int):  # x -> [x, x]
         strides = [stride] * expand_size
-    elif stride is None:
+    elif not stride:
+        # stride is None or empty
         strides = kernel_shape
     else:
         strides = stride

--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -164,7 +164,7 @@ def aten_avg_pool2d(
     if isinstance(stride, int):  # x -> [x, x]
         strides = [stride] * expand_size
     elif not stride:
-        # stride is None or empty
+        # stride is empty
         strides = kernel_shape
     else:
         strides = stride


### PR DESCRIPTION
Fix avg_pool2d to account for when `stride` is empty. Previously it was checking for None, which was not a valid input. Now checking for emptiness instead.

Tested with

```python
import torch
import onnxruntime

def func(x):
    return torch.nn.functional.avg_pool2d(x, 4)

export_output = torch.onnx.dynamo_export(func, torch.randn(1, 64, 32, 32))

onnxruntime.InferenceSession(export_output.model_proto.SerializeToString())
```

Exported graph:

```
ir_version: 8
producer_name: "pytorch"
producer_version: "2.1.0"
graph {
  node {
    input: "arg0"
    output: "avg_pool2d"
    name: "AveragePool_0"
    op_type: "AveragePool"
    attribute {
      name: "auto_pad"
      s: "NOTSET"
      type: STRING
    }
    attribute {
      name: "ceil_mode"
      i: 0
      type: INT
    }
    attribute {
      name: "count_include_pad"
      i: 1
      type: INT
    }
    attribute {
      name: "kernel_shape"
      ints: 4
      ints: 4
      type: INTS
    }
    attribute {
      name: "pads"
      ints: 0
      ints: 0
      ints: 0
      ints: 0
      type: INTS
    }
    attribute {
      name: "strides"
      ints: 4
      ints: 4
      type: INTS
    }
    doc_string: ""
  }
  name: "torch_jit"
  input {
    name: "arg0"
    type {
      tensor_type {
        elem_type: 1
        shape {
          dim {
            dim_value: 1
          }
          dim {
            dim_value: 64
          }
          dim {
            dim_value: 32
          }
          dim {
            dim_value: 32
          }
        }
      }
    }
  }
  output {
    name: "avg_pool2d"
    type {
      tensor_type {
        elem_type: 1
        shape {
          dim {
            dim_value: 1
          }
          dim {
            dim_value: 64
          }
          dim {
            dim_value: 8
          }
          dim {
            dim_value: 8
          }
        }
      }
    }
  }
}
opset_import {
  domain: ""
  version: 18
}
```

Fixes https://github.com/pytorch/pytorch/issues/105183