### PR TITLE
Disable release triggers on Github | chore(release)

### DIFF
--- a/.azure-pipelines/release-dev.yml
+++ b/.azure-pipelines/release-dev.yml
@@ -1,5 +1,6 @@
 # Build the dev version of the package and publish to artifacts
 
+# To configure triggers, see https://github.com/microsoft/onnx-converters-private/wiki/ONNX-Script-release
 trigger: none
 
 pool:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,14 +1,6 @@
 name: Release
 
 on:
-  schedule:
-    # Run daily at 00:00
-    - cron: '00 00 * * *'
-  push:
-    branches: [main, rel-*]
-  pull_request:
-    branches: [main, rel-*]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
We will use Azure Dev Ops for compliant releases