### PR TITLE
Create error reproduction | test(torchlib)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,7 +62,8 @@ jobs:
       - name: Run tests
         run: nox -t ${{ matrix.nox-tag }} --forcecolor -- -v --cov=onnxscript --cov-report=xml --cov-append --cov-branch -n=auto --junit-xml pytest.xml
         env:
-          CATCH_ORT_SEGFAULT: "${{ matrix.os == 'ubuntu-latest' && '1' || '0' }}"
+          CATCH_ORT_SEGFAULT: "${{ matrix.os != 'windows-latest' && '1' || '0' }}"
+          CREATE_REPRODUCTION_REPORT: "${{ matrix.os != 'windows-latest' && '1' || '0' }}"
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v3
@@ -72,6 +73,12 @@ jobs:
         with:
           name: Test Results (${{ matrix.name }}-${{ matrix.os }})
           path: pytest.xml
+      - name: Upload torchlib error reports
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Error reports (${{ matrix.name }}-${{ matrix.os }})
+          path: error_reports
 
   build_docs:
     strategy:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,8 +62,8 @@ jobs:
       - name: Run tests
         run: nox -t ${{ matrix.nox-tag }} --forcecolor -- -v --cov=onnxscript --cov-report=xml --cov-append --cov-branch -n=auto --junit-xml pytest.xml
         env:
-          CATCH_ORT_SEGFAULT: "${{ matrix.os != 'windows-latest' && '1' || '0' }}"
-          CREATE_REPRODUCTION_REPORT: "${{ matrix.os != 'windows-latest' && '1' || '0' }}"
+          CATCH_ORT_SEGFAULT: "${{ matrix.os == 'ubuntu-latest' && '1' || '0' }}"
+          CREATE_REPRODUCTION_REPORT: "${{ matrix.os == 'ubuntu-latest' && '1' || '0' }}"
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v3

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -735,9 +735,20 @@ def aten_atanh(self: TFloat) -> TFloat:
     return op.Atanh(self)
 
 
-@torch_op("aten::atleast_1d", private=True)
-def _aten_atleast_1d_onnx(self: Sequence[TTensor]) -> TTensor:
+@torch_op("aten::atleast_1d")
+def aten_atleast_1d(self: TTensor) -> TTensor:
     """atleast_1d(Tensor self) -> Tensor"""
+
+    shape = op.Shape(self)
+    rank = op.Size(shape)
+    if rank == 0:
+        self = op.Reshape(self, op.Constant(value_ints=[1]))
+    return self
+
+
+@torch_op("aten::atleast_1d.Sequence")
+def aten_atleast_1d_sequence(self: Sequence[TTensor]) -> TTensor:
+    """atleast_1d.Sequence(Tensor[] tensors) -> Tensor[]"""
 
     @graph()
     def reshape_to_1d(tensor):
@@ -750,25 +761,20 @@ def _aten_atleast_1d_onnx(self: Sequence[TTensor]) -> TTensor:
     return op.SequenceMap(self, body=reshape_to_1d)
 
 
-@torch_op("aten::atleast_1d")
-def aten_atleast_1d(self: Sequence[TTensor]) -> TTensor:
-    return _aten_atleast_1d_onnx(self)
-
-
-@torch_op("aten::atleast_1d")
-def aten_atleast_1d_single_tensor(self: TTensor) -> TTensor:
-    """atleast_1d(Tensor self) -> Tensor"""
+@torch_op("aten::atleast_2d")
+def aten_atleast_2d(self: TTensor) -> TTensor:
+    """atleast_2d(Tensor self) -> Tensor"""
 
     shape = op.Shape(self)
     rank = op.Size(shape)
-    if rank == 0:
-        self = op.Reshape(self, op.Constant(value_ints=[1]))
+    if rank <= 1:
+        self = op.Reshape(self, op.Constant(value_ints=[1, -1]))
     return self
 
 
-@torch_op("aten::atleast_2d", private=True)
-def _aten_atleast_2d_onnx(self: Sequence[TTensor]) -> TTensor:
-    """atleast_2d(Tensor self) -> Tensor"""
+@torch_op("aten::atleast_2d.Sequence")
+def aten_atleast_2d_sequence(self: Sequence[TTensor]) -> TTensor:
+    """atleast_2d.Sequence(Tensor[] tensors) -> Tensor[]"""
 
     @graph()
     def reshape_to_2d(tensor):
