### PR TITLE
Update beartype version | ci

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -13,7 +13,7 @@ COMMON_TEST_DEPENDENCIES = (
     "jinja2",
     "numpy==1.23.5",
     "typing_extensions",
-    "beartype",
+    "beartype!=0.16.0",
     "types-PyYAML",
     "expecttest",
     "hypothesis",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ sphinx-gallery
 sphinx>=6
 
 # Torch lib
-beartype
+beartype!=0.16.0
 
 # Testing
 expecttest


### PR DESCRIPTION
Avoid 0.16.0 because of https://github.com/beartype/beartype/issues/282