### PR TITLE
Add op(roll) | feat(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5747,6 +5747,7 @@ def _aten_roll_shift_and_dim_onnx(self: TTensor, shift: int, dim: int) -> TTenso
         slice_length = -shift_tensor
     else:
         slice_length = op.Gather(op.Shape(self), dim_tensor, axis=0) - shift_tensor
+    # from [A,B,C,D,E] -> [E,A,B,C,D], [E] is prefix, [A,B,C,D] is suffix
     suffix = op.Slice(self, op.Constant(value_ints=[0]), slice_length, axes=dim_tensor)
     prefix = op.Slice(self, slice_length, op.Reshape(op.Size(self), neg_1), axes=dim_tensor)
     result = op.Concat(prefix, suffix, axis=dim)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5694,7 +5694,7 @@ def aten_rnn_tanh_cell(
 
 @torch_op("aten::roll", trace_only=True)
 def aten_roll(
-    self: TTensor, shifts: Sequence[int], dims: Optional[Sequence[int]] = None
+    self: TTensor, shifts: INT64, dims: Optional[Sequence[int]] = None
 ) -> TTensor:
     """roll(Tensor self, int[1] shifts, int[1] dims=[]) -> Tensor"""
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5649,12 +5649,24 @@ def aten_rnn_tanh_cell(
     raise NotImplementedError()
 
 
+@torch_op("aten::roll", trace_only=True)
 def aten_roll(
     self: TensorType, shifts: Sequence[int], dims: Optional[Sequence[int]] = None
 ) -> TensorType:
     """roll(Tensor self, int[1] shifts, int[1] dims=[]) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Identity(self)
+
+
+def aten_roll_no_dim(self, shift):
+    pass
+
+def aten_roll_int(self, shift, dim):
+    pass
+
+def aten_roll_tuple(self, shifts, dims):
+    pass
+
 
 
 def aten_rot90(self: TensorType, k: int = 1, dims: Sequence[int] = (0, 1)) -> TensorType:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5754,32 +5754,6 @@ def _aten_roll_shift_and_dim_onnx(self: TTensor, shift: int, dim: int) -> TTenso
     return result
 
 
-@torch_op("aten::roll", private=True)
-def _aten_roll_shifts_and_dims_onnx(
-    self: TTensor,
-    shifts: Sequence[int],  # pylint: disable=unused-argument
-    dims: Sequence[int],  # pylint: disable=unused-argument
-    length: int,  # pylint: disable=unused-argument
-) -> TTensor:
-    result = op.Identity(self)
-    # for i in range(length):
-    #     shift = shifts[i]
-    #     dim = dims[i]
-    #     neg_1 = op.Constant(value_ints=[-1])
-    #     shift_tensor = op.Reshape(shift, neg_1)
-    #     slice_length = op.Gather(op.Shape(result), dim, axis=0) - shift_tensor
-    #     if shift_tensor < 0:
-    #         slice_length = -shift_tensor
-    #     dim_tensor = op.Reshape(dim, neg_1)
-    #     suffix = op.Slice(result, op.Constant(value_ints=[0]), slice_length, axes=dim_tensor)
-    #     prefix = op.Slice(result, slice_length, op.Reshape(op.Size(self), neg_1), axes=dim_tensor)
-    #     dim_int = dims[i]
-    #     # Below function not work, because dim_int is dynamic value
-    #     # We don't have any other way to handle this case
-    #     result = op.Concat(prefix, suffix, axis=dim_int)
-    return result
-
-
 def aten_rot90(self: TensorType, k: int = 1, dims: Sequence[int] = (0, 1)) -> TensorType:
     """rot90(Tensor self, int k=1, int[] dims=[0,1]) -> Tensor"""
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5705,12 +5705,8 @@ def aten_roll(self: TTensor, shifts: INT64, dims: Sequence[int] = ()) -> TTensor
         if isinstance(dims, tuple) and len(dims) == 0:  # Empty list
             # assert isinstance(shifts, int)
             return _aten_roll_shift_no_dim_onnx(self, shifts)
-        elif isinstance(shifts, int) and isinstance(dims, int):
-            return _aten_roll_shift_and_dim_onnx(self, shifts, dims)
         else:
-            # assert isinstance(shifts, np.ndarray)
-            # assert isinstance(dims, tuple)
-            # assert len(shifts) == len(dims)
+            # assert len(shifts) == len(dims), but shifts is a tensor, dims is a list
             result = self
             for i in range(len(shifts)):  # pylint: disable=consider-using-enumerate
                 shift = op.Gather(shifts, i, axis=0)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5712,7 +5712,7 @@ def aten_roll(
             assert len(shifts) == len(dims)
             result = self
             for i in range(len(shifts)):  # pylint: disable=consider-using-enumerate
-                shift = shifts[i]
+                shift = op.Gather(shifts, i, axis=0)
                 dim = dims[i]
                 result = _aten_roll_shift_and_dim_onnx(result, shift, dim)
             return result
@@ -5739,10 +5739,10 @@ def _aten_roll_shift_no_dim_onnx(self: TTensor, shift: INT64) -> TTensor:
 
 
 @torch_op("aten::roll", private=True)
-def _aten_roll_shift_and_dim_onnx(self: TTensor, shift: int, dim: int) -> TTensor:
+def _aten_roll_shift_and_dim_onnx(self: TTensor, shift: INT64, dim: int) -> TTensor:
     neg_1 = op.Constant(value_ints=[-1])
     dim_tensor = op.Reshape(op.Constant(value_int=dim), neg_1)
-    shift_tensor = op.Reshape(op.Constant(value_int=shift), neg_1)
+    shift_tensor = op.Reshape(shift, neg_1)
     if shift_tensor < 0:
         slice_length = -shift_tensor
     else:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5711,7 +5711,7 @@ def aten_roll(
         else:  # Below condition was skipped because we cannot handle it in OnnxScript
             assert len(shifts) == len(dims)
             result = self
-            for i in range(len(shifts)):
+            for i in range(len(shifts)):  # pylint: disable=consider-using-enumerate
                 shift = shifts[i]
                 dim = dims[i]
                 result = _aten_roll_shift_and_dim_onnx(result, shift, dim)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5726,7 +5726,8 @@ def _aten_roll_shift_no_dim_onnx(self: TTensor, shift: INT64) -> TTensor:
         # For [A,B,C,D], if shift is -1, slice_length = -(-1) = 1, means move [A] to the end
         slice_length = -shift_tensor
     else:
-        # For [A,B,C,D], if shift is 1, slice_length = 5 - 1 = 4, means move [D] to the beginning
+        # For [A,B,C,D], if shift is 1, slice_length = 4 - 1 = 3, means move [A,B,C] to the end
+        # The effect equals to move [D] to the beginning
         slice_length = op.Size(self_flatten) - shift_tensor
     # Get second part of the tensor, e.g. [A,B,C]
     suffix = op.Slice(self_flatten, op.Constant(value_ints=[0]), slice_length)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5711,7 +5711,7 @@ def _aten_roll_shifts_and_dims_onnx(
     self: TTensor,
     shifts: Sequence[int],  # pylint: disable=unused-argument
     dims: Sequence[int],  # pylint: disable=unused-argument
-    length: int  # pylint: disable=unused-argument
+    length: int,  # pylint: disable=unused-argument
 ) -> TTensor:
     result = op.Identity(self)
     # for i in range(length):

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5666,7 +5666,7 @@ def aten_roll(
         elif isinstance(shifts, int) and isinstance(dims, int):
             return _aten_roll_shift_and_dim_onnx(self, shifts, dims)
         else:  # Below condition was skipped because we cannot handle it in OnnxScript
-            assert(len(shifts) == len(dims))
+            assert len(shifts) == len(dims)
             result = _aten_roll_shifts_and_dims_onnx(self, shifts, dims, len(shifts))
             return result
 
@@ -5706,23 +5706,25 @@ def _aten_roll_shift_and_dim_onnx(self: TTensor, shift: INT64, dim: int) -> TTen
 
 
 @torch_op("aten::roll", private=True)
-def _aten_roll_shifts_and_dims_onnx(self: TTensor, shifts: Sequence[int], dims: Sequence[int], length: int):
+def _aten_roll_shifts_and_dims_onnx(
+    self: TTensor, shifts: Sequence[int], dims: Sequence[int], length: int
+) -> TTensor:
     result = op.Identity(self)
-    for i in range(length):
-        shift = shifts[i]
-        dim = dims[i]
-        neg_1 = op.Constant(value_ints=[-1])
-        shift_tensor = op.Reshape(shift, neg_1)
-        slice_length = op.Gather(op.Shape(result), dim, axis=0) - shift_tensor
-        if shift_tensor < 0:
-            slice_length = -shift_tensor
-        dim_tensor = op.Reshape(dim, neg_1)
-        suffix = op.Slice(result, op.Constant(value_ints=[0]), slice_length, axes=dim_tensor)
-        prefix = op.Slice(result, slice_length, op.Reshape(op.Size(self), neg_1), axes=dim_tensor)
-        dim_int = dims[i]
-        # Below function not work, because dim_int is dynamic value
-        # We don't have any other way to handle this case
-        # result = op.Concat(prefix, suffix, axis=dim_int)
+    # for i in range(length):
+    #     shift = shifts[i]
+    #     dim = dims[i]
+    #     neg_1 = op.Constant(value_ints=[-1])
+    #     shift_tensor = op.Reshape(shift, neg_1)
+    #     slice_length = op.Gather(op.Shape(result), dim, axis=0) - shift_tensor
+    #     if shift_tensor < 0:
+    #         slice_length = -shift_tensor
+    #     dim_tensor = op.Reshape(dim, neg_1)
+    #     suffix = op.Slice(result, op.Constant(value_ints=[0]), slice_length, axes=dim_tensor)
+    #     prefix = op.Slice(result, slice_length, op.Reshape(op.Size(self), neg_1), axes=dim_tensor)
+    #     dim_int = dims[i]
+    #     # Below function not work, because dim_int is dynamic value
+    #     # We don't have any other way to handle this case
+    #     result = op.Concat(prefix, suffix, axis=dim_int)
     return result
 
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5670,6 +5670,7 @@ def aten_roll(
             result = _aten_roll_shifts_and_dims_onnx(self, shifts, dims, len(shifts))
             return result
 
+
 @torch_op("aten::roll", private=True)
 def _aten_roll_shift_no_dim_onnx(self: TTensor, shift: INT64) -> TTensor:
     neg_1 = op.Constant(value_ints=[-1])
@@ -5707,7 +5708,10 @@ def _aten_roll_shift_and_dim_onnx(self: TTensor, shift: INT64, dim: int) -> TTen
 
 @torch_op("aten::roll", private=True)
 def _aten_roll_shifts_and_dims_onnx(
-    self: TTensor, shifts: Sequence[int], dims: Sequence[int], length: int
+    self: TTensor,
+    shifts: Sequence[int],  # pylint: disable=unused-argument
+    dims: Sequence[int],  # pylint: disable=unused-argument
+    length: int  # pylint: disable=unused-argument
 ) -> TTensor:
     result = op.Identity(self)
     # for i in range(length):

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5722,7 +5722,7 @@ def _aten_roll_shifts_and_dims_onnx(self: TTensor, shifts: Sequence[int], dims: 
         dim_int = dims[i]
         # Below function not work, because dim_int is dynamic value
         # We don't have any other way to handle this case
-        result = op.Concat(prefix, suffix, axis=dim_int)
+        # result = op.Concat(prefix, suffix, axis=dim_int)
     return result
 
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5693,9 +5693,7 @@ def aten_rnn_tanh_cell(
 
 
 @torch_op("aten::roll", trace_only=True)
-def aten_roll(
-    self: TTensor, shifts: INT64, dims: Optional[Sequence[int]] = None
-) -> TTensor:
+def aten_roll(self: TTensor, shifts: INT64, dims: Optional[Sequence[int]] = None) -> TTensor:
     """roll(Tensor self, int[1] shifts, int[1] dims=[]) -> Tensor"""
 
     self_rank = len(self.shape)

--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -674,17 +674,27 @@ def aten_leaky_relu_backward(
     raise NotImplementedError()
 
 
-@torch_op("aten::linear", trace_only=True)
-def aten_linear(input: TFloat, weight: TFloat, bias: Optional[TFloat] = None) -> TFloat:
+@torch_op("aten::linear")
+def aten_linear(input: TFloat, weight: TFloat) -> TFloat:
     """linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor"""
 
     # NOTE: The symbolic function in torch.onnx also uses Gemm in certain cases
     # Optimizers may consider this path and replace it with Gemm
+    # We do not use Gemm here because input can have batch dimensions, which Gemm does not support
     weight_transposed = op.Transpose(weight, perm=[1, 0])
-    result = op.MatMul(input, weight_transposed)
-    if bias is not None:
-        result = op.Add(result, bias)
-    return result
+    return op.MatMul(input, weight_transposed)
+
+
+@torch_op("aten::linear")
+def aten_linear_bias(input: TFloat, weight: TFloat, bias: TFloat) -> TFloat:
+    """linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor"""
+
+    # NOTE: The symbolic function in torch.onnx also uses Gemm in certain cases
+    # Optimizers may consider this path and replace it with Gemm
+    # We do not use Gemm here because input can have batch dimensions, which Gemm does not support
+    weight_transposed = op.Transpose(weight, perm=[1, 0])
+    mul = op.MatMul(input, weight_transposed)
+    return op.Add(mul, bias)
 
 
 @torch_op("aten::log_sigmoid")

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1609,6 +1609,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="fixme: the scale_factor tests",
     ),
     TorchLibOpInfo("ones_like", core_ops.aten_ones_like, trace_only=True),
+    TorchLibOpInfo("roll", core_ops.aten_roll, trace_only=True),
     TorchLibOpInfo(
         "scatter_reduce",
         core_ops.aten_scatter_reduce,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -362,10 +362,18 @@ def _replication_pad3d_input_wrangler(
 def _roll_input_wrangler(
     args: list[Any], kwargs: dict[str, Any]
 ) -> tuple[list[Any], dict[str, Any]]:
-    if len(args) >= 3 and isinstance(args[2], np.ndarray):
-        # Change dims from args to kwargs to keep tuple/list type
-        dims = args.pop(2)
-        kwargs["dims"] = dims.tolist()
+    if len(args) >= 3:
+        if isinstance(args[2], np.ndarray):  # convert dims to list[int]
+            # Change dims from args to kwargs to keep tuple/list type
+            dims = args.pop(2)
+            kwargs["dims"] = dims.tolist()
+        elif isinstance(args[2], int):  # convert dims to list[int]
+            dims = args.pop(2)
+            kwargs["dims"] = []
+            kwargs["dims"].append(dims)
+    if len(args) >= 2:
+        if isinstance(args[1], int):  # convert shift to tensor
+            args[1] = np.array([args[1]], dtype=np.int64)
     return args, kwargs
 
 

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1609,8 +1609,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="fixme: the scale_factor tests",
     ),
     TorchLibOpInfo("ones_like", core_ops.aten_ones_like, trace_only=True),
-    TorchLibOpInfo("roll", core_ops.aten_roll, trace_only=True)
-    .skip(
+    TorchLibOpInfo("roll", core_ops.aten_roll, trace_only=True).skip(
         matcher=lambda sample: not isinstance(sample.kwargs.get("shifts"), int),
         reason="Cannot handle when shifts is tuple",
     ),

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1610,7 +1610,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ),
     TorchLibOpInfo("ones_like", core_ops.aten_ones_like, trace_only=True),
     TorchLibOpInfo("roll", core_ops.aten_roll, trace_only=True).skip(
-        matcher=lambda sample: not isinstance(sample.kwargs.get("shifts"), int),
+        matcher=lambda sample: isinstance(sample.args[0], tuple),
         reason="Cannot handle when shifts is tuple",
     ),
     TorchLibOpInfo(

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1609,7 +1609,11 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="fixme: the scale_factor tests",
     ),
     TorchLibOpInfo("ones_like", core_ops.aten_ones_like, trace_only=True),
-    TorchLibOpInfo("roll", core_ops.aten_roll, trace_only=True),
+    TorchLibOpInfo("roll", core_ops.aten_roll, trace_only=True)
+    .skip(
+        matcher=lambda sample: not isinstance(sample.kwargs.get("shifts"), int),
+        reason="Cannot handle when shifts is tuple",
+    ),
     TorchLibOpInfo(
         "scatter_reduce",
         core_ops.aten_scatter_reduce,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1473,7 +1473,16 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         dtypes=[torch.float16],
         reason="fixme: ONNX Runtime aborted",
     ),
-    TorchLibOpInfo("nn.functional.linear", nn_ops.aten_linear, trace_only=True),
+    TorchLibOpInfo("nn.functional.linear", nn_ops.aten_linear).skip(
+        # input: input, args: weight, bias; so len(args) == 2 means bias is provided
+        matcher=lambda sample: len(sample.args) != 1,
+        reason="this overload is implemented for bias=None",
+    ),
+    TorchLibOpInfo("nn.functional.linear_bias", nn_ops.aten_linear_bias).skip(
+        # input: input, args: weight, bias; so len(args) == 2 means bias is provided
+        matcher=lambda sample: len(sample.args) != 2,
+        reason="this overload is implemented for bias!=None",
+    ),
     TorchLibOpInfo(
         "nn.functional.max_pool1d",
         nn_ops.aten_max_pool1d,
@@ -1722,6 +1731,9 @@ ops_test_common.duplicate_opinfo(OPS_DB, "new_empty_strided", ("new_empty_stride
 ops_test_common.duplicate_opinfo(OPS_DB, "new_full", ("new_full_dtype",))
 ops_test_common.duplicate_opinfo(OPS_DB, "new_ones", ("new_ones_dtype",))
 ops_test_common.duplicate_opinfo(OPS_DB, "new_zeros", ("new_zeros_dtype",))
+ops_test_common.duplicate_opinfo(
+    OPS_DB, "nn.functional.linear", ("nn.functional.linear_bias",)
+)
 ops_test_common.duplicate_opinfo(
     OPS_DB, "nn.functional.nll_loss", ("nn.functional.nll_loss_weight",)
 )

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -349,6 +349,16 @@ def _replication_pad3d_input_wrangler(
     return args, kwargs
 
 
+def _roll_input_wrangler(
+    args: list[Any], kwargs: dict[str, Any]
+) -> tuple[list[Any], dict[str, Any]]:
+    if len(args) >= 3 and isinstance(args[2], np.ndarray):
+        # Change dims from args to kwargs to keep tuple/list type
+        dims = args.pop(2)
+        kwargs["dims"] = dims.tolist()
+    return args, kwargs
+
+
 def _scatter_reduce_input_wrangler(
     args: list[Any], kwargs: dict[str, Any]
 ) -> tuple[list[Any], dict[str, Any]]:
@@ -1609,9 +1619,11 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="fixme: the scale_factor tests",
     ),
     TorchLibOpInfo("ones_like", core_ops.aten_ones_like, trace_only=True),
-    TorchLibOpInfo("roll", core_ops.aten_roll, trace_only=True).skip(
-        matcher=lambda sample: isinstance(sample.args[0], tuple),
-        reason="Cannot handle when shifts is tuple",
+    TorchLibOpInfo(
+        "roll",
+        core_ops.aten_roll,
+        trace_only=True,
+        input_wrangler=_roll_input_wrangler,
     ),
     TorchLibOpInfo(
         "scatter_reduce",


### PR DESCRIPTION
In ```_roll_input_wrangler```:
1. convert ```shifts``` from int to tensor 
2. convert ```dims``` from int or tensor to attributes list, so we can use loop in trace_only mode to process ```aten_roll(x, (y1, y2), (z1, z2))``` case.


