### PR TITLE
Support >2G model export | torchlib(feat)

### DIFF
--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -346,7 +346,7 @@ def _create_op_call_in_torch_graph(
     return node_ouputs
 
 
-def _estimate_tensor_size(tensor: torch.Tensor) -> int:
+def _tensor_rawdata_size(tensor: torch.Tensor) -> int:
     """Estimate the size of a tensor in bytes.
 
     Args:
@@ -700,7 +700,7 @@ class TorchScriptGraph:
             unique_custom_domains[function_proto.domain] = 1
 
         initializers_size = sum(
-            _estimate_tensor_size(tensor) for tensor in self.initializers.values()
+            _tensor_rawdata_size(tensor) for tensor in self.initializers.values()
         )
 
         large_model = initializers_size > _LARGE_MODEL_SIZE_THRESHOLD

--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -732,7 +732,8 @@ class TorchScriptGraph:
                 ) = self._torch_graph._export_onnx(  # type: ignore[attr-defined] # pylint: disable=protected-access
                     **export_kwargs
                 )
-                onnx_model = onnx.load_model(proto, load_external_data=True)
+                onnx_model = onnx.load_from_string(proto)
+                onnx.load_external_data_for_model(onnx_model, temp_dir)
         else:
             (
                 proto,

--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -727,7 +727,7 @@ class TorchScriptGraph:
                 _ = self._torch_graph._export_onnx(  # type: ignore[attr-defined] # pylint: disable=protected-access
                     **export_kwargs
                 )
-            onnx_model = onnx.load_model(onnx_file_path, load_external_data=True)
+                onnx_model = onnx.load_model(onnx_file_path, load_external_data=True)
         else:
             (
                 proto,

--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -724,10 +724,15 @@ class TorchScriptGraph:
             with tempfile.TemporaryDirectory() as temp_dir:
                 onnx_file_path = os.path.join(temp_dir, "exported_model.onnx")
                 export_kwargs["onnx_file_path"] = onnx_file_path
-                _ = self._torch_graph._export_onnx(  # type: ignore[attr-defined] # pylint: disable=protected-access
+                (
+                    proto,
+                    _,
+                    _,
+                    _,
+                ) = self._torch_graph._export_onnx(  # type: ignore[attr-defined] # pylint: disable=protected-access
                     **export_kwargs
                 )
-                onnx_model = onnx.load_model(onnx_file_path, load_external_data=True)
+                onnx_model = onnx.load_model(proto, load_external_data=True)
         else:
             (
                 proto,

--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import os
+import tempfile
 import typing
 import warnings
 from typing import Any, Dict, Final, List, Mapping, Optional, Sequence, Tuple, Union
@@ -340,6 +341,18 @@ def _create_op_call_in_torch_graph(
         _add_attribute_to_torchscript_node(node, key, value)
 
     return node_ouputs
+
+
+def _estimate_tensor_size(tensor: torch.Tensor) -> int:
+    """Estimate the size of a tensor in bytes.
+
+    Args:
+        tensor: The tensor to estimate the size of.
+
+    Returns:
+        The estimated size of the tensor in bytes.
+    """
+    return tensor.numel() * tensor.element_size()
 
 
 class TorchScriptGraph:
@@ -683,12 +696,15 @@ class TorchScriptGraph:
             # TODO(BowenBao): All local function domain versions are hardcoded as 1.
             unique_custom_domains[function_proto.domain] = 1
 
-        (
-            proto,
-            _,
-            _,
-            _,
-        ) = self._torch_graph._export_onnx(  # type: ignore[attr-defined] # pylint: disable=protected-access
+        initializers_size = sum(
+            _estimate_tensor_size(tensor) for tensor in self.initializers.values()
+        )
+
+        # Treat models > 1GB as large models so that we have ample room
+        # for the rest of the proto fields.
+        large_model = initializers_size > (2**30)
+
+        export_kwargs: dict[str, Any] = dict(
             initializers=self.initializers if include_initializers else {},
             onnx_opset_version=opset_version,
             # TODO(justinchuby): Figure out how to get the dynamic axes from the inputs
@@ -699,15 +715,30 @@ class TorchScriptGraph:
             keep_initializers_as_inputs=False,
             custom_opsets={},
             add_node_names=True,
-            # TODO(#493): Passing in this instead of reading from env.
-            # User must put the exported model file in the same folder to launch ORT.
-            onnx_file_path=os.path.join(
-                os.getenv("EXTERNAL_ONNX_INITIALIZER_FOLDER", ""), "dummy_model_path.onnx"
-            ),
             node_attr_to_name={},
         )
 
-        onnx_model = onnx.load_from_string(proto)
+        cache_model_to_disk = include_initializers and large_model
+
+        if cache_model_to_disk:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                onnx_file_path = os.path.join(temp_dir, "exported_model.onnx")
+                export_kwargs["onnx_file_path"] = onnx_file_path
+                _ = self._torch_graph._export_onnx(  # type: ignore[attr-defined] # pylint: disable=protected-access
+                    **export_kwargs
+                )
+            onnx_model = onnx.load_model(onnx_file_path, load_external_data=True)
+        else:
+            (
+                proto,
+                _,
+                _,
+                _,
+            ) = self._torch_graph._export_onnx(  # type: ignore[attr-defined] # pylint: disable=protected-access
+                **export_kwargs
+            )
+            onnx_model = onnx.load_from_string(proto)
+
         onnx_model.functions.extend(function_proto_dict.values())
 
         # `_export_onnx` only exports opset_imports that is visible to it. It does not
@@ -725,10 +756,14 @@ class TorchScriptGraph:
         )
 
         try:
-            onnx_model = onnx.shape_inference.infer_shapes(
-                onnx_model, check_type=True, strict_mode=False, data_prop=True
-            )
-            onnx.checker.check_model(onnx_model, full_check=True)
+            if not cache_model_to_disk:
+                # Only check the model if it is in memory.
+                # Otherwise the checker and shape_inference will fail because
+                # we cannot serialize the model.
+                onnx_model = onnx.shape_inference.infer_shapes(
+                    onnx_model, check_type=True, strict_mode=False, data_prop=True
+                )
+                onnx.checker.check_model(onnx_model, full_check=True)
         except (onnx.checker.ValidationError, onnx.shape_inference.InferenceError) as e:
             warnings.warn(f"ONNX model is invalid: {e}", stacklevel=1)
             logging.debug(

--- a/onnxscript/function_libs/torch_lib/graph_building_test.py
+++ b/onnxscript/function_libs/torch_lib/graph_building_test.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import tempfile
 import unittest
 
 import torch
@@ -11,7 +10,7 @@ import torch
 import onnxscript
 import onnxscript.testing
 from onnxscript import FLOAT, evaluator
-from onnxscript import opset17 as op
+from onnxscript import opset18 as op
 from onnxscript._internal import version_utils
 from onnxscript.function_libs.torch_lib import graph_building, ops
 
@@ -165,14 +164,8 @@ class TestModelSaving(unittest.TestCase):
         model = MLP(input_size, hidden_size, output_size)
         x = torch.randn(batch_size, input_size)
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            os.environ["EXTERNAL_ONNX_INITIALIZER_FOLDER"] = temp_dir
-            torch.onnx.dynamo_export(
-                model,
-                x,
-            )
-            # 3 initializers are saved to files as external data.
-            self.assertEqual(len(os.listdir(temp_dir)), 3)
+        # No error
+        torch.onnx.dynamo_export(model, x)
 
 
 if __name__ == "__main__":

--- a/onnxscript/function_libs/torch_lib/graph_building_test.py
+++ b/onnxscript/function_libs/torch_lib/graph_building_test.py
@@ -164,8 +164,9 @@ class TestModelSaving(unittest.TestCase):
         model = MLP(input_size, hidden_size, output_size)
         x = torch.randn(batch_size, input_size)
 
-        # No error
-        torch.onnx.dynamo_export(model, x)
+        model_proto = torch.onnx.dynamo_export(model, x).model_proto
+        # Assert model is larger than 2GB (~=3GB)
+        self.assertGreater(model_proto.ByteSize(), 2**31)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Support >2G model export by caching the model to disk when necessary.

Tested locally with `test_save_initializer_to_files_for_large_model`

Fixes #493

cc @wschin 