@@ -781,25 +787,22 @@ def _aten_atleast_2d_onnx(self: Sequence[TTensor]) -> TTensor:
     return op.SequenceMap(self, body=reshape_to_2d)
 
 
-@torch_op("aten::atleast_2d")
-def aten_atleast_2d(self: Sequence[TTensor]) -> TTensor:
-    return _aten_atleast_2d_onnx(self)
-
-
-@torch_op("aten::atleast_2d")
-def aten_atleast_2d_single_tensor(self: TTensor) -> TTensor:
-    """atleast_2d(Tensor self) -> Tensor"""
+@torch_op("aten::atleast_3d")
+def aten_atleast_3d(self: TTensor) -> TTensor:
+    """atleast_3d(Tensor self) -> Tensor"""
 
     shape = op.Shape(self)
     rank = op.Size(shape)
     if rank <= 1:
-        self = op.Reshape(self, op.Constant(value_ints=[1, -1]))
+        self = op.Reshape(self, op.Constant(value_ints=[1, -1, 1]))
+    elif rank == 2:
+        self = op.Unsqueeze(self, op.Constant(value_ints=[-1]))
     return self
 
 
-@torch_op("aten::atleast_3d")
-def aten_atleast_3d(self: Sequence[TTensor]) -> TTensor:
-    """atleast_3d(Tensor self) -> Tensor"""
+@torch_op("aten::atleast_3d.Sequence")
+def aten_atleast_3d_sequence(self: Sequence[TTensor]) -> TTensor:
+    """atleast_3d.Sequence(Tensor[] tensors) -> Tensor[]"""
 
     @graph()
     def reshape_to_3d(tensor):
@@ -812,19 +815,6 @@ def aten_atleast_3d(self: Sequence[TTensor]) -> TTensor:
         return tensor
 
     return op.SequenceMap(self, body=reshape_to_3d)
-
-
-@torch_op("aten::atleast_3d")
-def aten_atleast_3d_single_tensor(self: TTensor) -> TTensor:
-    """atleast_3d(Tensor self) -> Tensor"""
-
-    shape = op.Shape(self)
-    rank = op.Size(shape)
-    if rank <= 1:
-        self = op.Reshape(self, op.Constant(value_ints=[1, -1, 1]))
-    elif rank == 2:
-        self = op.Unsqueeze(self, op.Constant(value_ints=[-1]))
-    return self
 
 
 @torch_op("aten::baddbmm")

