### PR TITLE
New graph api prototype

### DIFF
--- a/onnxscript/function_libs/torch_lib/new_graph_prototype.py
+++ b/onnxscript/function_libs/torch_lib/new_graph_prototype.py
@@ -1,0 +1,378 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import numpy as np
+import onnx.helper
+from onnx import TensorProto
+
+from onnxscript import onnx_opset
+from onnxscript._internal import autocast
+
+from typing import Any, Mapping, Optional, Sequence, List, Dict, Tuple, Union
+
+import numpy as np
+import onnx
+import onnx.checker
+import onnx.defs
+import onnx.helper
+import onnx.shape_inference
+from typing_extensions import TypeAlias
+
+import onnxscript
+from onnxscript import evaluator
+from onnxscript._internal import param_manipulation, runtime_typing
+
+import dataclasses
+
+__all__ = [
+    "Graph",
+    "TorchScriptTracingEvaluator",
+]
+
+
+ValidArgumentType: TypeAlias = Union[
+    "TorchScriptTensor",
+    Sequence["TorchScriptTensor"],
+    Sequence[float],
+    Sequence[int],
+    str,
+    int,
+    float,
+    bool,
+    None,
+]
+ValidInputType: TypeAlias = Union[
+    "TorchScriptTensor",
+    Sequence["TorchScriptTensor"],
+    Sequence[float],
+    Sequence[int],
+    str,
+    int,
+    float,
+    bool,
+    None,
+]
+ValidTorchValueType: TypeAlias = Union[
+    torch.Value,
+    Sequence[torch.Value],
+    Sequence[float],
+    Sequence[int],
+    str,
+    int,
+    float,
+    bool,
+    None,
+]
+
+
+class Tensor:
+    """An implementation of ONNX Tensors, based on a wrapper around numpy arrays.
+    Serves to define overloaded ops with an ONNX/ONNXScript semantics.
+    """
+
+    def __init__(self, nparray: Optional[np.ndarray], opset=None):
+        if nparray is not None and not isinstance(nparray, np.ndarray):
+            raise TypeError(
+                f"Unexpected type {type(nparray)}. It must be a numpy array or None."
+            )
+
+        self._nparray = nparray
+        # FIXME(justinhuby): Create a better way to determine the opset version
+        self._opset: Any = opset or onnx_opset.opset18
+
+    @property
+    def value(self) -> np.ndarray:
+        if self._nparray is None:
+            raise ValueError("Tensor does not have a value.")
+        return self._nparray
+
+    @property
+    def rank(self) -> int:
+        return len(self.value.shape)
+
+    @property
+    def is_scalar(self) -> bool:
+        return self.rank == 0
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return self.value.shape
+
+    @property
+    def dtype(self) -> np.dtype:
+        return self.value.dtype
+
+    @property
+    def onnx_dtype(self) -> int:
+        return onnx.helper.np_dtype_to_tensor_dtype(self.dtype)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.value!r})"
+
+    def __bool__(self) -> bool:
+        return bool(self.value)
+
+    def __int__(self) -> int:
+        return int(self.value)
+
+    def __float__(self) -> float:
+        return float(self.value)
+
+    def __len__(self) -> int:
+        return self.shape[0]
+
+    def __index__(self) -> int:
+        return self.value.__index__()
+
+    def __getitem__(self, index):
+        op = self._opset
+        if op.version < 13:
+            raise RuntimeError("Indexing requires opset 13 or later.")
+        if not isinstance(index, tuple):
+            # Normalize representation to a tuple.
+            # A single index-value is equivalent to a tuple with a single element.
+            index = (index,)
+        if len(index) > self.rank:
+            raise ValueError(
+                f"Number of indices {len(index)} is greater than rank {self.rank}"
+            )
+
+        # Promote integer indices to tensors of rank 0
+        index = [autocast.cast_pyvalue_to_os_tensor(x) for x in index]
+        # Process all elements in index
+        shape = self.shape
+        sliced_indices = []
+        scalar_indices = []
+        to_squeeze = []
+        non_scalar_indices = []
+        for axis_, s in enumerate(index):
+            if isinstance(s, slice):
+                if s.start is None and s.stop is None and s.step is None:
+                    continue
+                if s.step is None or s.step > 0:
+                    sliced_indices.append(
+                        [
+                            s.start or 0,
+                            s.stop if s.stop is not None else shape[axis_],
+                            axis_,
+                            s.step or 1,
+                        ]
+                    )
+                else:
+                    sliced_indices.append(
+                        [
+                            s.start if s.start is not None else (shape[axis_] - 1),
+                            s.stop if s.stop is not None else -(shape[axis_] + 1),
+                            axis_,
+                            s.step,
+                        ]
+                    )
+            elif isinstance(s, Tensor):
+                if s.is_scalar:
+                    scalar_indices.append([s, s + 1, axis_, 1])
+                    to_squeeze.append(axis_)
+                else:
+                    non_scalar_indices.append((axis_, s))
+            else:
+                raise TypeError(f"Unexpected type {type(s)}: slice or int expected.")
+
+        # Non-scalar-indexing requires the use of ONNX Gather operation.
+        # Slicing can be implemented efficiently using ONNX's Slice operation.
+        # Scalar-indexing can be implemented using either Gather or with the Slice operation.
+        # We map scalar-indexing into the Slice operation, except in the special case
+        # of a single scalar-index (with no other sliced_index), which we map directly
+        # to a Gather.
+
+        if not (sliced_indices or scalar_indices or non_scalar_indices):
+            # Edge case: no index specified. Eg. A[:, :]
+            return op.Identity(self)
+        if not sliced_indices and len(scalar_indices) == 1:
+            # Special case of indexing along a single axis: A[i], A[:, i], A[:, :, i] etc.
+            # promote integer input to tensor
+            axis = to_squeeze[0]
+            index_value = index[axis]
+            # use Gather to perform indexing
+            result = op.Gather(self, index_value, axis=axis)
+        elif sliced_indices or scalar_indices:
+            sliced_indices = sliced_indices + scalar_indices
+            indices = np.array(sliced_indices, dtype=np.int64).T
+            starts = Tensor(indices[0])
+            ends = Tensor(indices[1])
+            axes = Tensor(indices[2])
+            steps = Tensor(indices[3])
+            result = op.Slice(self, starts, ends, axes, steps)
+            if to_squeeze:
+                result = Tensor(np.squeeze(result.value, axis=tuple(to_squeeze)))
+        else:
+            result = self
+        for axis, value in non_scalar_indices:
+            result = op.Gather(result, value, axis=axis)
+
+        return result
+
+    def __mod__(self, other):
+        if self.onnx_dtype in {
+            TensorProto.FLOAT,
+            TensorProto.DOUBLE,
+            TensorProto.FLOAT16,
+            TensorProto.BFLOAT16,
+        }:
+            return self._opset.Mod(self, other, fmod=1)
+        return self._opset.Mod(self, other)
+
+    def __ne__(self, other):
+        temp = self._opset.Equal(self, other)
+        return self._opset.Not(temp)
+
+    def __neg__(self):
+        return self._opset.Neg(self)
+
+    def __add__(self, other):
+        return self._opset.Add(self, other)
+
+    def __radd__(self, other):
+        return self._opset.Add(other, self)
+
+    def __and__(self, other):
+        return self._opset.And(self, other)
+
+    def __rand__(self, other):
+        return self._opset.And(other, self)
+
+    def __mul__(self, other):
+        return self._opset.Mul(self, other)
+
+    def __rmul__(self, other):
+        return self._opset.Mul(other, self)
+
+    def __matmul__(self, other):
+        return self._opset.MatMul(self, other)
+
+    def __or__(self, other):
+        return self._opset.Or(self, other)
+
+    def __pow__(self, other):
+        return self._opset.Pow(self, other)
+
+    def __sub__(self, other):
+        return self._opset.Sub(self, other)
+
+    def __rsub__(self, other):
+        return self._opset.Sub(other, self)
+
+    def __truediv__(self, other):
+        return self._opset.Div(self, other)
+
+    def __lt__(self, other):
+        return self._opset.Less(self, other)
+
+    def __le__(self, other):
+        return self._opset.LessOrEqual(self, other)
+
+    def __eq__(self, other):
+        return self._opset.Equal(self, other)
+
+    def __ge__(self, other):
+        return self._opset.GreaterOrEqual(self, other)
+
+    def __gt__(self, other):
+        return self._opset.Greater(self, other)
+
+###################################################################################################
+
+
+@dataclasses.dataclass(frozen=True, eq=True)
+class Node:
+
+    function: Optional[onnxscript.OnnxFunction] = None
+    namespace: str
+    op_name: str
+    inputs: Sequence[ValidInputType]
+    attributes: Mapping[str, ValidTorchValueType]
+    # TODO(titaiwang): define better outputs or only use "number of outputs"
+    n_outputs: int
+    # TODO(titaiwang): Will this work?
+    is_function: bool = function is not None
+
+    @classmethod
+    def from_op_schema(cls, op_schema: onnx.defs.OpSchema, inputs, attributes, n_outputs) -> Node:
+        namespace = op_schema.domain
+        op_name = op_schema.name
+        return cls(function=None, namespace=namespace, op_name=op_name, inputs=inputs, attributes=attributes, outputs=n_outputs)
+
+    @classmethod
+    def from_function(cls, onnx_function: onnxscript.OnnxFunction, inputs, attributes, n_outputs) -> Node:
+        namespace = onnx_function.function_ir.domain
+        op_name = onnx_function.name
+        return cls(function=onnx_function, namespace=namespace, op_name=op_name, inputs=inputs, attributes=attributes, outputs=n_outputs)
+
+
+class Graph:
+    def __init__(self) -> None:
+        # All the functions used, deduplicated by name
+        # key: (name, domain)
+        self._function_store: Dict[Tuple[str, str], onnxscript.OnnxFunction] = {}
+        self._nodes: List[Node] = []
+        self._inputs: List[Tensor] = []
+        self._outputs: List[Tensor] = []
+
+    def add_node(self, node: Node):
+        if node.is_function:
+            identifier = (node.op_name, node.namespace)
+            self._function_store[identifier] = node.function
+        self._nodes.append(node)
+
+    def add_input(self, tensor: Tensor):
+        self._inputs.append(tensor)
+    
+    def add_output(self, tensor: Tensor):
+        self._outputs.append(tensor)
+    
+        
+class GraphEvaluator(evaluator.Evaluator):
+    """An onnxscript Evaluator that captures the graph into torchscript."""
+
+    def __init__(self, graph: Graph):
+        self._graph: Graph = graph
+
+    @property
+    def graph(self) -> Graph:
+        return self._graph
+
+    def eval(self, op_schema, inputs, attributes):
+        n_outputs = evaluator.compute_num_outputs(op_schema, inputs, attributes)
+        node = Node.from_op_schema(op_schema, inputs, attributes, n_outputs)
+        return self._graph.add_node(node)
+
+    @runtime_typing.checked
+    def eval_function(  # type: ignore[override]
+        self,
+        function: onnxscript.OnnxFunction,
+        args: Sequence[ValidArgumentType],
+        kwargs: Mapping[str, ValidArgumentType],
+    ):
+        # args/kwargs are TorchScriptTensor/python built-in based
+        param_schemas = function.param_schemas()
+        (
+            inputs,
+            attributes,
+        ) = param_manipulation.separate_input_attributes_from_arguments(
+            param_schemas, args, kwargs, fill_defaults=True, allow_extra_kwargs=True
+        )
+        name_to_schema = {param.name: param for param in param_schemas}
+        # TODO(titaiwang): DO we still need this?
+        for name, value in attributes.items():
+            param = name_to_schema[name]
+            # Cast int to float if needed
+            if param.type in {float, "float"}:
+                # FIXME(justinchuby): Create invariant on the type of param.type to simplify this
+                attributes[name] = float(value)
+        # NOTE: Initialize node
+        node = Node.from_function(function, inputs, attributes, outputs=len(function.function_ir.outputs))
+        return self._graph.add_node(node)

