### PR TITLE
TorchScriptTensor to cache torch dtype for performance | feat(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -89,6 +89,7 @@ class TorchScriptTensor(onnxscript_tensor.Tensor):
         self._torch_value: torch.Value = value
         self._concrete_value: Optional[np.ndarray] = None
         self._shape: Optional[Tuple[int | None, ...]] = None
+        self._torch_dtype: Optional[torch.dtype] = None
         self._name: Optional[str] = None
         self._is_complex: bool = False
 
@@ -149,15 +150,19 @@ class TorchScriptTensor(onnxscript_tensor.Tensor):
     @property  # type: ignore[override]
     def dtype(self) -> torch.dtype | None:
         # TODO: Return numpy dtype
+        if self._torch_dtype is not None:
+            return self._torch_dtype
         torch_dtype = _type_utils.JitScalarType.from_value(  # type: ignore[attr-defined]
             self._torch_value, default=_type_utils.JitScalarType.UNDEFINED
         )
         if torch_dtype == _type_utils.JitScalarType.UNDEFINED:
             return None
-        return torch_dtype.dtype()
+        self._torch_dtype = torch_dtype.dtype()
+        return self._torch_dtype
 
     @dtype.setter
     def dtype(self, dtype: torch.dtype):
+        self._torch_dtype = dtype
         self._torch_value.setType(self._torch_value.type().with_dtype(dtype))
 
     @property


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #922

Retrieving torch dtype is slow due to fetching 'JitScalarType' through
pybind.

In a recent change in PyTorch exporter, this method is invoked heavily
to produce diagnostic info for operator arguments, which leads to slow
down.

Before this PR
```
...
└─ 17.767 FxOnnxInterpreter.run  torch/onnx/_internal/fx/fx_onnx_interpreter.py:418
   └─ 17.763 run_node  <@beartype(torch.onnx._internal.fx.fx_onnx_interpreter.FxOnnxInterpreter.run_node) at 0x7f7c73513e50>:1
         [2 frames hidden]  <@beartype(torch.onnx._internal.fx.fx...
            17.761 wrapper  torch/onnx/_internal/diagnostics/infra/decorator.py:70
            ├─ 15.735 format_function_signature_in_markdown  <@beartype(torch.onnx._internal.diagnostics.infra.decorator.format_function_signature_in_markdown) at 0x7f7c8c946040>:1
            │     [2 frames hidden]  <@beartype(torch.onnx._internal.diagn...
            │        15.733 format_function_signature_in_markdown  torch/onnx/_internal/diagnostics/infra/decorator.py:30
            │        └─ 15.658 format_argument  torch/onnx/_internal/fx/diagnostics.py:35
            │           └─ 15.503 _dict  torch/onnx/_internal/fx/diagnostics.py:150
            │              └─ 15.031 format_argument  torch/onnx/_internal/fx/diagnostics.py:35
            │                 ├─ 13.234 _onnxscript_torch_script_tensor  torch/onnx/_internal/fx/diagnostics.py:165
            │                 │  ├─ 11.797 TorchScriptTensor.dtype  onnxscript/function_libs/torch_lib/graph_building.py:150
            │                 │  │  └─ 11.207 from_value  <@beartype(torch.onnx._type_utils.JitScalarType.from_value) at 0x7f7c8d909e50>:1
            │                 │  │        [46 frames hidden]  <@beartype(torch.onnx._type_utils.Jit...
            │                 │  │           7.431 JitScalarType.from_value  torch/onnx/_type_utils.py:148
            │                 │  │           ├─ 4.399 _from_name  <@beartype(torch.onnx._type_utils.JitScalarType._from_name) at 0x7f7c8d909b80>:1
            │                 │  │           │     [46 frames hidden]  <@beartype(torch.onnx._type_utils.Jit...
            │                 │  │           └─ 2.813 [self]  None
            │                 │  └─ 0.779 _stringify_shape  torch/onnx/_internal/fx/diagnostics.py:181
...
```

After this PR:
```
...
└─ 4.689 FxOnnxInterpreter.run  torch/onnx/_internal/fx/fx_onnx_interpreter.py:418
   └─ 4.687 run_node  <@beartype(torch.onnx._internal.fx.fx_onnx_interpreter.FxOnnxInterpreter.run_node) at 0x7f5a630b5c10>:1
         [4 frames hidden]  <@beartype(torch.onnx._internal.fx.fx...
            4.684 wrapper  torch/onnx/_internal/diagnostics/infra/decorator.py:70
            ├─ 3.113 format_function_signature_in_markdown  <@beartype(torch.onnx._internal.diagnostics.infra.decorator.format_function_signature_in_markdown) at 0x7f5a77f14b80>:1
            │     [2 frames hidden]  <@beartype(torch.onnx._internal.diagn...
            │        3.110 format_function_signature_in_markdown  torch/onnx/_internal/diagnostics/infra/decorator.py:30
            │        └─ 3.049 format_argument  torch/onnx/_internal/fx/diagnostics.py:35
            │           └─ 2.894 _dict  torch/onnx/_internal/fx/diagnostics.py:150
            │              └─ 2.409 format_argument  torch/onnx/_internal/fx/diagnostics.py:35
            │                 └─ 1.551 _onnxscript_torch_script_tensor  torch/onnx/_internal/fx/diagnostics.py:165
            │                    └─ 0.628 _stringify_shape  torch/onnx/_internal/fx/diagnostics.py:181
...
```