### PR TITLE
Extend 'TorchScriptGraph' with field 'domain_name'

### DIFF
--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -359,10 +359,11 @@ def _tensor_rawdata_size(tensor: torch.Tensor) -> int:
 
 
 class TorchScriptGraph:
-    _LOCAL_FUNCTION_DOMAIN_NAME: Final[str] = "torch_export"
-    """The domain name for local functions."""
-
-    def __init__(self, parent_torch_script_graph: Optional[TorchScriptGraph] = None):
+    def __init__(
+        self,
+        parent_torch_script_graph: Optional[TorchScriptGraph] = None,
+        domain_name: Optional[str] = None,
+    ):
         self._torch_graph = torch.Graph()
         # All the functions used, deduplicated by name
         # key: (name, domain)
@@ -379,6 +380,11 @@ class TorchScriptGraph:
         self._sub_torch_script_graphs: Dict[str, TorchScriptGraph] = {}
         # Parent graph. None if this is the top level graph.
         self._parent_torch_script_graph = parent_torch_script_graph
+        # Domain name of the graph. None if this is the top level graph.
+        self._domain_name: Optional[str] = domain_name
+
+        if self._domain_name is None and self._parent_torch_script_graph is not None:
+            raise RuntimeError("Domain name is not set for local function.")
 
     @property
     def torch_graph(self):
@@ -399,6 +405,10 @@ class TorchScriptGraph:
     @property
     def num_outputs(self) -> int:
         return len(list(self._torch_graph.outputs()))
+
+    @property
+    def domain_name(self) -> Optional[str]:
+        return self._domain_name
 
     @runtime_typing.checked
     def add_input(
@@ -572,6 +582,7 @@ class TorchScriptGraph:
         self, opset_version: int
     ) -> Mapping[Tuple[str, str], onnx.FunctionProto]:
         function_proto_dict: Dict[Tuple[str, str], onnx.FunctionProto] = {}
+        # Fetch local function protos. E.g., local functions representing module calls.
         for (
             sub_graph_name,
             sub_torch_script_graph,
@@ -579,9 +590,11 @@ class TorchScriptGraph:
             function_proto_dict.update(
                 sub_torch_script_graph.fetch_function_proto_dict(opset_version)
             )
+            domain = sub_torch_script_graph.domain_name
+            assert domain is not None
             name_domain = (
                 sub_graph_name,
-                self._LOCAL_FUNCTION_DOMAIN_NAME,
+                domain,
             )
             assert (
                 name_domain not in function_proto_dict
@@ -589,6 +602,7 @@ class TorchScriptGraph:
             function_proto_dict[name_domain] = sub_torch_script_graph.to_function_proto(
                 opset_version, sub_graph_name
             )
+        # Fetch torchlib function protos.
         for name_domain, function in self._function_store.items():
             function_proto_dict[name_domain] = function.to_function_proto()
         return function_proto_dict
@@ -639,8 +653,10 @@ class TorchScriptGraph:
         onnx_inputs: Sequence[ValidInputType],
     ) -> Union[TorchScriptTensor, Tuple[TorchScriptTensor, ...]]:
         self._sub_torch_script_graphs[name] = sub_torch_script_graph
+        domain_name = sub_torch_script_graph.domain_name
+        assert domain_name is not None
         return self._add_torchscript_op_call(
-            f"{self._LOCAL_FUNCTION_DOMAIN_NAME}::{name}",
+            f"{domain_name}::{name}",
             onnx_inputs=(
                 *onnx_inputs,
                 *sub_torch_script_graph.initializers_inputs_from_parent.values(),
@@ -674,8 +690,11 @@ class TorchScriptGraph:
         onnx_model = onnx.load_from_string(proto)
 
         # Dissect the model proto and transform to function proto.
+        domain = self.domain_name
+        if domain is None:
+            raise RuntimeError("Domain name is not set.")
         onnx_function = onnx.helper.make_function(
-            domain=self._LOCAL_FUNCTION_DOMAIN_NAME,
+            domain=domain,
             fname=function_name,
             inputs=[input.name for input in onnx_model.graph.input],
             outputs=[output.name for output in onnx_model.graph.output],

--- a/requirements/lintrunner/requirements.txt
+++ b/requirements/lintrunner/requirements.txt
@@ -3,7 +3,7 @@ lintrunner-adapters>=0.8.0
 # RUFF, RUFF-FIX
 ruff==0.0.280
 # MYPY
-mypy==1.4.1
+mypy==1.5.0
 types-PyYAML==6.0.12.11
 # BLACK-ISORT
 black==23.7.0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1014
* #1017

Instead of hardcoded "torch_export". PyTorch exporter will fill this field with source package info of the nn.Module call represented by this graph, and eventually enclose this field in exported local function.