### PR TITLE
Add the opname property to OnnxFunction for BC | fix(api)

### DIFF
--- a/onnxscript/_internal/deprecation.py
+++ b/onnxscript/_internal/deprecation.py
@@ -1,0 +1,76 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Utility for deprecating APIs."""
+
+# Reference: https://github.com/pytorch/pytorch/blob/aed9bee0413dac190452fbfa9ab2a44b6e6843f5/torch/onnx/_deprecation.py
+
+import functools
+import textwrap
+from typing import Callable, TypeVar
+import warnings
+
+
+T = TypeVar("T")
+
+def deprecated(since: str, removed_in: str, instructions: str) -> Callable[[T], T]:
+    """Marks functions as deprecated.
+
+    It will result in a warning when the function is called and a note in the
+    docstring.
+
+    Args:
+        since: The version when the function was first deprecated.
+        removed_in: The version when the function will be removed.
+        instructions: The action users should take.
+
+    Returns:
+        A decorator that can be used to mark functions as deprecated.
+    """
+
+    def decorator(function):
+        @functools.wraps(function)
+        def wrapper(*args, **kwargs):
+            warnings.warn(
+                f"'{function.__module__}.{function.__qualname__}' "
+                f"is deprecated in version {since} and will be "
+                f"removed in {removed_in}. Please {instructions}.",
+                category=FutureWarning,
+                stacklevel=2,
+            )
+            return function(*args, **kwargs)
+
+        # Add a deprecation note to the docstring.
+        docstring = function.__doc__ or ""
+
+        # Add a note to the docstring.
+        deprecation_note = textwrap.dedent(
+            f"""\
+            .. deprecated:: {since}
+                Deprecated and will be removed in version {removed_in}.
+                Please {instructions}.
+            """
+        )
+
+        # Split docstring at first occurrence of newline
+        summary_and_body = docstring.split("\n\n", 1)
+
+        if len(summary_and_body) > 1:
+            summary, body = summary_and_body
+
+            # Dedent the body. We cannot do this with the presence of the summary because
+            # the body contains leading whitespaces when the summary does not.
+            body = textwrap.dedent(body)
+
+            new_docstring_parts = [deprecation_note, "\n\n", summary, body]
+        else:
+            summary = summary_and_body[0]
+
+            new_docstring_parts = [deprecation_note, "\n\n", summary]
+
+        wrapper.__doc__ = "".join(new_docstring_parts)
+
+        return wrapper
+
+    return decorator

--- a/onnxscript/_internal/deprecation.py
+++ b/onnxscript/_internal/deprecation.py
@@ -8,11 +8,11 @@
 
 import functools
 import textwrap
-from typing import Callable, TypeVar
 import warnings
-
+from typing import Callable, TypeVar
 
 T = TypeVar("T")
+
 
 def deprecated(since: str, removed_in: str, instructions: str) -> Callable[[T], T]:
     """Marks functions as deprecated.

--- a/onnxscript/values.py
+++ b/onnxscript/values.py
@@ -18,7 +18,7 @@ import onnx.defs
 
 from onnxscript import converter as converter_module
 from onnxscript import irbuilder, sourceinfo, type_annotation
-from onnxscript._internal import ast_utils
+from onnxscript._internal import ast_utils, deprecation
 
 _ATTRIBUTE_TYPE_TO_PYTHON_TYPE = {
     onnx.defs.OpSchema.AttrType.FLOAT: float,
@@ -472,6 +472,17 @@ class OnnxFunction(Op):
         self.kwargs = kwargs
         self._param_schemas: Optional[tuple[ParamSchema, ...]] = None
         self._op_schema: Optional[onnx.defs.OpSchema] = None
+
+    @property
+    @deprecation.deprecated(
+        since="0.1",
+        removed_in="0.3",
+        instructions="use '.name' instead",
+    )
+    def opname(self) -> str:
+        # NOTE: This is a temporary alias for backward compatibility for PyTorch 2.0.
+        # TODO: Remove this in onnxscript 0.3.
+        return self.name
 
     @property
     def op_schema(self) -> Optional[onnx.defs.OpSchema]:

--- a/onnxscript/values.py
+++ b/onnxscript/values.py
@@ -480,7 +480,7 @@ class OnnxFunction(Op):
         instructions="use '.name' instead",
     )
     def opname(self) -> str:
-        # NOTE: This is a temporary alias for backward compatibility for PyTorch 2.0.
+        # NOTE: This is a temporary alias for backward compatibility with PyTorch 2.0.
         # TODO: Remove this in onnxscript 0.3.
         return self.name
 


### PR DESCRIPTION
Add the opname property to OnnxFunction for backward compatibility with PyTorch 2.0. Marked as deprecated.

`test.py`

```python
import onnxscript
from onnxscript.onnx_opset import opset18 as op
custom_opset = onnxscript.values.Opset(domain="torch_onnx", version=1)


#'LGamma'
@onnxscript.script(custom_opset)
def LGamma(X):
    abs_gamma_x = op.Abs(X)
    output = op.Log(abs_gamma_x)
    return output
```

Result:

```
>>> import test
>>> test.LGamma.opname
<stdin>:1: FutureWarning: 'onnxscript.values.OnnxFunction.opname' is deprecated in version 0.1 and will be removed in 0.3. Please use '.name' instead.
'LGamma'
```