### PR TITLE
Handle loops in analysis of assigned vars

### DIFF
--- a/onnxscript/analysis.py
+++ b/onnxscript/analysis.py
@@ -80,8 +80,6 @@ def assigned_vars(
         return set()
     if ast_utils.is_print_call(stmt):
         return set()
-    if isinstance(stmt, list):
-        return assigned_in_block(stmt)
     raise ValueError(f"Unsupported statement type {type(stmt)!r}.")
 
 

--- a/onnxscript/analysis_test.py
+++ b/onnxscript/analysis_test.py
@@ -164,7 +164,7 @@ class TestExposedUses(unittest.TestCase):
 
 
 class TestAssignedVarAnalysis(unittest.TestCase):
-    def assertDefs(self, f, expected: set[str]):
+    def assert_assigned_vars(self, f, expected: set[str]):
         source, parse_tree = ast_utils.get_src_and_ast(f)
         result = analysis.assigned_vars(parse_tree.body, formatter(source))
         self.assertEqual(result, expected)
@@ -175,7 +175,7 @@ class TestAssignedVarAnalysis(unittest.TestCase):
             y = x + 2
             return y
 
-        self.assertDefs(f, {"x", "y"})
+        self.assert_assigned_vars(f, {"x", "y"})
 
     def test_if_defs(self):
         def f(x):
@@ -187,7 +187,7 @@ class TestAssignedVarAnalysis(unittest.TestCase):
                 z = 3 * t
             return z
 
-        self.assertDefs(f, {"z", "y", "t"})
+        self.assert_assigned_vars(f, {"z", "y", "t"})
 
     def test_loop_defs(self):
         def f(x):
@@ -198,7 +198,7 @@ class TestAssignedVarAnalysis(unittest.TestCase):
                 sum = sum + square
             return sum
 
-        self.assertDefs(f, {"sum", "x", "square"})
+        self.assert_assigned_vars(f, {"sum", "x", "square"})
 
     def test_if_loop_defs(self):
         def f(x):
@@ -212,7 +212,7 @@ class TestAssignedVarAnalysis(unittest.TestCase):
                 sum = 0
             return sum
 
-        self.assertDefs(f, {"sum", "x", "square"})
+        self.assert_assigned_vars(f, {"sum", "x", "square"})
 
 
 if __name__ == "__main__":

--- a/onnxscript/analysis_test.py
+++ b/onnxscript/analysis_test.py
@@ -163,5 +163,57 @@ class TestExposedUses(unittest.TestCase):
         self.assertUses(f, {"x"})
 
 
+class TestDefAnalysis(unittest.TestCase):
+    def assertDefs(self, f, expected: set[str]):
+        source, parse_tree = ast_utils.get_src_and_ast(f)
+        result = analysis.defs(parse_tree.body, formatter(source))
+        self.assertEqual(result, expected)
+
+    def test_basic_defs(self):
+        def f(x):
+            x = x + 1
+            y = x + 2
+            return y
+
+        self.assertDefs(f, {"x", "y"})
+
+    def test_if_defs(self):
+        def f(x):
+            if x > 1:
+                y = x + 1
+                z = 2 * y
+            else:
+                t = x + 2
+                z = 3 * t
+            return z
+
+        self.assertDefs(f, {"z", "y", "t"})
+
+    def test_loop_defs(self):
+        def f(x):
+            sum = 0
+            while x > 0:
+                x = x - 1
+                square = x * x
+                sum = sum + square
+            return sum
+
+        self.assertDefs(f, {"sum", "x", "square"})
+
+    def test_if_loop_defs(self):
+        def f(x):
+            if x > 0:
+                sum = 0
+                while x > 0:
+                    x = x - 1
+                    square = x * x
+                    sum = sum + square
+            else:
+                sum = 0
+            return sum
+
+        self.assertDefs(f, {"sum", "x", "square"})
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/onnxscript/analysis_test.py
+++ b/onnxscript/analysis_test.py
@@ -163,10 +163,10 @@ class TestExposedUses(unittest.TestCase):
         self.assertUses(f, {"x"})
 
 
-class TestDefAnalysis(unittest.TestCase):
+class TestAssignedVarAnalysis(unittest.TestCase):
     def assertDefs(self, f, expected: set[str]):
         source, parse_tree = ast_utils.get_src_and_ast(f)
-        result = analysis.defs(parse_tree.body, formatter(source))
+        result = analysis.assigned_vars(parse_tree.body, formatter(source))
         self.assertEqual(result, expected)
 
     def test_basic_defs(self):

--- a/onnxscript/converter.py
+++ b/onnxscript/converter.py
@@ -1102,9 +1102,11 @@ class Converter:
 
     def translate_if_stmt(self, stmt: ast.If) -> None:
         if hasattr(stmt, "live_out"):
-            live_defs = list(stmt.live_out.intersection(analysis.defs(stmt, self.message)))
+            live_defs = list(
+                stmt.live_out.intersection(analysis.assigned_vars(stmt, self.message))
+            )
         else:
-            live_defs = list(analysis.defs(stmt, self.message))
+            live_defs = list(analysis.assigned_vars(stmt, self.message))
         test = self.translate_expr(stmt.test, "cond").name
         lineno = self.source_of(stmt).lineno
         thenGraph, sub_fct_then = self.translate_block(
@@ -1183,7 +1185,7 @@ class Converter:
             self.fail(loop_stmt, f"Unexpected loop type {type(loop_stmt)!r}.")
         # analyze loop body
         exposed_uses = analysis.exposed_uses(loop_stmt.body, self.message)
-        vars_def_in_loop = analysis.defs(loop_stmt.body, self.message)
+        vars_def_in_loop = analysis.assigned_vars(loop_stmt.body, self.message)
         loop_state_vars = vars_def_in_loop.intersection(exposed_uses | loop_stmt.live_out)
         scan_outputs = set()  # TODO
         outputs = list(loop_state_vars | scan_outputs)

--- a/onnxscript/converter.py
+++ b/onnxscript/converter.py
@@ -1102,9 +1102,9 @@ class Converter:
 
     def translate_if_stmt(self, stmt: ast.If) -> None:
         if hasattr(stmt, "live_out"):
-            live_defs = list(stmt.live_out.intersection(analysis.defs(stmt)))
+            live_defs = list(stmt.live_out.intersection(analysis.defs(stmt, self.message)))
         else:
-            live_defs = list(analysis.defs(stmt))
+            live_defs = list(analysis.defs(stmt, self.message))
         test = self.translate_expr(stmt.test, "cond").name
         lineno = self.source_of(stmt).lineno
         thenGraph, sub_fct_then = self.translate_block(
@@ -1183,7 +1183,7 @@ class Converter:
             self.fail(loop_stmt, f"Unexpected loop type {type(loop_stmt)!r}.")
         # analyze loop body
         exposed_uses = analysis.exposed_uses(loop_stmt.body, self.message)
-        vars_def_in_loop = analysis.defs(loop_stmt.body)
+        vars_def_in_loop = analysis.defs(loop_stmt.body, self.message)
         loop_state_vars = vars_def_in_loop.intersection(exposed_uses | loop_stmt.live_out)
         scan_outputs = set()  # TODO
         outputs = list(loop_state_vars | scan_outputs)

--- a/onnxscript/converter_test.py
+++ b/onnxscript/converter_test.py
@@ -655,6 +655,18 @@ class TestConverter(testutils.TestBase):
         expected = np.array([13, 17], dtype=np.float32).reshape((2,))
         self.check_run(float_list_as_tensor, [], expected)
 
+    def test_loop_inside_if(self):
+        @script(default_opset=op)
+        def sum(n: INT64) -> INT64:
+            sum = op.Constant(value=0)
+            if n > 0:
+                for i in range(n):
+                    sum = sum + i
+            return sum
+
+        self.check_run(sum, [np.array(5, dtype=np.int64)], np.array(10, dtype=np.int64))
+        self.check_run(sum, [np.array(-5, dtype=np.int64)], np.array(0, dtype=np.int64))
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
The analysis function "assigned_vars" was not handling loops. Fix this.

Should fix issue https://github.com/microsoft/onnxscript/issues/879

See also PR https://github.com/microsoft/onnxscript/pull/909