--- a/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
+++ b/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
@@ -10,10 +10,11 @@ import numpy as np
 import onnx
 
 _REPRODUCTION_TEMPLATE = '''\
-import onnx
-import onnxruntime as ort
+import google.protobuf.text_format
 import numpy as np
 from numpy import array, float16, float32, float64, int32, int64
+import onnx
+import onnxruntime as ort
 
 onnx_model_text = """
 {onnx_model_text}
@@ -25,7 +26,8 @@ session_options = ort.SessionOptions()
 session_options.graph_optimization_level = (
     ort.GraphOptimizationLevel.ORT_DISABLE_ALL
 )
-onnx_model = onnx.parser.parse_model(onnx_model_text)
+onnx_model = onnx.ModelProto()
+google.protobuf.text_format.Parse(onnx_model_text, onnx_model)
 
 session = ort.InferenceSession(
     onnx_model.SerializeToString(), session_options, providers=("CPUExecutionProvider",)
@@ -64,7 +66,7 @@ def create_reproduction_report(
     ort_inputs: Mapping[str, Any],
     error: Exception,
 ) -> None:
-    onnx_model_text = onnx.printer.to_text(onnx_model)
+    onnx_model_text = str(onnx_model)
     with np.printoptions(threshold=sys.maxsize):
         ort_inputs = dict(ort_inputs.items())
         input_text = str(ort_inputs)

--- a/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
+++ b/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
@@ -96,16 +96,17 @@ onnxruntime=={ort.__version__}
 numpy=={np.__version__}
 torch=={torch.__version__}
 """
-
+    short_test_name = test_name.split(".")[-1]
     reproduction_code = _REPRODUCTION_TEMPLATE.format(
         onnx_model_text=onnx_model_text,
         ort_inputs=input_text,
+        short_test_name=short_test_name,
     )
 
     markdown = _ISSUE_MARKDOWN_TEMPLATE.format(
         error_text=error_text,
         test_name=test_name,
-        short_test_name=test_name.split(".")[-1],
+        short_test_name=short_test_name,
         reproduction_code=reproduction_code,
         error_stack=error_stack,
         sys_info=sys_info,

--- a/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
+++ b/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
@@ -1,4 +1,80 @@
+from __future__ import annotations
+
+import sys
+import time
+import traceback
+from typing import Any, Mapping
+
+import numpy as np
+import onnx
+
+_REPRODUCTION_TEMPLATE = '''
+import onnx
+import onnxruntime as ort
+import numpy as np
+
+onnx_model_text = """
+{onnx_model_text}
+"""
+
+ort_inputs = {ort_inputs}
+
+session_options = ort.SessionOptions()
+session_options.graph_optimization_level = (
+    ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+)
+onnx_model = onnx.parser.parse_model(onnx_model_text)
+
+session = ort.InferenceSession(
+    onnx_model, session_options, providers=("CPUExecutionProvider",)
+)
+ort_outputs = session.run(None, ort_inputs)
+'''
+
+_ISSUE_MARKDOWN_TEMPLATE = """
+### Error Reproduction
+
+ORT raises `{error_text}` when executing test `{test_name}` in ONNX Script `TorchLib`. To reproduce:
 
 
-def create_reproduction_report():
-    pass
+```python
+{reproduction_code}
+```
+
+### Full error stack
+
+```
+{error_stack}
+```
+"""
+
+
+def create_reproduction_report(
+    test_name: str,
+    onnx_model: onnx.ModelProto,
+    ort_inputs: Mapping[str, Any],
+    error: Exception,
+) -> None:
+    onnx_model_text = onnx.printer.to_text(onnx_model)
+    with np.printoptions(threshold=sys.maxsize):
+        ort_inputs = dict((k, v) for k, v in ort_inputs.items())
+        input_text = str(ort_inputs)
+    error_text = str(error)
+    error_stack = error_text + "\n" + "".join(traceback.format_tb(error.__traceback__))
+
+    reproduction_code = _REPRODUCTION_TEMPLATE.format(
+        onnx_model_text=onnx_model_text,
+        ort_inputs=input_text,
+    )
+
+    markdown = _ISSUE_MARKDOWN_TEMPLATE.format(
+        error_text=error_text,
+        test_name=test_name,
+        reproduction_code=reproduction_code,
+        error_stack=error_stack,
+    )
+
+    # Turn test name into a valid file name
+    markdown_file_name = f'test_name.split(".")[-1].replace("/", "-").replace(":", "-")-{int(time.time())}.md'
+    with open(markdown_file_name, "w") as f:
+        f.write(markdown)

--- a/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
+++ b/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
@@ -91,9 +91,10 @@ def create_reproduction_report(
     sys_info = f"""\
 OS: {platform.platform()}
 Python version: {sys.version}
-torch=={torch.__version__}
 onnx=={onnx.__version__}
 onnxruntime=={ort.__version__}
+numpy=={np.__version__}
+torch=={torch.__version__}
 """
 
     reproduction_code = _REPRODUCTION_TEMPLATE.format(

--- a/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
+++ b/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
@@ -66,10 +66,10 @@ def create_reproduction_report(
 ) -> None:
     onnx_model_text = onnx.printer.to_text(onnx_model)
     with np.printoptions(threshold=sys.maxsize):
-        ort_inputs = dict((k, v) for k, v in ort_inputs.items())
+        ort_inputs = dict(ort_inputs.items())
         input_text = str(ort_inputs)
     error_text = str(error)
-    error_stack = traceback.format_exc()
+    error_stack = error_text + "\n" + "".join(traceback.format_tb(error.__traceback__))
 
     reproduction_code = _REPRODUCTION_TEMPLATE.format(
         onnx_model_text=onnx_model_text,
@@ -85,9 +85,7 @@ def create_reproduction_report(
     )
 
     # Turn test name into a valid file name
-    markdown_file_name = (
-        f'{test_name.split(".")[-1].replace("/", "-").replace(":", "-")}-{str(time.time()).replace(".", "_")}.md'
-    )
+    markdown_file_name = f'{test_name.split(".")[-1].replace("/", "-").replace(":", "-")}-{str(time.time()).replace(".", "_")}.md'
     reports_dir = pathlib.Path("error_reports")
     reports_dir.mkdir(parents=True, exist_ok=True)
     with open(reports_dir / markdown_file_name, "w") as f:

--- a/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
+++ b/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pathlib
 import sys
 import time
 import traceback
@@ -8,10 +9,11 @@ from typing import Any, Mapping
 import numpy as np
 import onnx
 
-_REPRODUCTION_TEMPLATE = '''
+_REPRODUCTION_TEMPLATE = '''\
 import onnx
 import onnxruntime as ort
 import numpy as np
+from numpy import array, float16, float32, float64, int32, int64
 
 onnx_model_text = """
 {onnx_model_text}
@@ -26,7 +28,7 @@ session_options.graph_optimization_level = (
 onnx_model = onnx.parser.parse_model(onnx_model_text)
 
 session = ort.InferenceSession(
-    onnx_model, session_options, providers=("CPUExecutionProvider",)
+    onnx_model.SerializeToString(), session_options, providers=("CPUExecutionProvider",)
 )
 ort_outputs = session.run(None, ort_inputs)
 '''
