### PR TITLE
Ensure exporter creates valid python name for opset vars

### DIFF
--- a/onnxscript/backend/onnx_export.py
+++ b/onnxscript/backend/onnx_export.py
@@ -433,16 +433,20 @@ class Exporter:
         return "".join(text)
 
     def translate_opset_import(self, domain: str, version: int) -> str:
-        if (domain == "") or (domain == "ai.onnx"):
+        if domain in {"", "ai.onnx"}:
             return f"from onnxscript.onnx_opset import opset{version}\n"
         else:
             varname = self.make_opset_name(domain, version)
             return f"{varname} = Opset('{domain}', {version})\n"
 
     def translate_opset_imports(self, opset_imports: Sequence[onnx.OperatorSetIdProto]) -> str:
-        return "".join([self.translate_opset_import(x.domain, x.version) for x in opset_imports])
+        return "".join(
+            [self.translate_opset_import(x.domain, x.version) for x in opset_imports]
+        )
 
-    def translate_opset_imports_of(self, proto: ModelProto | FunctionProto | GraphProto ) -> str:
+    def translate_opset_imports_of(
+        self, proto: ModelProto | FunctionProto | GraphProto
+    ) -> str:
         if hasattr(proto, "opset_import"):
             text = self.translate_opset_imports(proto.opset_import)
             if isinstance(proto, FunctionProto):

--- a/onnxscript/backend/onnx_export.py
+++ b/onnxscript/backend/onnx_export.py
@@ -450,7 +450,8 @@ class Exporter:
         if hasattr(proto, "opset_import"):
             text = self.translate_opset_imports(proto.opset_import)
             if isinstance(proto, FunctionProto):
-                text += self.translate_opset_import(proto.domain, 1)
+                if not any(x.domain == proto.domain for x in proto.opset_import):
+                    text += self.translate_opset_import(proto.domain, 1)
             return text
         return ""
 


### PR DESCRIPTION
The existing exporter creates invalid python identifiers like "onnxscript.atenlib1" when generating variable names for opsets. Change this to create a name like "onnxscript_atenlib1".