### PR TITLE
Pin onnx-weekly to dev20230807 in requirements-dev | fix(release)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 setuptools>=61.0.0
 numpy
-onnx-weekly>=1.15.0.dev20230807
+onnx-weekly==1.15.0.dev20230807
 onnxruntime
 typing_extensions
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 setuptools>=61.0.0
 numpy
-onnx-weekly>=1.15.0.dev20230605
+onnx-weekly>=1.15.0.dev20230807
 onnxruntime
 typing_extensions
 


### PR DESCRIPTION
https://github.com/onnx/onnx/pull/5294 introduced a dependency to cv2 in tests, which fails our release pipeline. Instead of requiring cv2 we pin onnx to dev20230807 for now to unblock the release pipeline.