### PR TITLE
Add initializer setter to support constant tensors in fake mode export | torchlib(feat)

### DIFF
--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -402,6 +402,13 @@ class TorchScriptGraph:
     def initializers(self) -> Mapping[str, torch.Tensor]:
         return self._initializers
 
+    # NOTE: This setter is used in torch converter when we activate fake mode,
+    #       we need to filter out the initializers that has fake tensor. This
+    #       is because we don't want to introduce fake tensor in onnxscript.
+    @initializers.setter
+    def initializers(self, initializers: Dict[str, torch.Tensor]):
+        self._initializers = initializers
+
     @property
     def initializers_inputs(self) -> Mapping[str, TorchScriptTensor]:
         return self._initializers_inputs
@@ -447,9 +454,7 @@ class TorchScriptGraph:
         return tensor_value  # type: ignore[return-value]
 
     @runtime_typing.checked
-    def add_initializer(
-        self, name: str, value: torch.Tensor, save_value_to_default: bool = True
-    ) -> TorchScriptTensor:
+    def add_initializer(self, name: str, value: torch.Tensor) -> TorchScriptTensor:
         if name in self._initializers_inputs:
             # NOTE: Previously it raises when `name` is already set. This is relaxed
             # because this will be invoked multiple times when submodule is called
@@ -468,17 +473,14 @@ class TorchScriptGraph:
             # to root graph, and add as input to current graph.
             self._initializers_inputs_from_parent[
                 name
-            ] = self._parent_torch_script_graph.add_initializer(
-                name, value, save_value_to_default
-            )
+            ] = self._parent_torch_script_graph.add_initializer(name, value)
             torch_value = self._torch_graph.addInput(name)
             torch_value.setType(torch.TensorType.create_from_tensor(value))
             tensor_value = _wrap_torch_value_to_tensor(torch_value)
             self._initializers_inputs[name] = tensor_value  # type: ignore[assignment]
             return tensor_value  # type: ignore[return-value]
-        # NOTE: If an initializer relies on external input, its default value is detached.
-        if save_value_to_default:
-            self._initializers[name] = value
+
+        self._initializers[name] = value
         torch_value = self._torch_graph.addInput(name)
         torch_value.setType(torch.TensorType.create_from_tensor(value))
         tensor_value = _wrap_torch_value_to_tensor(torch_value)

--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -402,6 +402,13 @@ class TorchScriptGraph:
     def initializers(self) -> Mapping[str, torch.Tensor]:
         return self._initializers
 
+    # NOTE: This setter is used in torch converter when we activate fake mode,
+    #       we need to filter out the initializers that has fake tensor. This
+    #       is because we don't want to introduce fake tensor in onnxscript.
+    @initializers.setter
+    def initializers(self, initializers: Dict[str, torch.Tensor]):
+        self._initializers = initializers
+
     @property
     def initializers_inputs(self) -> Mapping[str, TorchScriptTensor]:
         return self._initializers_inputs
@@ -714,9 +721,7 @@ class TorchScriptGraph:
         return onnx_function
 
     @runtime_typing.checked
-    def to_model_proto(
-        self, opset_version: int, include_initializers: bool = True
-    ) -> onnx.ModelProto:
+    def to_model_proto(self, opset_version: int) -> onnx.ModelProto:
         function_proto_dict: Mapping[
             Tuple[str, str], onnx.FunctionProto
         ] = self.fetch_function_proto_dict(opset_version)
@@ -733,7 +738,7 @@ class TorchScriptGraph:
         large_model = initializers_size > _LARGE_MODEL_SIZE_THRESHOLD
 
         export_kwargs: dict[str, Any] = dict(
-            initializers=self.initializers if include_initializers else {},
+            initializers=self.initializers,
             onnx_opset_version=opset_version,
             dynamic_axes={},
             defer_weight_export=False,
@@ -751,7 +756,7 @@ class TorchScriptGraph:
         # We did not do it because it is harder to get right (vs. PyTorch's battle-tested
         # implementation) and creating the `TensorProto`s naively (by converting to numpy)
         # is slow.
-        cache_model_to_disk = include_initializers and large_model
+        cache_model_to_disk = large_model
 
         if cache_model_to_disk:
             with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
`include_initializer` is created and controled by fake_mode to detach initializers with their default values, preventing fake tensor becomes initializers. However, initializer could be constant tensors which should not be detached from its default value, as it's always real tensor. This PR removes the parameter, because after https://github.com/pytorch/pytorch/pull/107836, the filtering logic is added into converter.

NOTE: `include_initializers` is kept for potentially usage of debugging/experimenting on large scale models.