--- a/onnxscript/function_libs/torch_lib/new_graph_prototype.py
+++ b/onnxscript/function_libs/torch_lib/new_graph_prototype.py
@@ -19,7 +19,7 @@ from typing_extensions import TypeAlias
 import onnxscript
 from onnxscript import evaluator, onnx_opset
 from onnxscript import tensor as onnxscript_tensor
-from onnxscript._internal import runtime_typing
+from onnxscript._internal import param_manipulation, runtime_typing
 
 __all__ = [
     "Graph",
@@ -48,16 +48,22 @@ class GraphTensor(onnxscript_tensor.Tensor):
 
     def __init__(
         self,
-        torch_tensor: torch.Tensor,
         name: str,
-        opset=None,
         onnx_type: str = "tensor_type",
+        opset=None,
+        torch_tensor: Optional[torch.Tensor] = None,
     ):
         super().__init__(None)
         self._name = name
         self._torch_tensor = torch_tensor
-        self._shape: tuple[int, ...] = torch_tensor.shape
-        self._dtype: torch.dtype = torch_tensor.dtype
+        if torch_tensor is None:
+            self._shape = None
+            self._dtype = None
+        else:
+            self._dtype = torch_tensor.dtype
+            self._shape = tuple(
+                dim if isinstance(dim, int) else str(dim) for dim in torch_tensor.size()
+            )
         # FIXME(justinhuby): Create a better way to determine the opset version
         self._opset: Any = opset or onnx_opset.opset18
 
@@ -70,23 +76,27 @@ class GraphTensor(onnxscript_tensor.Tensor):
             )
         self._onnx_type = onnx_type
 
