### PR TITLE
Simplify model error message in test | test(torchlib)

### DIFF
--- a/onnxscript/tests/function_libs/torch_lib/ops_test.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test.py
@@ -16,7 +16,7 @@ Usage:
 from __future__ import annotations
 
 import unittest
-from typing import Any, Callable, Optional, Sequence, Tuple
+from typing import Callable, Optional, Sequence, Tuple
 
 import numpy as np
 import onnx
@@ -70,18 +70,6 @@ def _should_skip_xfail_test_sample(
             if decorator_meta.matcher(sample):
                 return decorator_meta.test_behavior, decorator_meta.reason
     return None, None
-
-
-def _split_function_and_wrangler(
-    onnx_function_and_wrangler: Callable[..., Any]
-    | tuple[Callable[..., Any], Callable[..., Any]]
-) -> tuple[Callable[..., Any], Callable[..., Any] | None]:
-    """Splits a function with an optional input wrangler into a function and an input wrangler."""
-    if isinstance(onnx_function_and_wrangler, tuple):
-        return onnx_function_and_wrangler
-
-    assert callable(onnx_function_and_wrangler)
-    return onnx_function_and_wrangler, None
 
 
 class TestFunctionValidity(unittest.TestCase):

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_common.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_common.py
@@ -517,9 +517,7 @@ def graph_executor(
             onnx.checker.check_model(onnx_model, full_check=True)
         except onnx.checker.ValidationError as e:
             raise AssertionError(
-                f"ONNX model is invalid: {e}. "
-                f"Model:\n"
-                f"{onnxscript.proto2text(onnx_model)}"
+                f"ONNX model is invalid. Model:\n{onnxscript.proto2text(onnx_model)}"
             ) from e
 
         try:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Remove the duplicate check_model message when displaying