### PR TITLE
Remove support for boolean operators 'and' and 'or'

### DIFF
--- a/onnxscript/converter_test.py
+++ b/onnxscript/converter_test.py
@@ -581,19 +581,6 @@ class TestConverter(testutils.TestBase):
         outputs = duplicate_output.to_function_proto().output
         self.assertNotEqual(outputs[0], outputs[1])
 
-    def test_bool_op_name_generation(self):
-        """Verify that python variable name is used as onnx variable name (when possible)
-        for boolean operation translation.
-        """
-
-        @script(default_opset=op)
-        def bool_op(X, Y):
-            T = X and Y
-            return T
-
-        node = bool_op.to_function_proto().node[0]
-        self.assertEqual(node.output[0], "T")
-
     def test_bool_attr_promotion(self):
         @script()
         def if_then_else(flag: bool, Y, Z):

--- a/onnxscript/tests/operator_test.py
+++ b/onnxscript/tests/operator_test.py
@@ -10,7 +10,7 @@ import onnx.helper
 import onnxscript.testing
 from onnxscript import script
 from onnxscript.onnx_opset import opset15 as op
-from onnxscript.onnx_types import BOOL, FLOAT
+from onnxscript.onnx_types import FLOAT
 
 
 class TestConverter(unittest.TestCase):
@@ -41,49 +41,6 @@ class TestConverter(unittest.TestCase):
             return op.Add(A, 1.0)
 
         onnxscript.testing.assert_isomorphic_function(explicit_plus1, implicit_plus1)
-
-    def test_bool_ops_binary(self):
-        @script(default_opset=op)
-        def py_two_or(a: BOOL, b: BOOL) -> BOOL:
-            return a or b
-
-        @script()
-        def onnx_two_or(a: BOOL, b: BOOL) -> BOOL:
-            return op.Or(a, b)
-
-        onnxscript.testing.assert_isomorphic_function(py_two_or, onnx_two_or)
-
-        @script(default_opset=op)
-        def py_two_and(a: BOOL, b: BOOL) -> BOOL:
-            return a and b
-
-        @script()
-        def onnx_two_and(a: BOOL, b: BOOL) -> BOOL:
-            return op.And(a, b)
-
-        onnxscript.testing.assert_isomorphic_function(py_two_and, onnx_two_and)
-
-    def test_bool_ops_three(self):
-        @script(default_opset=op)
-        def py_three_or(a: BOOL, b: BOOL, c: BOOL) -> BOOL:
-            return a or b or c
-
-        @script()
-        def onnx_three_or(a: BOOL, b: BOOL, c: BOOL) -> BOOL:
-            return op.Or(op.Or(a, b), c)
-
-        onnxscript.testing.assert_isomorphic_function(py_three_or, onnx_three_or)
-
-    def test_bool_ops_four(self):
-        @script(default_opset=op)
-        def py_four_and(a: BOOL, b: BOOL, c: BOOL, d: BOOL) -> BOOL:
-            return a and b and c and d
-
-        @script()
-        def onnx_four_and(a: BOOL, b: BOOL, c: BOOL, d: BOOL) -> BOOL:
-            return op.And(op.And(op.And(a, b), c), d)
-
-        onnxscript.testing.assert_isomorphic_function(py_four_and, onnx_four_and)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Removing support for boolean operators, as discussed in https://github.com/microsoft/onnxscript/pull/896 

This only removes the support for expressions like `X and Y`, which must instead be specified as `op.And(X, Y)`. The reason is that the shorthand notation cannot be supported in eager-mode easily. (It works for the scalar-case, but not for element-wise boolean ops on non-scalar tensors. Further, python uses short-circuit evaluation for these expressions, which will also cause a divergence in behavior with respect to the translated code.