-    def to_tensor_proto(self):
-        pass
+    def to_tensor_proto(self) -> onnx.TensorProto:
+        if self.value is None:
+            raise ValueError("Tensor value is None")
+        return onnx.numpy_helper.from_array(self.value.cpu().numpy(), self.name)
 
     def to_value_info(self) -> onnx.ValueInfoProto:
+        if self.dtype is None:
+            return onnx.helper.make_empty_tensor_value_info(self.name)
         # TODO: support more types?
-        if self.onnx_type == "tensot_type":
-            return onnx.helper.make_tensor_value_info(self.name, self.onnx_dtype, self.shape)
+        if self.onnx_type == "tensor_type":
+            return onnx.helper.make_tensor_value_info(self.name, self.onnx_dtype, self.shape)  # type: ignore[arg-type]
         if self.onnx_type == "sequence_type":
             return onnx.helper.make_tensor_sequence_value_info(
-                self.name, self.onnx_dtype, self.shape
+                self.name, self.onnx_dtype, self.shape  # type: ignore[arg-type]
             )
         if self.onnx_type == "optional_type":
             # NOTE: no `make_optional_value_info` API
-            element_type = onnx.helper.make_tensor_type_proto(self.onnx_dtype, self.shape)
+            element_type = onnx.helper.make_tensor_type_proto(self.onnx_dtype, self.shape)  # type: ignore[arg-type]
             optional_type_proto = onnx.helper.make_optional_type_proto(element_type)
             return onnx.helper.make_value_info(self.name, optional_type_proto)
