### PR TITLE
Fix aten::nonzero. Add aten::scalar_tensor overload for sym number

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5827,6 +5827,13 @@ def aten_scalar_tensor(s: float, dtype: int = FLOAT.dtype) -> TTensor:  # type: 
     return op.Cast(s, to=dtype)
 
 
+@torch_op("aten::scalar_tensor")
+def aten_scalar_tensor_sym_number(s: Union[FLOAT, INT32, BOOL], dtype: int = FLOAT.dtype) -> TTensor:  # type: ignore[type-var]
+    """scalar_tensor(Scalar s, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    return op.Cast(s, to=dtype)
+
+
 @torch_op("aten::scatter_add")
 def aten_scatter_add(
     self: TReal,
@@ -6547,11 +6554,6 @@ def aten_tensor_float(self: float, dtype: int) -> TensorType:
 def aten_tensor_int(self: int, dtype: int) -> TensorType:
     tensor = op.Constant(value_int=self)
     return op.Cast(tensor, to=dtype)
-
-
-@torch_op(("aten::tensor.bool", "aten::tensor.float", "aten::tensor.int"))
-def aten_tensor_sym_number(self: Union[FLOAT, INT32, BOOL], dtype: int) -> TensorType:
-    return op.Cast(self, to=dtype)
 
 
 def aten_tensordot(

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5021,7 +5021,7 @@ def aten_nextafter(self: TensorType, other: TensorType) -> TensorType:
 def aten_nonzero(self: TTensor) -> INT64:
     """nonzero(Tensor self) -> Tensor"""
 
-    return op.NonZero(self)
+    return op.Transpose(op.NonZero(self), perm=[1, 0])
 
 
 def aten_nonzero_numpy(self: TensorType) -> TensorType:
@@ -6546,6 +6546,11 @@ def aten_tensor_float(self: float, dtype: int) -> TensorType:
 def aten_tensor_int(self: int, dtype: int) -> TensorType:
     tensor = op.Constant(value_int=self)
     return op.Cast(tensor, to=dtype)
+
+
+@torch_op(("aten::tensor.bool", "aten::tensor.float", "aten::tensor.int"))
+def aten_tensor_sym_number(self: Union[FLOAT, INT32, BOOL], dtype: int) -> TensorType:
+    return op.Cast(self, to=dtype)
 
 
 def aten_tensordot(

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5020,7 +5020,8 @@ def aten_nextafter(self: TensorType, other: TensorType) -> TensorType:
 @torch_op("aten::nonzero")
 def aten_nonzero(self: TTensor) -> INT64:
     """nonzero(Tensor self) -> Tensor"""
-
+    # NOTE: In torch the return shape is [n, d], while in onnx [d, n],
+    # where `d` is rank of input tensor, `n` is number of nonzero elements.
     return op.Transpose(op.NonZero(self), perm=[1, 0])
 
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5828,7 +5828,9 @@ def aten_scalar_tensor(s: float, dtype: int = FLOAT.dtype) -> TTensor:  # type: 
 
 
 @torch_op("aten::scalar_tensor")
-def aten_scalar_tensor_sym_number(s: Union[FLOAT, INT32, BOOL], dtype: int = FLOAT.dtype) -> TTensor:  # type: ignore[type-var]
+def aten_scalar_tensor_sym_number(
+    s: Union[FLOAT, INT32, BOOL], dtype: int = FLOAT.dtype
+) -> TTensor:
     """scalar_tensor(Scalar s, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
 
     return op.Cast(s, to=dtype)

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -320,6 +320,14 @@ def _nll_loss_input_wrangler(
     return args, kwargs
 
 
+def _nonzero_input_wrangler(
+    args: list[Any], kwargs: dict[str, Any]
+) -> tuple[list[Any], dict[str, Any]]:
+    if "as_tuple" in kwargs:
+        del kwargs["as_tuple"]
+    return args, kwargs
+
+
 def _randn_input_wrangler(
     args: list[Any], kwargs: dict[str, Any]
 ) -> tuple[list[Any], dict[str, Any]]:
@@ -1007,9 +1015,15 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo(
         "nonzero",
         core_ops.aten_nonzero,
-    ).xfail(
-        matcher=lambda sample: sample.kwargs.get("as_tuple") is not None,
+        input_wrangler=_nonzero_input_wrangler,
+    )
+    .xfail(
+        matcher=lambda sample: sample.kwargs.get("as_tuple"),
         reason="as_tuple=True is not supported",
+    )
+    .xfail(
+        matcher=lambda sample: len(sample.input.shape) == 0,
+        reason="Output 'shape' do not match: torch.Size([0, 1]) != torch.Size([0, 0]).",
     ),
     TorchLibOpInfo(
         "normal",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -385,6 +385,14 @@ def _roll_input_wrangler(
     return args, kwargs
 
 
+def _scalar_tensor_input_wrangler(
+    args: list[Any], kwargs: dict[str, Any]
+) -> tuple[list[Any], dict[str, Any]]:
+    if "requires_grad" in kwargs:
+        del kwargs["requires_grad"]
+    return args, kwargs
+
+
 def _scatter_reduce_input_wrangler(
     args: list[Any], kwargs: dict[str, Any]
 ) -> tuple[list[Any], dict[str, Any]]:
@@ -1102,7 +1110,11 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ),
     TorchLibOpInfo("rsqrt", core_ops.aten_rsqrt),
     TorchLibOpInfo("rsub", core_ops.aten_rsub),
-    # TorchLibOpInfo("scalar_tensor", core_ops.aten_scalar_tensor),  # no test case in OPS_DB
+    TorchLibOpInfo(
+        "scalar_tensor",
+        core_ops.aten_scalar_tensor,
+        input_wrangler=_scalar_tensor_input_wrangler,
+    ),
     TorchLibOpInfo(
         "scatter_add",
         core_ops.aten_scatter_add,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1023,7 +1023,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     )
     .xfail(
         matcher=lambda sample: len(sample.input.shape) == 0,
-        reason="Output 'shape' do not match: torch.Size([0, 1]) != torch.Size([0, 0]).",
+        reason="fixme: output 'shape' do not match: torch.Size([0, 1]) != torch.Size([0, 0]).",
     ),
     TorchLibOpInfo(
         "normal",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #931

Fix aten::nonzero impl and test.
Fix aten::scalar_tensor test.
Add aten::scalar_tensor overload for sym number.