### PR TITLE
Publish source to PyPI as well

### DIFF
--- a/.azure-pipelines/_release-template.yml
+++ b/.azure-pipelines/_release-template.yml
@@ -15,7 +15,7 @@ steps:
     displayName: 'Copy Python Wheel to: $(Build.ArtifactStagingDirectory)'
     inputs:
       SourceFolder: 'dist'
-      Contents: '*.whl'
+      Contents: '*.*'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
   - task: PublishBuildArtifacts@1
     displayName: 'Publish onnxscript'


### PR DESCRIPTION
Previously we publish only the wheel file and not the source distribution. Update to publish source as well by including the source in the upload