-        return onnx.helper.make_empty_tensor_value_info(self.name)
+        raise ValueError(f"Invalid onnx type: {self.onnx_type}")
 
     # TODO: better way to find out if it's a fake tensor?
     @property
@@ -95,45 +105,71 @@ class GraphTensor(onnxscript_tensor.Tensor):
             fake_tensor,
         )
 
-        return isinstance(self._torch_tensor, fake_tensor.FakeTensor)
+        return isinstance(self.value, fake_tensor.FakeTensor) or self.value is None
 
     @property
-    def np_dtype(self) -> np.dtype:
+    def np_dtype(self) -> Optional[np.dtype]:
         from torch.onnx._internal.fx import (  # pylint: disable=import-outside-toplevel
             type_utils,
         )
 
-        return type_utils.from_torch_dtype_to_numpy_dtype(self.dtype)
+        return type_utils.from_torch_dtype_to_np_dtype(self.dtype) if self.dtype else None
 
     @property
     def onnx_type(self) -> str:
         return self._onnx_type
 
+    @onnx_type.setter
+    def onnx_type(self, onnx_type: str):
+        if onnx_type not in {"tensor_type", "sequence_type", "optional_type"}:
+            raise ValueError(
+                f"Invalid onnx type: {onnx_type}, must be one of the three: tensor_type, sequence_type, optional_type"
+            )
+        self._onnx_type = onnx_type
+
     @property
     def name(self) -> str:
         return self._name
 