@@ -75,6 +77,10 @@ def create_reproduction_report(
     )
 
     # Turn test name into a valid file name
-    markdown_file_name = f'test_name.split(".")[-1].replace("/", "-").replace(":", "-")-{int(time.time())}.md'
-    with open(markdown_file_name, "w") as f:
+    markdown_file_name = (
+        f'{test_name.split(".")[-1].replace("/", "-").replace(":", "-")}-{int(time.time())}.md'
+    )
+    reports_dir = pathlib.Path("error_reports")
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    with open(reports_dir / markdown_file_name, "w") as f:
         f.write(markdown)

--- a/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
+++ b/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
@@ -82,6 +82,8 @@ def create_reproduction_report(
     ort_inputs: Mapping[str, Any],
     error: Exception,
 ) -> None:
+    # NOTE: We choose to embed the ONNX model as a string in the report instead of
+    # saving it to a file because it is easier to share the report with others.
     onnx_model_text = str(onnx_model)
     with np.printoptions(threshold=sys.maxsize):
         ort_inputs = dict(ort_inputs.items())
@@ -94,8 +96,7 @@ Python version: {sys.version}
 onnx=={onnx.__version__}
 onnxruntime=={ort.__version__}
 numpy=={np.__version__}
-torch=={torch.__version__}
-"""
+torch=={torch.__version__}"""
     short_test_name = test_name.split(".")[-1]
     reproduction_code = _REPRODUCTION_TEMPLATE.format(
         onnx_model_text=onnx_model_text,
@@ -113,7 +114,7 @@ torch=={torch.__version__}
     )
 
     # Turn test name into a valid file name
-    markdown_file_name = f'{test_name.split(".")[-1].replace("/", "-").replace(":", "-")}-{str(time.time()).replace(".", "_")}.md'
+    markdown_file_name = f'{short_test_name.replace("/", "-").replace(":", "-")}-{str(time.time()).replace(".", "_")}.md'
     reports_dir = pathlib.Path("error_reports")
     reports_dir.mkdir(parents=True, exist_ok=True)
     with open(reports_dir / markdown_file_name, "w", encoding="utf-8") as f:

--- a/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
+++ b/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
@@ -34,6 +34,9 @@ session_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABL
 onnx_model = onnx.ModelProto()
 google.protobuf.text_format.Parse(onnx_model_text, onnx_model)
 
+# Uncomment this line to save the model to a file for examination
+# onnx.save_model(onnx_model, "{short_test_name}.onnx")
+
 onnx.checker.check_model(onnx_model)
 session = ort.InferenceSession(onnx_model.SerializeToString(), session_options, providers=("CPUExecutionProvider",))
 

