### PR TITLE
Fix `attribute_proto` generation of function in protobuf 4.X

### DIFF
--- a/onnxscript/irbuilder.py
+++ b/onnxscript/irbuilder.py
@@ -468,7 +468,7 @@ class IRFunction:
             attributes=attribute_names,
             doc_string=self.docstring,
         )
-        if hasattr(onnx.FunctionProto, "attribute_proto"):
+        if hasattr(f, "attribute_proto"):
             f.attribute_proto.extend(
                 [attr.attr_proto for attr in self.attrs if attr.has_default]
             )

--- a/onnxscript/irbuilder.py
+++ b/onnxscript/irbuilder.py
@@ -468,6 +468,7 @@ class IRFunction:
             attributes=attribute_names,
             doc_string=self.docstring,
         )
+        # In protobuf 4.x fields aren't defined as class attribute so it should check instance attribute instead
         if hasattr(f, "attribute_proto"):
             f.attribute_proto.extend(
                 [attr.attr_proto for attr in self.attrs if attr.has_default]


### PR DESCRIPTION
In protobuf 4.x fields aren't defined as class attribute so it should check instance attribute instead
```
>>> import google.protobuf
>>> google.protobuf.__version__
'4.21.0'
>>> import onnx
>>> hasattr(onnx.FunctionProto, "attribute_proto")
False
>>> hasattr(onnx.FunctionProto(), "attribute_proto")
True
```