-    @property
-    def value(self) -> torch.Tensor:  # type: ignore[override]
+    @name.setter
+    def name(self, name: str):
+        self._name = name
+
+    @property  # type: ignore[override]
+    def value(self) -> Optional[torch.Tensor]:
         return self._torch_tensor
 
-    @property
-    def shape(self) -> tuple[int, ...]:
+    @property  # type: ignore[override]
+    def shape(self) -> Optional[tuple[int, ...]]:
         return self._shape
+
+    @shape.setter
+    def shape(self, shape: tuple[int, ...]):
+        self._shape = shape
 
     @property
     def rank(self) -> int:
-        return len(self.shape)
+        return len(self.shape) if self.shape is not None else 0
+
+    @property  # type: ignore[override]
+    def dtype(self) -> Optional[torch.dtype]:
+        from torch.onnx._internal.fx import (  # pylint: disable=import-outside-toplevel
+            type_utils,
+        )
+
+        if type_utils.is_torch_symbolic_type(self.value):
+            return type_utils.from_sym_value_to_torch_dtype(self.value)  # type: ignore[arg-type]
+        return self._dtype if self._dtype is not None else None
+
+    @dtype.setter
+    def dtype(self, dtype: torch.dtype):
+        self._dtype = dtype
 
     @property
-    def dtype(self) -> torch.dtype:  # type: ignore[override]
-        return self._dtype
-
-    @property
-    def onnx_dtype(self) -> int:
+    def onnx_dtype(self) -> Optional[int]:  # type: ignore[override]
         return (
             onnx.helper.np_dtype_to_tensor_dtype(self.np_dtype)
-            if self.dtype is not None
+            if self.np_dtype is not None
             else None
         )
 
@@ -148,21 +184,25 @@ class Node:
         op_name: str,
         inputs: List[GraphTensor],
         attributes: Dict[str, ValidArgumentType],
-        outputs: List[GraphTensor],
+        n_outputs: int,
     ):
         self._inputs = inputs
-        self._outputs = outputs
         self._attributes = attributes
         self._namespace = namespace
         self._op_name = op_name
+        self._outputs: List[GraphTensor] = [GraphTensor(name="")] * n_outputs
 
     @property
-    def inputs(self) -> List[GraphTensor]:
-        return self._inputs
+    def inputs(self) -> Tuple[GraphTensor, ...]:
+        return tuple(self._inputs)
 
     @property
-    def outputs(self) -> List[GraphTensor]:
-        return self._outputs
+    def outputs(self) -> Tuple[GraphTensor, ...]:
+        return tuple(self._outputs)
+
+    @outputs.setter
+    def outputs(self, outputs: List[GraphTensor]):
+        self._outputs = outputs
 
     @property
     def attributes(self) -> Dict[str, ValidArgumentType]:
@@ -194,13 +234,13 @@ class Node:
         op_schema: onnx.defs.OpSchema,
         inputs: List[GraphTensor],
         attributes: Dict[str, ValidArgumentType],
