### PR TITLE
Move the test steps out of the dev-release pipeline | ci(release)

### DIFF
--- a/.azure-pipelines/_release-template.yml
+++ b/.azure-pipelines/_release-template.yml
@@ -21,11 +21,3 @@ steps:
     displayName: 'Publish onnxscript'
     inputs:
       ArtifactName: onnxscript
-  # Test the wheels. This needs to happen after PublishBuildArtifacts
-  # to avoid interference with the artifacts
-  - script: python -m pip install -r requirements-dev.txt
-    displayName: 'Install Python dependencies'
-  - script: python -m pip install dist/*.whl --no-deps
-    displayName: 'Install wheel'
-  - script: python -m pytest -v -n auto
-    displayName: 'Run tests'

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -10,3 +10,11 @@ variables:
   ONNX_SCRIPT_RELEASE: 1
 steps:
   - template: _release-template.yml
+  # Test the wheels. This needs to happen after PublishBuildArtifacts
+  # to avoid interference with the artifacts
+  - script: python -m pip install -r requirements-dev.txt
+    displayName: 'Install Python dependencies'
+  - script: python -m pip install dist/*.whl --no-deps
+    displayName: 'Install wheel'
+  - script: python -m pytest -v -n auto
+    displayName: 'Run tests'


### PR DESCRIPTION
Move the test steps out of the dev-release pipeline because the tests may fail due to dependency changes. For the dev pipeline we need to ensure daily releases are successful and are less worried about failing tests. The tests steps are moved to only exist in the official release pipeline.