### PR TITLE
Create action to display test results on Github | test

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,12 +60,19 @@ jobs:
       - name: Install nox
         run: python -m pip install nox
       - name: Run tests
-        run: nox -t ${{ matrix.nox-tag }} --forcecolor -- -v --cov=onnxscript --cov-report=xml --cov-append --cov-branch -n=auto
+        run: nox -t ${{ matrix.nox-tag }} --forcecolor -- -v --cov=onnxscript --cov-report=xml --cov-append --cov-branch -n=auto --junit-xml pytest.xml
         env:
           CACHE_ORT_SESSIONS: "${{ matrix.os == 'windows-latest' && '0' || '1' }}"
           CATCH_ORT_SEGFAULT: "${{ matrix.os == 'ubuntu-latest' && '1' || '0' }}"
       - name: Upload coverage to Codecov
+        if: always()
         uses: codecov/codecov-action@v3
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Test Results (${{ matrix.name }})
+          path: pytest.xml
 
   build_docs:
     strategy:
@@ -75,7 +82,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Python ${{ matrix.python-version }}
+      - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
@@ -99,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Python ${{ matrix.python-version }}
+      - name: Setup Python
         uses: actions/setup-python@v4
       - name: Update readme
         run: |
@@ -109,3 +116,23 @@ jobs:
             echo "Update readme by running `python docs/update_readme.py`"
             exit 1
           fi
+
+  publish-test-results:
+    name: "Publish Tests Results to Github"
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      # only needed unless run with comment_mode: off
+      pull-requests: write
+    if: always()
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: "artifacts/**/*.xml"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -71,7 +71,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: Test Results (${{ matrix.name }})
+          name: Test Results (${{ matrix.name }}-${{ matrix.os }})
           path: pytest.xml
 
   build_docs:


### PR DESCRIPTION
Use the `EnricoMi/publish-unit-test-result-action@v2` action to publish test results to GitHub. Example:

![image](https://github.com/microsoft/onnxscript/assets/11205048/a29e89c6-fffd-4379-968a-5b5a510b72eb)