-        outputs: List[GraphTensor],
+        n_outputs: int,
     ) -> OpNode:
         return OpNode(
             opschema=op_schema,
             inputs=inputs,
             attributes=attributes,
-            outputs=outputs,
+            n_outputs=n_outputs,
         )
 
     @classmethod
@@ -209,13 +249,13 @@ class Node:
         onnx_function: onnxscript.OnnxFunction,
         inputs: List[GraphTensor],
         attributes: Dict[str, ValidArgumentType],
-        outputs: List[GraphTensor],
+        n_outputs: int,
     ) -> FunctionNode:
         return FunctionNode(
             function=onnx_function,
             inputs=inputs,
             attributes=attributes,
-            outputs=outputs,
+            n_outputs=n_outputs,
         )
 
     @classmethod
@@ -223,7 +263,7 @@ class Node:
         return ModuleNode(
             subgraph=subgraph,
             inputs=inputs,
-            outputs=subgraph.outputs,
+            n_outputs=len(subgraph.outputs),  # type: ignore[arg-type]
             name=name,
         )
 
@@ -234,14 +274,14 @@ class OpNode(Node):
         opschema: onnx.defs.OpSchema,
         inputs: List[GraphTensor],
         attributes: Dict[str, ValidArgumentType],
-        outputs: List[GraphTensor],
+        n_outputs: int,
     ):
         super().__init__(
             namespace=opschema.domain,
             op_name=opschema.name,
             inputs=inputs,
             attributes=attributes,
-            outputs=outputs,
+            n_outputs=n_outputs,
         )
         self._opschema = opschema
 
@@ -255,14 +295,14 @@ class FunctionNode(Node):
         function: onnxscript.OnnxFunction,
         inputs: List[GraphTensor],
         attributes: Dict[str, ValidArgumentType],
-        outputs: List[GraphTensor],
+        n_outputs: int,
     ):
         super().__init__(
             namespace=function.function_ir.domain,
             op_name=function.name,
             inputs=inputs,
             attributes=attributes,
-            outputs=outputs,
+            n_outputs=n_outputs,
         )
         self._function = function
 
@@ -272,15 +312,13 @@ class FunctionNode(Node):
 
 
 class ModuleNode(Node):
-    def __init__(
-        self, subgraph: Graph, inputs: List[GraphTensor], outputs: List[GraphTensor], name: str
-    ):
+    def __init__(self, subgraph: Graph, inputs: List[GraphTensor], n_outputs: int, name: str):
         super().__init__(
             namespace=subgraph.domain_name,  # type: ignore[arg-type]
             op_name=name,
             inputs=inputs,
             attributes={},
-            outputs=outputs,
+            n_outputs=n_outputs,
         )
         self._subgraph = subgraph
 
@@ -292,9 +330,9 @@ class ModuleNode(Node):
 class Graph:
     def __init__(
         self,
-        producer_name="pytorch",
         parent_graph: Optional[Graph] = None,
         domain_name: Optional[str] = None,
+        producer_name: str = "pytorch",
         opset_version: int = 18,
     ) -> None:
         # All the functions used, deduplicated by name
@@ -302,13 +340,13 @@ class Graph:
         self._function_store: Dict[Tuple[str, str], onnxscript.OnnxFunction] = {}
         self._nodes: List[Node] = []
         self._inputs: List[GraphTensor] = []
-        self._outputs: List[GraphTensor] = []
+        self._outputs: Optional[Tuple[GraphTensor]] = None
         self._initializers: Dict[str, GraphTensor] = {}
         self._producer_name: str = producer_name
         self._opset_version: int = opset_version
-        # TODO: what are these two string for?
+        # TODO: what is doc_string for?
         self._doc_string: str = ""
-        self._name: str = ""
+        self._name: str = "main_graph" if parent_graph is None else "sub_graph"
         # NOTE: below are used by splitting subgraphs
         # Mapping from intializer name to input(ensor).
         self._initializers_inputs: Dict[str, GraphTensor] = {}
@@ -338,20 +376,20 @@ class Graph:
         return self._producer_name
 
     @property
