### PR TITLE
Fix attribute for ONNX 1.14.1 | fix

### DIFF
--- a/onnxscript/irbuilder.py
+++ b/onnxscript/irbuilder.py
@@ -173,8 +173,8 @@ class IRAttributeParameter:
                 "Attribute has no default value. Only attributes with default "
                 "values can be converted to AttributeProto."
             )
-        if version_utils.onnx_older_than("1.14.1"):
-            # Argument 'attr_type' was added after version 1.14.0.
+        if version_utils.onnx_older_than("1.15"):
+            # Argument 'attr_type' was added after version 1.14.
             return helper.make_attribute(self.name, self.default_value)
         # pylint: disable=unexpected-keyword-arg
         return helper.make_attribute(self.name, self.default_value, attr_type=self.type)  # type: ignore[call-arg]

--- a/onnxscript/irbuilder.py
+++ b/onnxscript/irbuilder.py
@@ -174,6 +174,7 @@ class IRAttributeParameter:
                 "values can be converted to AttributeProto."
             )
         if version_utils.onnx_older_than("1.15"):
+            # TODO(after 1.14 is deprecated): Remove this branch.
             # Argument 'attr_type' was added after version 1.14.
             return helper.make_attribute(self.name, self.default_value)
         # pylint: disable=unexpected-keyword-arg


### PR DESCRIPTION
The version checking logic for creating an attribute proto is not robust with ONNX 1.14.1. This fixes it in preparation for ONNX 1.14.1 release.