### PR TITLE
Revert "Mark tests as flaky and enable reruns | test(torchlib)"

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -21,7 +21,6 @@ COMMON_TEST_DEPENDENCIES = (
     "parameterized",
     "pytest-cov",
     "pytest-randomly",
-    "pytest-rerunfailures",
     "pytest-subtests",
     "pytest-xdist",
     "pytest!=7.1.0",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_common.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_common.py
@@ -56,8 +56,6 @@ FLOAT_TYPES = (
 
 TEST_OPSET_VERSION = 18
 IS_WINDOWS = os.name == "nt"
-# The number of reruns for flaky tests
-FLAKY_RERUNS = 5
 
 
 @dataclasses.dataclass
@@ -149,38 +147,6 @@ def skip(
         enabled_if=enabled_if,
         test_class_name=test_class_name,
         test_behavior="skip",
-    )
-
-
-def flaky(
-    op_name: str,
-    variant_name: str = "",
-    *,
-    reason: str,
-    dtypes: Optional[Collection[torch.dtype]] = None,
-    enabled_if: bool = True,
-    test_class_name: Optional[str] = None,
-) -> DecorateMeta:
-    """Mark an OpInfo test as flaky to enable reruns.
-
-    Args:
-        op_name: The name of the operator.
-        variant_name: Optional OpInfo variant_test_name.
-        reason: The reason for the flakiness.
-        dtypes: The dtypes to mark as flaky.
-        enabled_if: Whether rerun when flaky is enabled.
-        test_class_name: The test class name to apply the flaky marker to.
-            If None, it is applied to all test classes.
-    """
-    return DecorateMeta(
-        op_name=op_name,
-        variant_name=variant_name,
-        decorator=pytest.mark.flaky(reruns=FLAKY_RERUNS, rerun_except="AssertionError"),
-        dtypes=dtypes,
-        reason=reason,
-        enabled_if=enabled_if,
-        test_class_name=test_class_name,
-        test_behavior="flaky",
     )
 
 
@@ -571,12 +537,12 @@ def graph_executor(
             onnxruntime.capi.onnxruntime_pybind11_state.NotImplemented,
             # pylint: enable=c-extension-no-member
         ) as e:
-            raise RuntimeError(
+            raise AssertionError(
                 "ONNX Runtime failed to evaluate:\n"
                 + _format_model_and_input_information(onnx_model, ort_inputs)
             ) from e
         except OrtAbortedError as e:
-            raise OrtAbortedError(
+            raise AssertionError(
                 "ONNX Runtime aborted:\n"
                 + _format_model_and_input_information(onnx_model, ort_inputs)
             ) from e

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -165,37 +165,6 @@ class TorchLibOpInfo:
         )
         return self
 
-    def flaky(
-        self,
-        variant_name: str = "",
-        *,
-        reason: str,
-        dtypes: Optional[Collection[torch.dtype]] = None,
-        enabled_if: bool = True,
-        test_class_name: Optional[str] = None,
-    ) -> Self:
-        """Marks an OpInfo test as flaky.
-
-        Args:
-            variant_name: Optional OpInfo variant_test_name.
-            reason: The reason for the flakiness.
-            dtypes: The dtypes to mark as flaky.
-            enabled_if: Whether rerun when flaky is enabled.
-            test_class_name: The test class name to apply the flaky marker to.
-                If None, it is applied to all test classes.
-        """
-        self.skips_or_fails.append(
-            ops_test_common.flaky(
-                self.op_info_name,
-                variant_name,
-                reason=reason,
-                dtypes=dtypes,
-                enabled_if=enabled_if,
-                test_class_name=test_class_name,
-            )
-        )
-        return self
-
 
 # Modify this section ##########################################################
 
@@ -556,11 +525,11 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         dtypes=[torch.float16],
         reason="fixme: SplitToSequence op inference failed. https://github.com/microsoft/onnxruntime/issues/16006",
     ),
-    TorchLibOpInfo("clamp_max", core_ops.aten_clamp_max).flaky(
+    TorchLibOpInfo("clamp_max", core_ops.aten_clamp_max).skip(
         enabled_if=ops_test_common.IS_WINDOWS,
         reason="fixme: ORT has memory errors. https://github.com/microsoft/onnxruntime/issues/16492",
     ),
-    TorchLibOpInfo("clamp_min", core_ops.aten_clamp_min).flaky(
+    TorchLibOpInfo("clamp_min", core_ops.aten_clamp_min).skip(
         enabled_if=ops_test_common.IS_WINDOWS,
         reason="fixme: ORT has memory errors. https://github.com/microsoft/onnxruntime/issues/16492",
     ),
@@ -725,7 +694,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         matcher=lambda sample: torch.numel(sample.input) == 0,
         reason="values of matmul of [m, 0] and [0, n] matrices are undefined",
     ),
-    TorchLibOpInfo("maximum", core_ops.aten_maximum).flaky(
+    TorchLibOpInfo("maximum", core_ops.aten_maximum).skip(
         enabled_if=ops_test_common.IS_WINDOWS,
         reason="fixme: ORT has memory errors. https://github.com/microsoft/onnxruntime/issues/16492",
     ),
@@ -750,7 +719,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo("mT", core_ops.aten_mT),
     TorchLibOpInfo("mT", core_ops.aten_mT_complex, complex=True),
     TorchLibOpInfo("min_dim", core_ops.aten_min_dim)
-    .flaky(
+    .skip(
         variant_name="reduction_with_dim",
         enabled_if=ops_test_common.IS_WINDOWS,
         reason="fixme: ORT has memory errors. https://github.com/microsoft/onnxruntime/issues/16492",
@@ -777,7 +746,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         matcher=lambda sample: len(sample.args) > 0,
         reason="this ATen overload only supports one tensor as input by design",
     ),
-    TorchLibOpInfo("minimum", core_ops.aten_minimum).flaky(
+    TorchLibOpInfo("minimum", core_ops.aten_minimum).skip(
         enabled_if=ops_test_common.IS_WINDOWS,
         reason="fixme: ORT has memory errors. https://github.com/microsoft/onnxruntime/issues/16492",
     ),
@@ -1249,7 +1218,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         matcher=lambda sample: "dim" in sample.kwargs,
         reason="this overload does not support the 'dim' attribute by design",
     )
-    .flaky(
+    .skip(
         enabled_if=ops_test_common.IS_WINDOWS,
         reason="fixme: ORT has memory errors. https://github.com/microsoft/onnxruntime/issues/16492",
     )
@@ -1262,7 +1231,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         matcher=lambda sample: "dim" not in sample.kwargs,
         reason="this overload requires the 'dim' attribute by design",
     )
-    .flaky(
+    .skip(
         enabled_if=ops_test_common.IS_WINDOWS,
         reason="fixme: ORT has memory errors. https://github.com/microsoft/onnxruntime/issues/16492",
     )
@@ -1275,7 +1244,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         matcher=lambda sample: "dim" in sample.kwargs,
         reason="this overload does not support the 'dim' attribute by design",
     )
-    .flaky(
+    .skip(
         enabled_if=ops_test_common.IS_WINDOWS,
         reason="fixme: ORT has memory errors. https://github.com/microsoft/onnxruntime/issues/16492",
     )
@@ -1288,7 +1257,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         matcher=lambda sample: "dim" not in sample.kwargs,
         reason="this overload requires the 'dim' attribute by design",
     )
-    .flaky(
+    .skip(
         enabled_if=ops_test_common.IS_WINDOWS,
         reason="fixme: ORT has memory errors. https://github.com/microsoft/onnxruntime/issues/16492",
     )
@@ -1304,7 +1273,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         variant_name="partial_views",
         reason="ONNX doesn't have partial view for tensor",
     ),
-    TorchLibOpInfo("clamp", core_ops.aten_clamp, trace_only=True).flaky(
+    TorchLibOpInfo("clamp", core_ops.aten_clamp, trace_only=True).skip(
         enabled_if=ops_test_common.IS_WINDOWS,
         reason="fixme: ORT has memory errors. https://github.com/microsoft/onnxruntime/issues/16492",
     ),
@@ -1365,7 +1334,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ),
     TorchLibOpInfo("logit", core_ops.aten_logit, trace_only=True),
     TorchLibOpInfo("max_dim", core_ops.aten_max_dim)
-    .flaky(
+    .skip(
         variant_name="reduction_with_dim",
         enabled_if=ops_test_common.IS_WINDOWS,
         reason="fixme: ORT has memory errors. https://github.com/microsoft/onnxruntime/issues/16492",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,6 @@ hypothesis
 parameterized
 pytest-cov
 pytest-randomly
-pytest-rerunfailures
 pytest-subtests
 pytest-xdist
 pytest!=7.1.0


### PR DESCRIPTION
Reverts microsoft/onnxscript#911

No rerun was triggered. Need more testing. 