-    def outputs(self) -> List[GraphTensor]:
-        return self._outputs
+    def outputs(self) -> Optional[Tuple[GraphTensor, ...]]:
+        return tuple(self._outputs) if self._outputs is not None else None
 
     @property
     def domain_name(self) -> Optional[str]:
         return self._domain_name
 
     @property
-    def inputs(self) -> List[GraphTensor]:
-        return self._inputs
+    def inputs(self) -> Tuple[GraphTensor, ...]:
+        return tuple(self._inputs)
 
     @property
-    def nodes(self) -> List[Node]:
-        return self._nodes
+    def nodes(self) -> Tuple[Node, ...]:
+        return tuple(self._nodes)
 
     @property
     def doc_string(self) -> str:
@@ -374,8 +412,8 @@ class Graph:
         self._inputs.append(tensor)
 
     @runtime_typing.checked
-    def add_output(self, tensor: GraphTensor):
-        self._outputs.append(tensor)
+    def add_outputs(self, tensor: Tuple[GraphTensor, ...]):
+        self._outputs = tensor  # type: ignore[assignment]
 
     # TODO(titaiwang): this function is not friendly to users when
     # they want to build the graph from scratch, as they need to
@@ -409,11 +447,11 @@ class Graph:
 
     def _get_constant_tensors(self) -> Dict[str, GraphTensor]:
         input_const = [tensor for tensor in self._inputs if not tensor.is_fake]
