### PR TITLE
Compare value or shape for specified outputs | test(torchlib)

### DIFF
--- a/onnxscript/tests/function_libs/torch_lib/ops_test.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test.py
@@ -252,7 +252,10 @@ def run_test_output_match(
                         else torch.tensor(torch_output)
                     )
 
-                    if op.name in ops_test_data.NONDETERMINISTIC_OPS:
+                    if (
+                        op.name in ops_test_data.NONDETERMINISTIC_OPS
+                        or j in ops_test_data.COMPARE_SHAPE_ONLY_OPS[op.name]
+                    ):
                         # Check shape and dtype only for ops that are known to be
                         # nondeterministic
                         test_suite.assertEqual(actual.shape, expected.shape)

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -2014,7 +2014,9 @@ NONDETERMINISTIC_OPS: frozenset[str] = frozenset(
 COMPARE_SHAPE_ONLY_OPS: dict[
     str,
     set,
-] = {info.op_info_name: set(info.compare_shape_only_for_output) for info in TESTED_TORCHLIB_OPS}
+] = {
+    info.op_info_name: set(info.compare_shape_only_for_output) for info in TESTED_TORCHLIB_OPS
+}
 
 TORCHLIB_OPINFO_MAPPING: dict[
     str,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1033,14 +1033,14 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         core_ops.aten_embedding_bag,
         tolerance={torch.float16: (1e-2, 1e-2)},
         trace_only=True,
-        compare_shape_only_for_output=(1,2,3),
+        compare_shape_only_for_output=(1, 2, 3),
     ),
     TorchLibOpInfo(
         "ops.aten.embedding_bag.padding_idx",
         core_ops.aten_embedding_bag_padding_idx,
         trace_only=True,
         tolerance={torch.float16: (1e-2, 1e-2)},
-        compare_shape_only_for_output=(1,2,3),
+        compare_shape_only_for_output=(1, 2, 3),
     ),
     TorchLibOpInfo(
         "nn.functional.embedding",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -79,7 +79,7 @@ class TorchLibOpInfo:
     nondeterministic: bool = False
     # Whether to compare the shape only for the output[index]
     # For example: (1,2) means compare value for output[0] and shape for output[1] and [2]
-    # Maybe can combine with nondeterminstic setting
+    # We may be able to combine this with the nondeterminstic option
     compare_shape_only_for_output: tuple[int] = ()
     # Whether the function is designed for complex inputs
     complex: bool = False
@@ -2010,8 +2010,8 @@ NONDETERMINISTIC_OPS: frozenset[str] = frozenset(
 
 COMPARE_SHAPE_ONLY_OPS: dict[
     str,
-    tuple,
-] = {info.op_info_name: info.compare_shape_only_for_output for info in TESTED_TORCHLIB_OPS}
+    set,
+] = {info.op_info_name: set(info.compare_shape_only_for_output) for info in TESTED_TORCHLIB_OPS}
 
 TORCHLIB_OPINFO_MAPPING: dict[
     str,


### PR DESCRIPTION
Add one property for TorchLibOpInfo.compare_shape_only_for_output, the value is tuple(int), for example, 
```
    TorchLibOpInfo(
        "ops.aten.embedding_bag",
        core_ops.aten_embedding_bag,
        tolerance={torch.float16: (1e-2, 1e-2)},
        trace_only=True,
        compare_shape_only_for_output=(1,2,3),
    ),
```
The ```(1,2,3)``` means compare value for output[0], and compare shape for output[1],[2],[3]