### PR TITLE
Fix arange issue for int8/int16/int32 dtype

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -507,7 +507,7 @@ def _adjust_args_for_arange_int_dtype(
     step = op.Cast(step, to=FLOAT.dtype)
 
     if start < zero:
-        start = op.Cast(op.Cast(start, to=dtype), to=FLOAT.dtype)
+        start = op.Ceil(start)
 
     if step < zero:
         start = op.Floor(start)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -531,7 +531,7 @@ def aten_arange_start_step(
         # PyTorch arange op handles these integral types differently from INT64,
         # so we have to adjust these arguments accordingly.
         # https://github.com/pytorch/pytorch/blob/121cfb60c0817816fcbe2190303b7f6d05c77cf3/torch/_refs/__init__.py#L4794
-        start, end, step = _adjust_args_for_arange_int_dtype(start, end, step, dtype)
+        start, end, step = _adjust_args_for_arange_int_dtype(start, end, step)
         result = op.Cast(op.Range(start, end, step), to=dtype)
     elif dtype == INT64.dtype:
         end = op.Cast(end, to=dtype)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -521,7 +521,7 @@ def aten_arange_start_step(
     if dtype == -1:
         result = op.Range(start, end, step)
     elif _range_supported(dtype):
-        if dtype in [INT16.dtype, INT32.dtype]:
+        if dtype in (INT16.dtype, INT32.dtype):
             start, end, step = _aten_arange_start_step_onnx(start, end, step, dtype)
             result = op.Cast(op.Range(start, end, step), to=dtype)
         else:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -488,9 +488,8 @@ def aten_arange_start(
 def _aten_arange_start_step_onnx(
     start: TRealUnlessFloat16OrInt8,
     end: TRealUnlessFloat16OrInt8,
-    step: TRealUnlessFloat16OrInt8
+    step: TRealUnlessFloat16OrInt8,
 ) -> Tuple[FLOAT, FLOAT, FLOAT]:
-
     zero = op.Cast(0.0, to=FLOAT.dtype)
     start = op.Cast(start, to=FLOAT.dtype)
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -425,6 +425,15 @@ def _range_supported(dtype: int) -> bool:
     }
 
 
+def _integral_to_be_adjusted(dtype: int) -> bool:
+    """Returns true if the dtype is special integral handled by torch."""
+    return dtype in {
+        INT8.dtype,
+        INT16.dtype,
+        INT32.dtype,
+    }
+
+
 @torch_op("aten::arange", trace_only=True)
 def aten_arange(end: Union[DOUBLE, FLOAT, INT16, INT32, INT64], dtype: int = -1) -> TensorType:
     """arange(Scalar end, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
@@ -485,23 +494,23 @@ def aten_arange_start(
 
 
 @torch_op("aten::arange.start_step", private=True)
-def _aten_arange_start_step_onnx(
+def _adjust_args_for_arange_int_dtype(
     start: TRealUnlessFloat16OrInt8,
     end: TRealUnlessFloat16OrInt8,
     step: TRealUnlessFloat16OrInt8,
     dtype: int,
 ) -> Tuple[FLOAT, FLOAT, FLOAT]:
+
     zero = op.Cast(0.0, to=FLOAT.dtype)
     start = op.Cast(start, to=FLOAT.dtype)
+    end = op.Cast(end, to=FLOAT.dtype)
+    step = op.Cast(step, to=FLOAT.dtype)
 
     if start < zero:
         start = op.Cast(op.Cast(start, to=dtype), to=FLOAT.dtype)
 
-    step = op.Cast(step, to=FLOAT.dtype)
     if step < zero:
         start = op.Floor(start)
-
-    end = op.Cast(end, to=FLOAT.dtype)
 
     return (start, end, step)
 
@@ -520,27 +529,25 @@ def aten_arange_start_step(
 
     if dtype == -1:
         result = op.Range(start, end, step)
-    elif _range_supported(dtype):
-        if dtype in (INT16.dtype, INT32.dtype):
-            start, end, step = _aten_arange_start_step_onnx(start, end, step, dtype)
-            result = op.Cast(op.Range(start, end, step), to=dtype)
-        else:
-            end = op.Cast(end, to=dtype)
-            start = op.Cast(start, to=dtype)
-            step = op.Cast(step, to=dtype)
-            result = op.Range(start, end, step)
+    elif _integral_to_be_adjusted(dtype):
+        # PyTorch arange op handles these integral types differently from INT64,
+        # so we have to adjust these arguments accordingly.
+        # https://github.com/pytorch/pytorch/blob/121cfb60c0817816fcbe2190303b7f6d05c77cf3/torch/_refs/__init__.py#L4794
+        start, end, step = _adjust_args_for_arange_int_dtype(start, end, step, dtype)
+        result = op.Cast(op.Range(start, end, step), to=dtype)
+    elif dtype == INT64.dtype:
+        end = op.Cast(end, to=dtype)
+        start = op.Cast(start, to=dtype)
+        step = op.Cast(step, to=dtype)
+        result = op.Range(start, end, step)
     else:
         # Cast input to float if dtype is not supported by Range,
-        # because the input dtype may be e.g. bfloat16 / int8 etc.
+        # because the input dtype may be e.g. bfloat16,
         # which Range does not support. The output type is ensured because the output
         # is casted to the specified dtype.
-        if dtype == INT8.dtype:
-            start, end, step = _aten_arange_start_step_onnx(start, end, step, dtype)
-        else:
-            end = op.Cast(end, to=FLOAT.dtype)
-            start = op.Cast(start, to=FLOAT.dtype)
-            step = op.Cast(step, to=FLOAT.dtype)
-
+        end = op.Cast(end, to=FLOAT.dtype)
+        start = op.Cast(start, to=FLOAT.dtype)
+        step = op.Cast(step, to=FLOAT.dtype)
         result = op.Cast(op.Range(start, end, step), to=dtype)
 
     return result

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -498,9 +498,7 @@ def _adjust_args_for_arange_int_dtype(
     start: TRealUnlessFloat16OrInt8,
     end: TRealUnlessFloat16OrInt8,
     step: TRealUnlessFloat16OrInt8,
-    dtype: int,
 ) -> Tuple[FLOAT, FLOAT, FLOAT]:
-
     zero = op.Cast(0.0, to=FLOAT.dtype)
     start = op.Cast(start, to=FLOAT.dtype)
     end = op.Cast(end, to=FLOAT.dtype)

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1351,8 +1351,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "arange_start_step",
         core_ops.aten_arange_start_step,
         trace_only=True,
-    )
-    .xfail(
+    ).xfail(
         matcher=lambda sample: len(sample.args) != 2,
         reason="arange_start_step overload takes three arguments (input, start, step)",
     ),
@@ -1360,8 +1359,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "arange_start",
         core_ops.aten_arange_start,
         trace_only=True,
-    )
-    .skip(
+    ).skip(
         matcher=lambda sample: len(sample.args) != 1,
         reason="arange_start overload takes two arguments (input, start)",
     ),

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1353,10 +1353,6 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         trace_only=True,
     )
     .xfail(
-        dtypes=(torch.int32,),
-        reason="fixme: output shape mismatch in edge cases. https://github.com/microsoft/onnxscript/issues/974",
-    )
-    .xfail(
         matcher=lambda sample: len(sample.args) != 2,
         reason="arange_start_step overload takes three arguments (input, start, step)",
     ),
@@ -1364,10 +1360,6 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "arange_start",
         core_ops.aten_arange_start,
         trace_only=True,
-    )
-    .xfail(
-        dtypes=(torch.int32,),
-        reason="fixme: output shape mismatch in edge cases. https://github.com/microsoft/onnxscript/issues/974",
     )
     .skip(
         matcher=lambda sample: len(sample.args) != 1,


### PR DESCRIPTION
ONNX op 'Range' behaves differently with Torch op 'arange' when the expected output dtype is INT32.

Totally 2 differences are found in two conditions below:

1. 'start' is negative, or 
2. 'step' is negative. 

This PR will make necessary adjustments to make these 2 ops behave same.

Fix #974 .