--- a/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
+++ b/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
@@ -48,7 +48,7 @@ for _ in range(N):
 _ISSUE_MARKDOWN_TEMPLATE = """
 ### Summary
 
-ORT raises `{error_text}` when executing test `{test_name}` in ONNX Script `TorchLib`.
+ONNX Runtime raises `{error_text}` when executing test `{test_name}` in ONNX Script `TorchLib`.
 
 To recreate this report, use
 

--- a/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
+++ b/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
@@ -1,0 +1,4 @@
+
+
+def create_reproduction_report():
+    pass

--- a/onnxscript/tests/function_libs/torch_lib/ops_test.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test.py
@@ -12,6 +12,13 @@ Usage:
 
     pytest onnxscript/tests/function_libs/torch_lib/ops_test.py -k nn_functional_scaled_dot_product_attention
 
+## Environment variables
+
+1. Set environment variable `CATCH_ORT_SEGFAULT=1` to catch segmentation faults
+in onnxruntime by running the inference sessions in a separate process.
+
+2. Set `CREATE_REPRODUCTION_REPORT=1` to create markdown files for reproduction of
+errors.
 """
 from __future__ import annotations
 

--- a/onnxscript/tests/function_libs/torch_lib/ops_test.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test.py
@@ -209,7 +209,8 @@ def run_test_output_match(
                     # TODO(justinchuby): Find a more general solution
                     reference_torch_outputs = [reference_torch_outputs]
 
-                function_output = function_executor(reference_torch_outputs)(
+                test_name = test_suite.id()
+                function_output = function_executor(test_name, reference_torch_outputs)(
                     onnx_function, input_onnx, kwargs_onnx
                 )
                 # Finally we re-flatten everything

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_common.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_common.py
@@ -546,7 +546,7 @@ def graph_executor(
                 error_reproduction.create_reproduction_report(
                     test_name, onnx_model, ort_inputs, e
                 )
-            raise AssertionError(
+            raise RuntimeError(
                 "ONNX Runtime failed to evaluate:\n"
                 + _format_model_and_input_information(onnx_model, ort_inputs)
             ) from e
@@ -556,10 +556,16 @@ def graph_executor(
                 error_reproduction.create_reproduction_report(
                     test_name, onnx_model, ort_inputs, e
                 )
-            raise AssertionError(
+            raise OrtAbortedError(
                 "ONNX Runtime aborted:\n"
                 + _format_model_and_input_information(onnx_model, ort_inputs)
             ) from e
+        except Exception as e:
+            if os.environ.get("CREATE_REPRODUCTION_REPORT") == "1":
+                error_reproduction.create_reproduction_report(
+                    test_name, onnx_model, ort_inputs, e
+                )
+            raise
 
     return _capture_graph_and_evaluate_torch_script_evaluator
 

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -519,29 +519,38 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo("atan", core_ops.aten_atan),
     TorchLibOpInfo("atan2", core_ops.aten_atan2),
     TorchLibOpInfo("atanh", core_ops.aten_atanh),
-    TorchLibOpInfo("atleast_1d", core_ops.aten_atleast_1d),
-    TorchLibOpInfo(
-        "atleast_1d_single_tensor",
-        core_ops.aten_atleast_1d_single_tensor,
-    ).skip(
+    TorchLibOpInfo("atleast_1d", core_ops.aten_atleast_1d).skip(
         matcher=lambda sample: isinstance(sample.input, (list, tuple)),
-        reason="atleast_1d_single_tensor overload takes single tensor as input",
+        reason="takes single tensor as input",
     ),
-    TorchLibOpInfo("atleast_2d", core_ops.aten_atleast_2d),
     TorchLibOpInfo(
-        "atleast_2d_single_tensor",
-        core_ops.aten_atleast_2d_single_tensor,
+        "atleast_1d_Sequence",
+        core_ops.aten_atleast_1d_sequence,
     ).skip(
-        matcher=lambda sample: isinstance(sample.input, (list, tuple)),
-        reason="atleast_2d_single_tensor overload takes single tensor as input",
+        matcher=lambda sample: not isinstance(sample.input, (list, tuple)),
+        reason="takes tensor sequences only",
     ),
-    TorchLibOpInfo("atleast_3d", core_ops.aten_atleast_3d),
+    TorchLibOpInfo("atleast_2d", core_ops.aten_atleast_2d).skip(
+        matcher=lambda sample: isinstance(sample.input, (list, tuple)),
+        reason="takes single tensor as input",
+    ),
     TorchLibOpInfo(
-        "atleast_3d_single_tensor",
-        core_ops.aten_atleast_3d_single_tensor,
+        "atleast_2d_Sequence",
+        core_ops.aten_atleast_2d_sequence,
+    ).skip(
+        matcher=lambda sample: not isinstance(sample.input, (list, tuple)),
+        reason="takes tensor sequences only",
+    ),
+    TorchLibOpInfo("atleast_3d", core_ops.aten_atleast_3d).skip(
+        matcher=lambda sample: isinstance(sample.input, (list, tuple)),
+        reason="takes single tensor as input",
+    ),
+    TorchLibOpInfo(
+        "atleast_3d_Sequence",
+        core_ops.aten_atleast_3d_sequence,
     ).skip(
         matcher=lambda sample: isinstance(sample.input, (list, tuple)),
-        reason="atleast_3d_single_tensor overload takes single tensor as input",
+        reason="takes tensor sequences only",
     ),
     TorchLibOpInfo("baddbmm", core_ops.aten_baddbmm),
     TorchLibOpInfo("bernoulli", core_ops.aten_bernoulli, nondeterministic=True),
@@ -1828,9 +1837,9 @@ ops_test_common.duplicate_opinfo(OPS_DB, "any", ("any_dim",))
 ops_test_common.duplicate_opinfo(OPS_DB, "arange", ("arange_start", "arange_start_step"))
 ops_test_common.duplicate_opinfo(OPS_DB, "argmax", ("argmax_dim",))
 ops_test_common.duplicate_opinfo(OPS_DB, "argmin", ("argmin_dim",))
-ops_test_common.duplicate_opinfo(OPS_DB, "atleast_1d", ("atleast_1d_single_tensor",))
-ops_test_common.duplicate_opinfo(OPS_DB, "atleast_2d", ("atleast_2d_single_tensor",))
-ops_test_common.duplicate_opinfo(OPS_DB, "atleast_3d", ("atleast_3d_single_tensor",))
+ops_test_common.duplicate_opinfo(OPS_DB, "atleast_1d", ("atleast_1d_Sequence",))
+ops_test_common.duplicate_opinfo(OPS_DB, "atleast_2d", ("atleast_2d_Sequence",))
+ops_test_common.duplicate_opinfo(OPS_DB, "atleast_3d", ("atleast_3d_Sequence",))
 ops_test_common.duplicate_opinfo(OPS_DB, "cat", ("concat", "concatenate"))
 ops_test_common.duplicate_opinfo(OPS_DB, "clone", ("lift_fresh_copy",))
 ops_test_common.duplicate_opinfo(OPS_DB, "full_like", ("full_like_dtype",))

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -526,10 +526,12 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo(
         "atleast_1d_Sequence",
         core_ops.aten_atleast_1d_sequence,
-    ).skip(
+    )
+    .skip(
         matcher=lambda sample: not isinstance(sample.input, (list, tuple)),
         reason="takes tensor sequences only",
-    ).xfail(
+    )
+    .xfail(
         reason=(
             "fixme: [ONNXRuntimeError] : 1 : FAIL : This is an invalid model. Error: Duplicate definition of name (_0x9370ed0_rank)."
             "https://github.com/microsoft/onnxscript/issues/960"
@@ -542,10 +544,12 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo(
         "atleast_2d_Sequence",
         core_ops.aten_atleast_2d_sequence,
-    ).skip(
+    )
+    .skip(
         matcher=lambda sample: not isinstance(sample.input, (list, tuple)),
         reason="takes tensor sequences only",
-    ).xfail(
+    )
+    .xfail(
         reason=(
             "fixme: [ONNXRuntimeError] : 1 : FAIL : This is an invalid model. Error: Duplicate definition of name (_0x9370ed0_rank)."
             "https://github.com/microsoft/onnxscript/issues/960"

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -548,9 +548,16 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo(
         "atleast_3d_Sequence",
         core_ops.aten_atleast_3d_sequence,
-    ).skip(
-        matcher=lambda sample: isinstance(sample.input, (list, tuple)),
+    )
+    .skip(
+        matcher=lambda sample: not isinstance(sample.input, (list, tuple)),
         reason="takes tensor sequences only",
+    )
+    .xfail(
+        reason=(
+            "fixme: [ONNXRuntimeError] : 1 : FAIL : This is an invalid model. Error: Duplicate definition of name (_0x9370ed0_rank)."
+            "https://github.com/microsoft/onnxscript/issues/960"
+        )
     ),
     TorchLibOpInfo("baddbmm", core_ops.aten_baddbmm),
     TorchLibOpInfo("bernoulli", core_ops.aten_bernoulli, nondeterministic=True),
@@ -1279,7 +1286,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "vstack",
         core_ops.aten_vstack,
     ).xfail(
-        reason="fixme: A bug of constant-propagation optimization within the subgraph, we can avoid it by turning off graph-optimizations in session options",
+        reason="fixme: [ONNXRuntimeError] : 1 : FAIL : This is an invalid model. Error: Duplicate definition of name (_0x62afb00_rank). https://github.com/microsoft/onnxscript/issues/960",
     ),
     TorchLibOpInfo("where", core_ops.aten_where, input_wrangler=_where_input_wrangler).xfail(
         dtypes=(torch.bool,),
@@ -1421,7 +1428,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         core_ops.aten_hstack,
         trace_only=True,
     ).xfail(
-        reason="fixme: A bug of constant-propagation optimization within the subgraph, we can avoid it by turning off graph-optimizations in session options",
+        reason="fixme: RUNTIME_EXCEPTION : Exception during initialization: Invalid tensor data type 0. https://github.com/microsoft/onnxscript/issues/960",
     ),
     TorchLibOpInfo(
         "nn.functional.grid_sample",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -529,6 +529,11 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ).skip(
         matcher=lambda sample: not isinstance(sample.input, (list, tuple)),
         reason="takes tensor sequences only",
+    ).xfail(
+        reason=(
+            "fixme: [ONNXRuntimeError] : 1 : FAIL : This is an invalid model. Error: Duplicate definition of name (_0x9370ed0_rank)."
+            "https://github.com/microsoft/onnxscript/issues/960"
+        )
     ),
     TorchLibOpInfo("atleast_2d", core_ops.aten_atleast_2d).skip(
         matcher=lambda sample: isinstance(sample.input, (list, tuple)),
@@ -540,6 +545,11 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ).skip(
         matcher=lambda sample: not isinstance(sample.input, (list, tuple)),
         reason="takes tensor sequences only",
+    ).xfail(
+        reason=(
+            "fixme: [ONNXRuntimeError] : 1 : FAIL : This is an invalid model. Error: Duplicate definition of name (_0x9370ed0_rank)."
+            "https://github.com/microsoft/onnxscript/issues/960"
+        )
     ),
     TorchLibOpInfo("atleast_3d", core_ops.aten_atleast_3d).skip(
         matcher=lambda sample: isinstance(sample.input, (list, tuple)),
@@ -1426,7 +1436,6 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo(
         "hstack",
         core_ops.aten_hstack,
-        trace_only=True,
     ).xfail(
         reason="fixme: RUNTIME_EXCEPTION : Exception during initialization: Invalid tensor data type 0. https://github.com/microsoft/onnxscript/issues/960",
     ),


### PR DESCRIPTION
A tool to create reproduction instructions automatically from tests. To use, set `CREATE_REPRODUCTION_REPORT=1`. E.g.

```
CREATE_REPRODUCTION_REPORT=1 python -m pytest onnxscript/tests/function_libs/torch_lib/ops_test.py -k test_output_match_opinfo__concat_cpu_float32

```

- It will create md files with repro script under the `error_reports` folder. 
- Fixed `atleast_*` function implementations.
- Error reports will be uploaded to artifacts in CI.
- Updated test schema matching logic to consider `tensor(*)` compatible with `seq(tensor(*))`. New tests errors discovered by unskipped tests tracked in: https://github.com/microsoft/onnxscript/issues/960.

Close #564