-        output_const = [tensor for tensor in self._outputs if not tensor.is_fake]
+        output_const = [tensor for tensor in self._outputs if not tensor.is_fake]  # type: ignore[union-attr]
         node_related_const = [
             tensor
             for node in self._nodes
-            for tensor in (node.inputs + node.outputs)  # TODO: outputs?
+            for tensor in (node.inputs + node.outputs)
             if not tensor.is_fake
         ]
         return {
@@ -460,7 +498,7 @@ class Graph:
             domain=domain,
             fname=name,
             inputs=[input.name for input in self.inputs],
-            outputs=[output.name for output in self.outputs],
+            outputs=[output.name for output in self.outputs],  # type: ignore[union-attr]
             nodes=node_value_infos,
             opset_imports=[
                 onnx.helper.make_opsetid(domain, self.opset_version)
@@ -473,7 +511,7 @@ class Graph:
     def _to_onnx_graph(self) -> onnx.GraphProto:
         # convert tensor to tensor value info according to the onnx_type
         input_value_infos = [tensor.to_value_info() for tensor in self._inputs]
-        output_value_infos = [tensor.to_value_info() for tensor in self._outputs]
+        output_value_infos = [tensor.to_value_info() for tensor in self._outputs]  # type: ignore[union-attr]
         # convert initializer
         initializer = [
             constant_tensor.to_tensor_proto() for constant_tensor in self.initializers.values()
@@ -502,12 +540,12 @@ class Graph:
         for function_proto in function_proto_dict.values():
             # TODO(BowenBao): All local function domain versions are hardcoded as 1.
             unique_custom_domains[function_proto.domain] = 1
-
         model_proto = onnx.helper.make_model(
             graph_proto,
-            producer_name=self._producer_name,
+            producer_name=self.producer_name,
             doc_string=self.doc_string,
             functions=list(function_proto_dict.values()),
+            opset_imports=[onnx.helper.make_opsetid("", self.opset_version)],
         )
 
         # TODO: Do we still need this after using onnx.helper api?
@@ -524,7 +562,6 @@ class Graph:
                 for domain, version in unique_custom_domains.items()
             ]
         )
-
         model_proto = onnx.shape_inference.infer_shapes(
             model_proto, check_type=True, strict_mode=False, data_prop=True
         )
@@ -552,36 +589,38 @@ class GraphEvaluator(evaluator.Evaluator):
     def graph(self) -> Graph:
         return self._graph
 
-    # def eval(self, schema, inputs, attributes):
-    #     n_outputs = evaluator.compute_num_outputs(schema, inputs, attributes)
-    #     node = Node.from_op_schema(schema, inputs, attributes, outputs)
-    #     return self._graph.add_node(node)
+    def eval(self, schema, inputs, attributes):
+        n_outputs = evaluator.compute_num_outputs(schema, inputs, attributes)
+        node = Node.from_op_schema(schema, inputs, attributes, n_outputs)
+        self._graph.add_node(node)
+        return node.outputs
 
-    # @runtime_typing.checked
-    # def eval_function(  # type: ignore[override]
-    #     self,
-    #     function: onnxscript.OnnxFunction,
-    #     args: Sequence[ValidArgumentType],
-    #     kwargs: Mapping[str, ValidArgumentType],
-    # ):
-    #     # args/kwargs are TorchScriptTensor/python built-in based
-    #     param_schemas = function.param_schemas()
-    #     (
-    #         inputs,
-    #         attributes,
-    #     ) = param_manipulation.separate_input_attributes_from_arguments(
-    #         param_schemas, args, kwargs, fill_defaults=True, allow_extra_kwargs=True
-    #     )
-    #     name_to_schema = {param.name: param for param in param_schemas}
-    #     # TODO(titaiwang): DO we still need this?
-    #     for name, value in attributes.items():
-    #         param = name_to_schema[name]
-    #         # Cast int to float if needed
-    #         if param.type in {float, "float"}:
-    #             # FIXME(justinchuby): Create invariant on the type of param.type to simplify this
-    #             attributes[name] = float(value)
-    #     # NOTE: Initialize node
-    #     node = Node.from_function(
-    #         function, inputs, attributes, outputs=function.function_ir.outputs
-    #     )
-    #     return self._graph.add_node(node)
+    @runtime_typing.checked
+    def eval_function(  # type: ignore[override]
+        self,
+        function: onnxscript.OnnxFunction,
+        args: Sequence[ValidArgumentType],
+        kwargs: Mapping[str, ValidArgumentType],
+    ):
+        # args/kwargs are TorchScriptTensor/python built-in based
+        param_schemas = function.param_schemas()
+        (
+            inputs,
+            attributes,
+        ) = param_manipulation.separate_input_attributes_from_arguments(
+            param_schemas, args, kwargs, fill_defaults=True, allow_extra_kwargs=True
+        )
+        name_to_schema = {param.name: param for param in param_schemas}
+        # TODO(titaiwang): DO we still need this?
+        for name, value in attributes.items():
+            param = name_to_schema[name]
+            # Cast int to float if needed
+            if param.type in {float, "float"}:
+                # FIXME(justinchuby): Create invariant on the type of param.type to simplify this
+                attributes[name] = float(value)
+        # NOTE: Initialize node
+        node = Node.from_function(
+            function, inputs, attributes, n_outputs=len(function.function_ir.outputs)
+        )
+        self._graph.add_node(node)
+        return node.outputs


### PR DESCRIPTION
Where we use PyTorch API: https://github.com/pytorch/pytorch/blob/main/torch/onnx/_internal/fx/fx_onnx_interpreter.py
The old API: https://github.com/microsoft/onnxscript/blob/main/onnxscript/function_libs/torch_lib/graph_building.py

Related issue and discussion: https://github.com/microsoft/onnx-converters-private/issues/158

The PR uses three component to build the graph: Tensor, Node, Graph.

Tensor:
- Add shape and dtype
- Add onnx_type
- Add `to_onnx_value_info()`
- TODO: Should we make `onnx_type` an object/class?

Node:
- inputs and outputs
- operators
- attributes
- onnx_function(optional)
- `to_node_proto()`

Graph:
- inputs and outputs
- initializers
- nodes
- function_store
- `to_onnx_model()`
- TODO: `load_from_onnx()`

TODO:
1. multiple outputs test
2. subgraph test
3. opset_imports
4. doc_string
5. Should we keep evaluator? We could use `add_node` to directly insert node into graph
6. graph sorting