### PR TITLE
Always upload SARIF in PR | chore

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -73,6 +73,8 @@ jobs:
         run: |
           python -m lintrunner_adapters to-sarif lint.json lintrunner.sarif
       - name: Upload SARIF file
+        # Use always() to always upload SARIF even if lintrunner returns with error code
+        # To toggle linter comments in the files page, press `i` on the keyboard
         if: always()
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -73,8 +73,7 @@ jobs:
         run: |
           python -m lintrunner_adapters to-sarif lint.json lintrunner.sarif
       - name: Upload SARIF file
-        # Do not display on drafts to make reviewing easier
-        if: github.event.pull_request.draft == false
+        if: always()
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@v2
         with:


### PR DESCRIPTION
I realized the SARIF file wasn’t uploaded without always()

Use `i` to toggle comment display if needed.