### PR TITLE
Fix slice_scatter

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6251,7 +6251,7 @@ def aten_slice_copy(
     raise NotImplementedError()
 
 
-@torch_op("aten::slice_scatter", trace_only=True)
+@torch_op("aten::slice_scatter")
 def aten_slice_scatter(
     self: TTensor,
     src: TTensor,
@@ -6268,41 +6268,21 @@ def aten_slice_scatter(
     # Assert(end-start == shape(src) > 0)
     # Try torch sample to get more information:
     # https://pytorch.org/docs/master/generated/torch.slice_scatter.html?highlight=slice_scatter#torch.slice_scatter
-    # e.g. if dim=2, shape=5, permute will be [0,1]+[4]+[2,3]=[0,1,4,2,3]
-    last = len(src.shape)
-    perm = list(range(0, last))
-    perm.insert(dim, perm.pop(-1))
-    return _aten_slice_scatter_onnx(self, src, start, end, step, dim, perm)
-
-
-@torch_op("aten::slice_scatter", private=True)
-def _aten_slice_scatter_onnx(
-    self: TTensor,
-    src: TTensor,
-    start: INT64,
-    end: INT64,
-    step: INT64,
-    dim: int,
-    perm: Sequence[int],
-) -> TTensor:
-    neg_1 = op.Constant(value_ints=[-1])
-    # Get shapes expcept specifide dim
-    # e.g. if dim=2, shape=(2,3,5,7), shape_expand will be (2,3,7,1)
-    src_shape = op.Shape(src)
-    last_dim = op.Reshape(op.Size(src_shape), neg_1)
-    dim_tensor = op.Reshape(op.Constant(value_int=dim), neg_1)
-    shape_before_dim = op.Slice(src_shape, op.Constant(value_ints=[0]), dim_tensor)
-    shape_after_dim = op.Slice(src_shape, op.Add(dim_tensor, 1), last_dim)
-    shape_expand = op.Concat(
-        shape_before_dim, shape_after_dim, op.Constant(value_ints=[1]), axis=0
+    zero = op.Constant(value_ints=[0])
+    one = op.Constant(value_ints=[1])
+    self_shape = op.Shape(self)
+    dim_shape = op.Gather(self_shape, dim, axis=0)
+    index_base = op.Range(0, dim_shape, 1)
+    index_base = op.Slice(
+        index_base,
+        op.Unsqueeze(start, zero),
+        op.Unsqueeze(end, zero),
+        zero,
+        op.Unsqueeze(step, zero),
     )
-    # Generate index but not finalized, need to do transpose later
-    # e.g. [[0,1,2],[0,1,2],[0,1,2]...,[0,1,2]], total count = 2x3x7
-    index_base = op.Range(start, end, step)  # e.g. [0,1,2]
-    index_expand = op.Expand(index_base, shape_expand)
-    indices = op.Transpose(index_expand, perm=perm)
-
-    return op.ScatterElements(self, indices, src, axis=dim)
+    index_base = op.Unsqueeze(index_base, op.Range(1, op.Size(self_shape) - dim, 1))
+    shape_expand = op.ScatterElements(self_shape, op.Unsqueeze(op.Constant(value_int=dim), zero), one, axis=0)
+    indices = op.Expand(index_base, shape_expand)
 
 
 def aten_slogdet(self: TensorType) -> tuple[TensorType, TensorType]:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6283,6 +6283,7 @@ def aten_slice_scatter(
     index_base = op.Unsqueeze(index_base, op.Range(1, op.Size(self_shape) - dim, 1))
     shape_expand = op.ScatterElements(self_shape, op.Unsqueeze(op.Constant(value_int=dim), zero), one, axis=0)
     indices = op.Expand(index_base, shape_expand)
+    return op.ScatterElements(self, indices, src, axis=dim)
 
 
 def aten_slogdet(self: TensorType) -> tuple[TensorType, TensorType]:

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -760,18 +760,114 @@ def sample_inputs_slice_scatter(op_info, device, dtype, requires_grad, **kwargs)
 
     L = 20
     cases = (
-        ((L, L, L), (L, L, L,), (0, 0, L, 1)),
-        ((L, L, L), (L // 2, L, L,), (0, L // 2, L, 1)),
-        ((L, L, L), (L // 4, L, L,), (0, L // 2, L, 2)),
-        ((L, L, L), (L, L, L,), (1, 0, L, 1)),
-        ((L, L, L), (L, L // 2, L,), (1, L // 2, L, 1)),
-        ((L, L, L), (L, L // 4, L,), (1, L // 2, L, 2)),
-        ((L, L, L), (L, L, L,), (2, 0, L, 1)),
-        ((L, L, L), (L, L, L // 2,), (2, L // 2, L, 1)),
-        ((L, L, L), (L, L, L // 4,), (2, L // 2, L, 2)),
-        ((L, L, L), (L, L // 2, L,), (1, L // 2, L * 2, 1)),  # end > L
-        ((L, L, L), (L, L, L,), (-2, 0, L, 1)),  # negative dim
-        ((L, L, L), (L, L, L // 4,), (-1, L // 2, L * 2, 2)),  # end > L and negative dim
+        (
+            (L, L, L),
+            (
+                L,
+                L,
+                L,
+            ),
+            (0, 0, L, 1),
+        ),
+        (
+            (L, L, L),
+            (
+                L // 2,
+                L,
+                L,
+            ),
+            (0, L // 2, L, 1),
+        ),
+        (
+            (L, L, L),
+            (
+                L // 4,
+                L,
+                L,
+            ),
+            (0, L // 2, L, 2),
+        ),
+        (
+            (L, L, L),
+            (
+                L,
+                L,
+                L,
+            ),
+            (1, 0, L, 1),
+        ),
+        (
+            (L, L, L),
+            (
+                L,
+                L // 2,
+                L,
+            ),
+            (1, L // 2, L, 1),
+        ),
+        (
+            (L, L, L),
+            (
+                L,
+                L // 4,
+                L,
+            ),
+            (1, L // 2, L, 2),
+        ),
+        (
+            (L, L, L),
+            (
+                L,
+                L,
+                L,
+            ),
+            (2, 0, L, 1),
+        ),
+        (
+            (L, L, L),
+            (
+                L,
+                L,
+                L // 2,
+            ),
+            (2, L // 2, L, 1),
+        ),
+        (
+            (L, L, L),
+            (
+                L,
+                L,
+                L // 4,
+            ),
+            (2, L // 2, L, 2),
+        ),
+        (
+            (L, L, L),
+            (
+                L,
+                L // 2,
+                L,
+            ),
+            (1, L // 2, L * 2, 1),
+        ),  # end > L
+        (
+            (L, L, L),
+            (
+                L,
+                L,
+                L,
+            ),
+            (-2, 0, L, 1),
+        ),  # negative dim
+        (
+            (L, L, L),
+            (
+                L,
+                L,
+                L // 4,
+            ),
+            (-1, L // 2, L * 2, 2),
+        ),  # end > L and negative dim
     )
 
     for input_shape, src_shape, args in cases:

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -760,114 +760,18 @@ def sample_inputs_slice_scatter(op_info, device, dtype, requires_grad, **kwargs)
 
     L = 20
     cases = (
-        (
-            (L, L, L),
-            (
-                L,
-                L,
-                L,
-            ),
-            (0, 0, L, 1),
-        ),
-        (
-            (L, L, L),
-            (
-                L // 2,
-                L,
-                L,
-            ),
-            (0, L // 2, L, 1),
-        ),
-        (
-            (L, L, L),
-            (
-                L // 4,
-                L,
-                L,
-            ),
-            (0, L // 2, L, 2),
-        ),
-        (
-            (L, L, L),
-            (
-                L,
-                L,
-                L,
-            ),
-            (1, 0, L, 1),
-        ),
-        (
-            (L, L, L),
-            (
-                L,
-                L // 2,
-                L,
-            ),
-            (1, L // 2, L, 1),
-        ),
-        (
-            (L, L, L),
-            (
-                L,
-                L // 4,
-                L,
-            ),
-            (1, L // 2, L, 2),
-        ),
-        (
-            (L, L, L),
-            (
-                L,
-                L,
-                L,
-            ),
-            (2, 0, L, 1),
-        ),
-        (
-            (L, L, L),
-            (
-                L,
-                L,
-                L // 2,
-            ),
-            (2, L // 2, L, 1),
-        ),
-        (
-            (L, L, L),
-            (
-                L,
-                L,
-                L // 4,
-            ),
-            (2, L // 2, L, 2),
-        ),
-        (
-            (L, L, L),
-            (
-                L,
-                L // 2,
-                L,
-            ),
-            (1, L // 2, L * 2, 1),
-        ),  # end > L
-        (
-            (L, L, L),
-            (
-                L,
-                L,
-                L,
-            ),
-            (-2, 0, L, 1),
-        ),  # negative dim
-        (
-            (L, L, L),
-            (
-                L,
-                L,
-                L // 4,
-            ),
-            (-1, L // 2, L * 2, 2),
-        ),  # end > L and negative dim
+        ((L, L, L), (L, L, L), (0, 0, L, 1)),
+        ((L, L, L), (L // 2, L, L), (0, L // 2, L, 1)),
+        ((L, L, L), (L // 4, L, L), (0, L // 2, L, 2)),
+        ((L, L, L), (L, L, L), (1, 0, L, 1)),
+        ((L, L, L), (L, L // 2, L), (1, L // 2, L, 1)),
+        ((L, L, L), (L, L // 4, L), (1, L // 2, L, 2)),
+        ((L, L, L), (L, L, L), (2, 0, L, 1)),
+        ((L, L, L), (L, L, L // 2), (2, L // 2, L, 1)),
+        ((L, L, L), (L, L, L // 4), (2, L // 2, L, 2)),
+        ((L, L, L), (L, L // 2, L), (1, L // 2, L * 2, 1)),  # end > L
+        ((L, L, L), (L, L, L), (-2, 0, L, 1)),  # negative dim
+        ((L, L, L), (L, L, L // 4), (-1, L // 2, L * 2, 2)),  # end > L and negative dim
     )
 
     for input_shape, src_shape, args in cases:

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1776,7 +1776,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         variant_name="sum",
         reason="fixme: MLFloat16 data type is not supported with ScatterElements opset 18 when reduction is 'add'",
     ),
-    TorchLibOpInfo("slice_scatter", core_ops.aten_slice_scatter, trace_only=True),
+    TorchLibOpInfo("slice_scatter", core_ops.aten_slice_scatter),
     TorchLibOpInfo("slice", core_ops.aten_slice, trace_only=True),
     TorchLibOpInfo(
         "ops.aten.stft",  # Custom from extra_opinfo

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1776,7 +1776,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         variant_name="sum",
         reason="fixme: MLFloat16 data type is not supported with ScatterElements opset 18 when reduction is 'add'",
     ),
-    TorchLibOpInfo("slice_scatter", core_ops.aten_slice_scatter),
+    TorchLibOpInfo("ops.aten.slice_scatter", core_ops.aten_slice_scatter),
     TorchLibOpInfo("slice", core_ops.aten_slice, trace_only=True),
     TorchLibOpInfo(
         "ops.aten.stft",  # Custom from extra_opinfo


### PR DESCRIPTION
Current logic for slice_scatter doesn't handle the case when param start or end is out of range for [0, dim_value), while this case is valid. Most of the case (for transformer models) it will use MAX_INT for end. Current test data doesn't have such case so it doesn't cover such case. Using (torch.zeros(8, 8), torch.ones(2, 8), 0, 6, 100, 1) can fail current implementation.

This PR is to fix this, and also adjust the logic to make it simpler. The Transpose logic in current implementation is not necessary.

The new implementation passes all current test data as well as above one. I don't know how to add new test data to current UT code, someone please help me on this.

Fixes https://github.com/microsoft/onnxscript/issues/945