### PR TITLE
Cleanup translator

### DIFF
--- a/onnxscript/autocast.py
+++ b/onnxscript/autocast.py
@@ -177,9 +177,14 @@ def static_cast_inputs(converter, op_schema: Optional[OpSchema], args) -> tuple[
     """Used for autocast during script-translation."""
 
     def get_type_info(x):
-        return x if not x.is_const() else None
+        """Return x if x is not a constant and None otherwise.
+        A non-constant tensor-variable can serve as the second argument of CastLike,
+        serving as the type-info for the cast."""
+        return None if x is None or x.is_const() else x
 
     def cast(x, typeinfo) -> str:
+        if x is None:
+            return None
         if x.is_const() and typeinfo is not None:
             # Scalar values are promoted to tensors of a type chosen as below:
 

--- a/onnxscript/autocast.py
+++ b/onnxscript/autocast.py
@@ -179,10 +179,11 @@ def static_cast_inputs(converter, op_schema: Optional[OpSchema], args) -> tuple[
     def get_type_info(x):
         """Return x if x is not a constant and None otherwise.
         A non-constant tensor-variable can serve as the second argument of CastLike,
-        serving as the type-info for the cast."""
+        serving as the type-info for the cast.
+        """
         return None if x is None or x.is_const() else x
 
-    def cast(x, typeinfo) -> str:
+    def cast(x, typeinfo) -> Optional[str]:
         if x is None:
             return None
         if x.is_const() and typeinfo is not None:

--- a/onnxscript/converter.py
+++ b/onnxscript/converter.py
@@ -382,7 +382,10 @@ class Converter:
         )
 
     def emit_const(
-        self, pyvalue: PyValue, suggested_name: Optional[PreferredName], info: sourceinfo.SourceInfo
+        self,
+        pyvalue: PyValue,
+        suggested_name: Optional[PreferredName],
+        info: sourceinfo.SourceInfo,
     ) -> ConverterExpression:
         if suggested_name is None:
             if isinstance(pyvalue, int):
@@ -991,14 +994,22 @@ class Converter:
             elif isinstance(lhs, ast.Tuple):
                 # Assignments of the form "x, y, z = op.SomeOp(...)"
                 if not isinstance(rhs, ast.Call):
-                    self.fail(rhs, f"RHS must be a Call expression for unpacking, found: {type(rhs)!r}")
+                    self.fail(
+                        rhs,
+                        f"RHS must be a Call expression for unpacking, found: {type(rhs)!r}",
+                    )
                 callee, inputs, attrs = self.translate_call_expr(rhs)
 
                 def generate_onnx_name(x: ast.AST):
                     if not isinstance(x, ast.Name):
                         self.fail(x, f"LHS must be a Name for unpacking, found: {type(x)!r}")
                     onnx_name = self.generate_unique_name(x.id)
-                    self.bind(x.id, values.Dynamic(onnx_name, values.DynamicKind.Intermediate, self.source_of(x)))
+                    self.bind(
+                        x.id,
+                        values.Dynamic(
+                            onnx_name, values.DynamicKind.Intermediate, self.source_of(x)
+                        ),
+                    )
                     return onnx_name
 
                 outputs = [generate_onnx_name(x) for x in lhs.elts]

--- a/onnxscript/converter.py
+++ b/onnxscript/converter.py
@@ -318,13 +318,12 @@ class Converter:
             fail(info.msg(msg) if info else msg)
         return self.ir_builder.make_attr_ref(attrname, val.value, pytype)
 
-    # TODO(rama): Cleanup representation of returned values (ConverterExpression etc.)
     def to_onnx_var(
         self,
         val: values.SymbolValue | PyValue,
         target: Optional[PreferredName] = None,
         info: Optional[sourceinfo.SourceInfo] = None,
-    ) -> ConverterExpression | OnnxVarName:
+    ) -> ConverterExpression:
         if isinstance(val, values.AttrRef):
             # promote attribute to value
             result = self.generate_unique_name(target or "tmp")
@@ -345,7 +344,7 @@ class Converter:
                 return ConverterExpression(result_as_bool, ConverterExpressionKind.CONST)
             return ConverterExpression(result, ConverterExpressionKind.CONST)
         if isinstance(val, values.Dynamic):
-            return val.value
+            return ConverterExpression(val.value, ConverterExpressionKind.ANY)
         # Assume value is a python-value convertible to a tensor
         # TODO: check if value is convertible to a TensorProto, so that we can
         # produce a better error message otherwise
@@ -353,7 +352,7 @@ class Converter:
 
     def py_var_to_onnx_var(
         self, py_var: str, info: sourceinfo.SourceInfo
-    ) -> ConverterExpression | OnnxVarName:
+    ) -> ConverterExpression:
         return self.to_onnx_var(self.lookup(py_var, info), target=py_var, info=info)
 
     def emit_docstring(self, docstring: str) -> None:
@@ -556,9 +555,8 @@ class Converter:
             return ConverterExpression(results, ConverterExpressionKind.ANY)
         return ConverterExpression(r, ConverterExpressionKind.ANY)
 
-    def translate_opt_expr(self, node):
+    def translate_opt_expr(self, node: ast.expr) -> ConverterExpression:
         """Translation of an expression where "None" is permitted.
-
         (eg., for an optional argument)
         None is represented as a NameConstant in Python 3.7 and Constant in Python 3.9.
         """
@@ -907,7 +905,7 @@ class Converter:
 
         return op, [left, right], []
 
-    def translate_name_expr(self, node: ast.Name) -> ConverterExpression | OnnxVarName:
+    def translate_name_expr(self, node: ast.Name) -> ConverterExpression:
         return self.py_var_to_onnx_var(node.id, self.source_of(node))
 
     # pylint: disable=inconsistent-return-statements
@@ -1253,7 +1251,7 @@ class Converter:
             self.source_of(loop_stmt),
         )
         for pv in loop_state_vars:
-            ov = self.py_var_to_onnx_var(pv, self.source_of(loop_stmt))
+            ov = self.py_var_to_onnx_var(pv, self.source_of(loop_stmt)).name
             if ov not in self._current_fn.assigned_names:
                 # When converting the loop-body into a graph, we need to handle
                 # identity assignments of the form "x = y" inside the loop body
@@ -1268,7 +1266,8 @@ class Converter:
             )
         body = self.exit_scope()
         inputs = [o_loop_bound, o_true] + [
-            self.py_var_to_onnx_var(pv, self.source_of(loop_stmt)) for pv in loop_state_vars
+            self.py_var_to_onnx_var(pv, self.source_of(loop_stmt)).name
+            for pv in loop_state_vars
         ]
         graph, sub_functions = body.to_graph_and_functions()
         attrs = [self.ir_builder.make_attr("body", graph)]
@@ -1304,7 +1303,7 @@ class Converter:
         for pvar in live_defs:
             if pvar in self.current_scope():
                 pv_val = self.current_scope()[pvar]
-                output = self.to_onnx_var(pv_val, pvar)
+                output = self.to_onnx_var(pv_val, pvar).name
                 if output not in self._current_fn.assigned_names:
                     # To return an outer-scope variable, an ONNX Graph has to
                     # use an explicit copy via Identity.
@@ -1328,7 +1327,7 @@ class Converter:
                         f"branch, known variables: {list(self._locals)}.",
                     )
                 # introduce a copy
-                ovar = self.emit_copy(self.to_onnx_var(pv_val, pvar), pvar)
+                ovar = self.emit_copy(self.to_onnx_var(pv_val, pvar).name, pvar)
 
                 # TODO: retrieve the annotation if any.
                 typeinfo = None

--- a/onnxscript/converter_test.py
+++ b/onnxscript/converter_test.py
@@ -581,6 +581,19 @@ class TestConverter(testutils.TestBase):
         outputs = duplicate_output.to_function_proto().output
         self.assertNotEqual(outputs[0], outputs[1])
 
+    def test_bool_op_name_generation(self):
+        """Verify that python variable name is used as onnx variable name (when possible)
+        for boolean operation translation.
+        """
+
+        @script(default_opset=op)
+        def bool_op(X, Y):
+            T = X and Y
+            return T
+
+        node = bool_op.to_function_proto().node[0]
+        self.assertEqual(node.output[0], "T")
+
     def test_bool_attr_promotion(self):
         @script()
         def if_then_else(flag: bool, Y, Z):

--- a/onnxscript/converter_test.py
+++ b/onnxscript/converter_test.py
@@ -432,7 +432,7 @@ class TestConverter(testutils.TestBase):
             return r
 
         ast_name = "_ast" if sys.version_info[:2] < (3, 9) else "ast"
-        self.check_failure(f1, f"Left term must be a tuple not <class '{ast_name}.Name'>")
+        self.check_failure(f1, f"Left term must be a tuple not '<class '{ast_name}.Name'>'")
 
     def check_run(self, onnxfn, inputs, expected_output):
         # Test by converting to model and running with ORT


### PR DESCRIPTION
Cleanup following aspects of the translator:

* `ConverterExpression` was being misused to cover 0, 1, or more ONNX variables created during translation. The resulting type-annotations were unclear and the code was fragile in a few places. It now is used to represent a single ONNX variable.
* The translation of multiple-variable assignments, like `x, y, z = op.SomeOp(...)` has been refactored.
* `translate_bool_op_expr` was not using the suggested target name (the original python variable name) for generated onnx variable. Fix this.
* Fix `translate_subscript_expr` so that it returns a `ConverterExpression`, rather than a string, for uniformity.
