### PR TITLE
Implement `aten::div.Tensor_mode` | feat(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -2217,17 +2217,13 @@ def aten_div_mode(self: TFloat, other: TFloat, rounding_mode: str) -> TFloat:
     # TODO(justinchuby): trace_only=False when we use opset19 which supports string comparison
     assert rounding_mode in {"trunc", "floor"}
 
-    # Cast inputs to float to preserve numerical precision
-    self_float = op.Cast(self, to=FLOAT.dtype)
-    other_float = op.Cast(other, to=FLOAT.dtype)
     if rounding_mode == "trunc":
         # Rounds the results of the division towards zero.
         # Equivalent to C-style integer division
-        result = aten_trunc(op.Div(self_float, other_float))
+        result = aten_trunc(op.Div(self, other))
     else:  # rounding_mode == "floor"
-        result = op.Floor(op.Div(self_float, other_float))
+        result = op.Floor(op.Div(self, other))
 
-    result = op.CastLike(result, self)
     return result
 
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -2217,13 +2217,17 @@ def aten_div_mode(self: TFloat, other: TFloat, rounding_mode: str) -> TFloat:
     # TODO(justinchuby): trace_only=False when we use opset19 which supports string comparison
     assert rounding_mode in {"trunc", "floor"}
 
+    # Cast inputs to float to preserve numerical precision
+    self_float = op.Cast(self, to=FLOAT.dtype)
+    other_float = op.Cast(other, to=FLOAT.dtype)
     if rounding_mode == "trunc":
         # Rounds the results of the division towards zero.
         # Equivalent to C-style integer division
-        result = aten_trunc(op.Div(self, other))
+        result = aten_trunc(op.Div(self_float, other_float))
     else:  # rounding_mode == "floor"
-        result = op.Floor(op.Div(self, other))
+        result = op.Floor(op.Div(self_float, other_float))
 
+    result = op.CastLike(result, self)
     return result
 
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -2190,12 +2190,18 @@ def aten_dist(self: TensorType, other: TensorType, p: float = 2.0) -> TensorType
     raise NotImplementedError()
 
 
-@torch_op(("aten::div", "aten::div.Tensor"))
+@torch_op(("aten::div", "aten::div.Tensor", "aten::div.Scalar"))
 def aten_div(self: TFloat, other: TFloat) -> TFloat:
     """div.Tensor(Tensor self, Tensor other) -> Tensor"""
 
     # Int inputs will be promoted to float by PyTorch
     return op.Div(self, other)
+
+@torch_op(("aten::div.Tensor_mode", "aten::div.Scalar_mode"), rounding_mode: str)
+def aten_div(self: TFloat, other: TFloat) -> TFloat:
+    """div.Tensor_mode(Tensor self, Tensor other, *, str? rounding_mode) -> Tensor"""
+
+    pass
 
 
 def aten_divide(self: TensorType, other: TensorType) -> TensorType:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -2773,10 +2773,11 @@ def aten_floor(self: TFloatOrBFloat16) -> TFloatOrBFloat16:
     return op.Floor(self)
 
 
-def aten_floor_divide(self: TensorType, other: TensorType) -> TensorType:
+@torch_op("aten::floor_divide")
+def aten_floor_divide(self: TFloat, other: TFloat) -> TFloat:
     """floor_divide(Tensor self, Tensor other) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Floor(op.Div(self, other))
 
 
 def aten_fmax(self: TensorType, other: TensorType) -> TensorType:

--- a/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
+++ b/onnxscript/tests/function_libs/torch_lib/error_reproduction.py
@@ -6,6 +6,7 @@ import sys
 import time
 import traceback
 from typing import Any, Mapping
+import difflib
 
 import numpy as np
 import onnx
@@ -113,6 +114,12 @@ expected = {expected}
 actual = {actual}
 ```
 
+### Difference
+
+```diff
+{diff}
+```
+
 ### Full error stack
 
 ```
@@ -178,6 +185,13 @@ def create_mismatch_report(
     error_text = str(error)
     error_stack = error_text + "\n" + "".join(traceback.format_tb(error.__traceback__))
     short_test_name = test_name.split(".")[-1]
+    diff = difflib.unified_diff(
+        str(actual).splitlines(),
+        str(expected).splitlines(),
+        tofile="actual",
+        fromfile="expected",
+        lineterm="",
+    )
     markdown = _MISMATCH_MARKDOWN_TEMPLATE.format(
         test_name=test_name,
         short_test_name=short_test_name,
@@ -186,6 +200,7 @@ def create_mismatch_report(
         kwargs=kwargs,
         expected=expected,
         actual=actual,
+        diff="\n".join(diff),
         error_stack=error_stack,
     )
 

--- a/onnxscript/tests/function_libs/torch_lib/ops_test.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test.py
@@ -22,6 +22,7 @@ errors.
 """
 from __future__ import annotations
 
+import os
 import unittest
 from typing import Callable, Optional, Sequence, Tuple
 
@@ -36,7 +37,11 @@ from torch.utils import _pytree as pytree
 
 import onnxscript
 import onnxscript.evaluator
-from onnxscript.tests.function_libs.torch_lib import ops_test_common, ops_test_data
+from onnxscript.tests.function_libs.torch_lib import (
+    error_reproduction,
+    ops_test_common,
+    ops_test_data,
+)
 
 # All dtypes will be tested on the generated symbolic functions.
 # complex64 will be flattened to float32.
@@ -260,6 +265,10 @@ def run_test_output_match(
                             check_device=False,
                         )
                     except AssertionError as e:
+                        if os.environ.get("CREATE_REPRODUCTION_REPORT") == "1":
+                            error_reproduction.create_mismatch_report(
+                                test_name, j, inputs, cpu_sample.kwargs, actual, expected, e
+                            )
                         if len(flattened_torch_outputs) > 1:
                             raise AssertionError(f"Output {j} mismatch") from e
                         raise

--- a/onnxscript/tests/function_libs/torch_lib/ops_test.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test.py
@@ -267,7 +267,7 @@ def run_test_output_match(
                     except AssertionError as e:
                         if os.environ.get("CREATE_REPRODUCTION_REPORT") == "1":
                             error_reproduction.create_mismatch_report(
-                                test_name, j, inputs, cpu_sample.kwargs, actual, expected, e
+                                test_name, i, inputs, cpu_sample.kwargs, actual, expected, e
                             )
                         if len(flattened_torch_outputs) > 1:
                             raise AssertionError(f"Output {j} mismatch") from e

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_common.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_common.py
@@ -8,6 +8,7 @@ import dataclasses
 import multiprocessing
 import os
 import pprint
+import sys
 import unittest
 import warnings
 from typing import (
@@ -57,6 +58,7 @@ FLOAT_TYPES = (
 
 TEST_OPSET_VERSION = 18
 IS_WINDOWS = os.name == "nt"
+IS_MACOS = sys.platform == "darwin"
 
 
 @dataclasses.dataclass

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_common.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_common.py
@@ -8,7 +8,6 @@ import dataclasses
 import multiprocessing
 import os
 import pprint
-import sys
 import unittest
 import warnings
 from typing import (
@@ -58,7 +57,6 @@ FLOAT_TYPES = (
 
 TEST_OPSET_VERSION = 18
 IS_WINDOWS = os.name == "nt"
-IS_MACOS = sys.platform == "darwin"
 
 
 @dataclasses.dataclass

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -647,15 +647,8 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     .skip(
         variant_name="trunc_rounding",
         dtypes=(torch.float16,),
-        # Numbers match on MacOS sometimes but not other times
-        enabled_if=ops_test_common.IS_MACOS,
+        # Numbers match sometimes but not other times
         reason="fixme: off-by-one. https://github.com/microsoft/onnxscript/issues/990",
-    )
-    .xfail(
-        variant_name="floor_rounding",
-        dtypes=(torch.float16,),
-        test_class_name="TestOutputConsistencyEager",
-        reason="fixme: off-by-one and inverted inf. https://github.com/microsoft/onnxscript/issues/989",
     ),
     TorchLibOpInfo("dot", core_ops.aten_dot),
     TorchLibOpInfo(

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -638,17 +638,17 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         matcher=lambda sample: sample.kwargs.get("rounding_mode") is None,
         reason="this variation requires the rounding_mode argument",
     )
-    .xfail(
-        variant_name="trunc_rounding",
-        dtypes=(torch.float16,),
-        enabled_if=not ops_test_common.IS_MACOS,
-        reason="fixme: off-by-one. https://github.com/microsoft/onnxscript/issues/990",
-    )
     .skip(
         variant_name="trunc_rounding",
         dtypes=(torch.float16,),
         # Numbers match sometimes but not other times
         reason="fixme: off-by-one. https://github.com/microsoft/onnxscript/issues/990",
+    )
+    .xfail(
+        variant_name="floor_rounding",
+        dtypes=(torch.float16,),
+        test_class_name="TestOutputConsistencyEager",
+        reason="fixme: off-by-one and inverted inf. https://github.com/microsoft/onnxscript/issues/989",
     ),
     TorchLibOpInfo("dot", core_ops.aten_dot),
     TorchLibOpInfo(

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -636,9 +636,6 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo("div_mode", core_ops.aten_div_mode, trace_only=True).skip(
         matcher=lambda sample: sample.kwargs.get("rounding_mode") is None,
         reason="this variation requires the rounding_mode argument",
-    # ).xfail(
-    #     dtypes=(torch.float16,),
-    #     reason="fixme: division"
     ),
     TorchLibOpInfo("dot", core_ops.aten_dot),
     TorchLibOpInfo(

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -641,7 +641,13 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     .xfail(
         variant_name="trunc_rounding",
         dtypes=(torch.float16,),
-        # Numbers match on MacOS
+        enabled_if=not ops_test_common.IS_MACOS,
+        reason="fixme: off-by-one. https://github.com/microsoft/onnxscript/issues/990",
+    )
+    .skip(
+        variant_name="trunc_rounding",
+        dtypes=(torch.float16,),
+        # Numbers match on MacOS sometimes but not other times
         enabled_if=not ops_test_common.IS_MACOS,
         reason="fixme: off-by-one. https://github.com/microsoft/onnxscript/issues/990",
     )

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -641,6 +641,8 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     .xfail(
         variant_name="trunc_rounding",
         dtypes=(torch.float16,),
+        # Numbers match on MacOS
+        enabled_if=not ops_test_common.IS_MACOS,
         reason="fixme: off-by-one. https://github.com/microsoft/onnxscript/issues/990",
     )
     .xfail(

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -662,6 +662,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo("fill", core_ops.aten_fill),
     TorchLibOpInfo("flip", core_ops.aten_flip, input_wrangler=_flip_input_wrangler),
     TorchLibOpInfo("floor", core_ops.aten_floor),
+    TorchLibOpInfo("floor_divide", core_ops.aten_floor_divide),
     TorchLibOpInfo("fmod", core_ops.aten_fmod),
     TorchLibOpInfo("full", core_ops.aten_full),
     TorchLibOpInfo(

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -633,9 +633,21 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         matcher=lambda sample: sample.kwargs.get("rounding_mode") is not None,
         reason="this variation does not take the rounding_mode argument",
     ),
-    TorchLibOpInfo("div_mode", core_ops.aten_div_mode, trace_only=True).skip(
+    TorchLibOpInfo("div_mode", core_ops.aten_div_mode, trace_only=True)
+    .skip(
         matcher=lambda sample: sample.kwargs.get("rounding_mode") is None,
         reason="this variation requires the rounding_mode argument",
+    )
+    .xfail(
+        variant_name="trunc_rounding",
+        dtypes=(torch.float16,),
+        reason="fixme: off-by-one. https://github.com/microsoft/onnxscript/issues/990",
+    )
+    .xfail(
+        variant_name="floor_rounding",
+        dtypes=(torch.float16,),
+        test_class_name="TestOutputConsistencyEager",
+        reason="fixme: off-by-one and inverted inf. https://github.com/microsoft/onnxscript/issues/989",
     ),
     TorchLibOpInfo("dot", core_ops.aten_dot),
     TorchLibOpInfo(
@@ -659,7 +671,11 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo("fill", core_ops.aten_fill),
     TorchLibOpInfo("flip", core_ops.aten_flip, input_wrangler=_flip_input_wrangler),
     TorchLibOpInfo("floor", core_ops.aten_floor),
-    TorchLibOpInfo("floor_divide", core_ops.aten_floor_divide),
+    TorchLibOpInfo("floor_divide", core_ops.aten_floor_divide).xfail(
+        dtypes=(torch.float16,),
+        test_class_name="TestOutputConsistencyEager",
+        reason="fixme: off-by-one issue due to numerical precision. https://github.com/microsoft/onnxscript/issues/989",
+    ),
     TorchLibOpInfo("fmod", core_ops.aten_fmod),
     TorchLibOpInfo("full", core_ops.aten_full),
     TorchLibOpInfo(

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -635,7 +635,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ),
     TorchLibOpInfo("div_mode", core_ops.aten_div_mode, trace_only=True)
     .skip(
-        matcher=lambda sample: sample.kwargs.get("rounding_mode") is None,
+        variant_name="no_rounding_mode",
         reason="this variation requires the rounding_mode argument",
     )
     .skip(

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -629,12 +629,16 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo("cosh", core_ops.aten_cosh),
     TorchLibOpInfo("cross", core_ops.aten_cross),
     # TorchLibOpInfo("detach", core_ops.aten_detach),  # detach is not in OP-TEST-DB
-    TorchLibOpInfo(
-        "div",
-        core_ops.aten_div,
-    ).skip(
+    TorchLibOpInfo("div", core_ops.aten_div).skip(
         matcher=lambda sample: sample.kwargs.get("rounding_mode") is not None,
-        reason="rounding_mode is not yet supported",
+        reason="this variation does not take the rounding_mode argument",
+    ),
+    TorchLibOpInfo("div_mode", core_ops.aten_div_mode, trace_only=True).skip(
+        matcher=lambda sample: sample.kwargs.get("rounding_mode") is None,
+        reason="this variation requires the rounding_mode argument",
+    # ).xfail(
+    #     dtypes=(torch.float16,),
+    #     reason="fixme: division"
     ),
     TorchLibOpInfo("dot", core_ops.aten_dot),
     TorchLibOpInfo(
@@ -1838,6 +1842,7 @@ ops_test_common.duplicate_opinfo(OPS_DB, "atleast_2d", ("atleast_2d_Sequence",))
 ops_test_common.duplicate_opinfo(OPS_DB, "atleast_3d", ("atleast_3d_Sequence",))
 ops_test_common.duplicate_opinfo(OPS_DB, "cat", ("concat", "concatenate"))
 ops_test_common.duplicate_opinfo(OPS_DB, "clone", ("lift_fresh_copy",))
+ops_test_common.duplicate_opinfo(OPS_DB, "div", ("div_mode",))
 ops_test_common.duplicate_opinfo(OPS_DB, "full_like", ("full_like_dtype",))
 ops_test_common.duplicate_opinfo(OPS_DB, "index_put", ("index_put_bool",))
 ops_test_common.duplicate_opinfo(OPS_DB, "max", ("max_dim",))

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -648,7 +648,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         variant_name="trunc_rounding",
         dtypes=(torch.float16,),
         # Numbers match on MacOS sometimes but not other times
-        enabled_if=not ops_test_common.IS_MACOS,
+        enabled_if=ops_test_common.IS_MACOS,
         reason="fixme: off-by-one. https://github.com/microsoft/onnxscript/issues/990",
     )
     .xfail(


### PR DESCRIPTION
`aten::div.Tensor_mode` is implemented with two ONNX functions. When `rounding_mode` is `None`, we use `aten_div`. When it is not None, we use `aten_div_mode`. This way we don't need to handle when `rounding_mode==None` in `aten_div`.

For `float16` inputs we need to cast to float32 to preserve precision. Otherwise `-inf` sometimes becomes `inf` in the output.

- Additionally registers aliases "aten::divide", "aten::true_divide" to `aten_div`.
- Supports saving mismatches to error reports
- xfail and documents off-by-one errors with float16 (https://github.com/microsoft/onnxscript/issues/990, https://github.com/microsoft/onnxscript/issues/989)

Fixes #980