### PR TITLE
Stable logcumsumexp | feat(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -3732,7 +3732,7 @@ def aten_logaddexp2(self: TFloatOrBFloat16, other: TFloatOrBFloat16) -> TFloatOr
     return op.Div(op.Log(summation), op.Log(2.0))
 
 
-@torch_op("aten::logcumsumexp", trace_only=False)
+@torch_op("aten::logcumsumexp")
 def aten_logcumsumexp(self: TFloatOrBFloat16, dim: int) -> TFloatOrBFloat16:
     """logcumsumexp(Tensor self, int dim) -> Tensor"""
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -3743,9 +3743,8 @@ def aten_logcumsumexp(self: TFloatOrBFloat16, dim: int) -> TFloatOrBFloat16:
         # Make dim 1-d
         dims = op.Unsqueeze(dim, axes=[0])
         # TODO(justinchuby): Add explanation
-        result = op.Log(
-            op.CumSum(op.Exp(self - op.ReduceMax(self, dims)), dims)
-        ) + op.ReduceMax(self, dims)
+        self_max = op.ReduceMax(self, dims)
+        result = op.Log(op.CumSum(op.Exp(self - self_max), dims)) + self_max
     return result
 
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -3746,26 +3746,26 @@ def _aten_logcumsumexp_onnx(self: TFloatOrBFloat16, dims: Sequence[int]) -> TFlo
     for stability.
     """
 
-    @graph()
-    def log_add_exp(x, y):
-        # Compute pairwise log_exp.
-        # Based on https://www.tensorflow.org/api_docs/python/tf/math/cumulative_logsumexp.
-        # log_add_exp(x, y) = log(1 + exp(min(x, y) - max(x, y))) + max(x, y)
-        sum_out = op.Add(op.Log(op.Add(1, op.Exp(op.Sub(op.Min(x, y), op.Max(x, y))))), op.Max(x, y))
-        return x, sum_out
+    # @graph()
+    # def log_add_exp(x, y):
+    #     # Compute pairwise log_exp.
+    #     # Based on https://www.tensorflow.org/api_docs/python/tf/math/cumulative_logsumexp.
+    #     # log_add_exp(x, y) = log(1 + exp(min(x, y) - max(x, y))) + max(x, y)
+    #     sum_out = op.Add(op.Log(op.Add(1, op.Exp(op.Sub(op.Min(x, y), op.Max(x, y))))), op.Max(x, y))
+    #     return sum_out, sum_out
 
-    self_rank = op.Size(op.Shape(self))
-    if self_rank == 0:
-        # A scalar
-        result = op.Identity(self)
-    elif self_rank == 1:
-        # A 1d tensor
-        _, result = op.Scan(op.CastLike(0.0, self), self, body=log_add_exp, num_scan_inputs=1, scan_input_axes=dims, scan_output_axes=dims)
-    else:
-        zero = op.Expand(op.CastLike(0.0, self), op.Shape(self))
-        # Take dims out from zero
-        zero = op.ReduceSum(zero, dims, keepdims=0)
-        _, result = op.Scan(zero, self, body=log_add_exp, num_scan_inputs=1, scan_input_axes=dims, scan_output_axes=dims)
+    # self_rank = op.Size(op.Shape(self))
+    # if self_rank == 0:
+    #     # A scalar
+    #     result = op.Identity(self)
+    # elif self_rank == 1:
+    #     # A 1d tensor
+    #     _, result = op.Scan(op.CastLike(0.0, self), self, body=log_add_exp, num_scan_inputs=1, scan_input_axes=dims, scan_output_axes=dims)
+    # else:
+    #     zero = op.Expand(op.CastLike(0.0, self), op.Shape(self))
+    #     # Take dims out from zero
+    #     zero = op.ReduceSum(zero, dims, keepdims=0)
+    #     _, result = op.Scan(zero, self, body=log_add_exp, num_scan_inputs=1, scan_input_axes=dims, scan_output_axes=dims)
 
     return result
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -3748,7 +3748,7 @@ def aten_logcumsumexp(self: TFloatOrBFloat16, dim: int) -> TFloatOrBFloat16:
         # out = [out_1, out_2, ..., out_n], then
         # out_i = log(cumsum(exp(A)))_i
         #       = log(exp(a_1) + ... + exp(a_i))
-        #       = log(exp(a_1) + ... + exp(a_i)) - max(A) + max(B)
+        #       = log(exp(a_1) + ... + exp(a_i)) - max(A) + max(A)
         #       = log((exp(a_1) + ... + exp(a_i)) / exp(max(A))) + max(A)
         #       = log(exp(a_1-max(A)) + ... + exp(a_i-max(A))) + max(A)
         #       = log(sum<j=1...i>(exp(a_j - max(A)))) + max(A)

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -676,9 +676,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ),
     TorchLibOpInfo("logaddexp", core_ops.aten_logaddexp),
     TorchLibOpInfo("logaddexp2", core_ops.aten_logaddexp2),
-    TorchLibOpInfo("logcumsumexp", core_ops.aten_logcumsumexp).xfail(
-        reason="naive implementation not numerically stable"
-    ),
+    TorchLibOpInfo("logcumsumexp", core_ops.aten_logcumsumexp, trace_only=True),
     TorchLibOpInfo("logdet", core_ops.aten_logdet),
     TorchLibOpInfo(
         "logsumexp",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -697,7 +697,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ),
     TorchLibOpInfo("logaddexp", core_ops.aten_logaddexp),
     TorchLibOpInfo("logaddexp2", core_ops.aten_logaddexp2),
-    TorchLibOpInfo("logcumsumexp", core_ops.aten_logcumsumexp, trace_only=True),
+    TorchLibOpInfo("logcumsumexp", core_ops.aten_logcumsumexp),
     TorchLibOpInfo("logdet", core_ops.aten_logdet),
     TorchLibOpInfo(
         "logsumexp",


### PR DESCRIPTION
Stable logcumsumexp with the subtract-max trick. I tried to use Scan unsuccessfully and it proved to be not needed. Thanks @gramalingam for his help with math & `Scan`