### PR TITLE
Create the Rank and IsScalar shared functions | feat(torchlib)

### DIFF
--- a/onnxscript/function_libs/tools/torch_lib/deduce_type_constraints_test.py
+++ b/onnxscript/function_libs/tools/torch_lib/deduce_type_constraints_test.py
@@ -30,9 +30,7 @@ class TestDeduceTypeConstraints(unittest.TestCase):
         "_aten_embedding_bag_onnx",
         "_aten_embedding_bag_1d_padding_idx_onnx",
     )
-    _SKIP_FUNCTIONS_WITH_NESTED_FUNCTION = (
-        "aten_all",
-    )
+    _SKIP_FUNCTIONS_WITH_NESTED_FUNCTION = ("aten_all",)
 
     @parameterized.parameterized.expand(
         ((op,) for op in torch_lib_onnx_functions_from_registry()),

--- a/onnxscript/function_libs/tools/torch_lib/deduce_type_constraints_test.py
+++ b/onnxscript/function_libs/tools/torch_lib/deduce_type_constraints_test.py
@@ -30,7 +30,9 @@ class TestDeduceTypeConstraints(unittest.TestCase):
         "_aten_embedding_bag_onnx",
         "_aten_embedding_bag_1d_padding_idx_onnx",
     )
-    _SKIP_FUNCTIONS_WITH_NESTED_FUNCTION = ()
+    _SKIP_FUNCTIONS_WITH_NESTED_FUNCTION = (
+        "aten_all",
+    )
 
     @parameterized.parameterized.expand(
         ((op,) for op in torch_lib_onnx_functions_from_registry()),

--- a/onnxscript/function_libs/torch_lib/_constants.py
+++ b/onnxscript/function_libs/torch_lib/_constants.py
@@ -1,0 +1,3 @@
+"""Shared constants for the library."""
+
+DOMAIN = "pkg.onnxscript.torch_lib"

--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -728,7 +728,6 @@ class TorchScriptGraph:
             opset_imports=onnx_model.opset_import,
             doc_string=onnx_model.doc_string,
         )
-        # TODO: onnx.checker.check_function(onnx_function)?
         return onnx_function
 
     @runtime_typing.checked
@@ -811,6 +810,13 @@ class TorchScriptGraph:
                 onnx.helper.make_opsetid(domain, version)
                 for domain, version in unique_custom_domains.items()
             ]
+        )
+        # Include the library shared opset domain
+        # TODO: Remove after https://github.com/microsoft/onnxscript/issues/834 is fixed
+        onnx_model.opset_import.append(
+            onnx.helper.make_opsetid(
+                common_ops.common_opset.domain, common_ops.common_opset.version
+            )
         )
 
         try:

--- a/onnxscript/function_libs/torch_lib/ops/common.py
+++ b/onnxscript/function_libs/torch_lib/ops/common.py
@@ -1,9 +1,9 @@
 """Common operators shared in the torchlib library."""
 
 import onnxscript
-from onnxscript import INT64, BOOL
-from onnxscript import opset18 as op
 import onnxscript.values
+from onnxscript import BOOL, INT64
+from onnxscript import opset18 as op
 from onnxscript.function_libs.torch_lib import _constants, tensor_typing
 
 DOMAIN = f"{_constants.DOMAIN}.common"
@@ -25,11 +25,13 @@ common_opset = CommonOpset()
 # TODO(justinchuby): How does onnxscript know what an op is a function?
 # Or do we need onnxscript to support calling functions from a different module?
 
+
 @onnxscript.script(common_opset)
 def Rank(input: tensor_typing.TTensor) -> INT64:
     """Take the rank of the input tensor."""
 
     return op.Size(op.Shape(input))
+
 
 @onnxscript.script(common_opset)
 def IsScalar(input: tensor_typing.TTensor) -> BOOL:

--- a/onnxscript/function_libs/torch_lib/ops/common.py
+++ b/onnxscript/function_libs/torch_lib/ops/common.py
@@ -13,10 +13,10 @@ class CommonOpset(onnxscript.values.Opset):
     def __new__(cls):
         return onnxscript.values.Opset.__new__(cls, DOMAIN, 1)
 
-    def Rank(self, x: tensor_typing.TTensor) -> INT64:
+    def Rank(self, input: tensor_typing.TTensor) -> INT64:
         return Rank(x)
 
-    def IsScalar(self, x: tensor_typing.TTensor) -> BOOL:
+    def IsScalar(self, input: tensor_typing.TTensor) -> BOOL:
         return IsScalar(x)
 
 

--- a/onnxscript/function_libs/torch_lib/ops/common.py
+++ b/onnxscript/function_libs/torch_lib/ops/common.py
@@ -22,6 +22,7 @@ class CommonOpset(onnxscript.values.Opset):
 
 common_opset = CommonOpset()
 
+
 @onnxscript.script(common_opset)
 def Rank(input: tensor_typing.TTensor) -> INT64:
     """Take the rank of the input tensor."""

--- a/onnxscript/function_libs/torch_lib/ops/common.py
+++ b/onnxscript/function_libs/torch_lib/ops/common.py
@@ -22,4 +22,4 @@ def Rank(input: tensor_typing.TTensor) -> INT64:
 def IsScalar(input: tensor_typing.TTensor) -> BOOL:
     """Return whether the input has rank 0, or is a scalar."""
 
-    return op.Size(op.Shape(input)) == 0
+    return op.Equal(op.Size(op.Shape(input)), op.Constant(value_int=0))

--- a/onnxscript/function_libs/torch_lib/ops/common.py
+++ b/onnxscript/function_libs/torch_lib/ops/common.py
@@ -8,19 +8,7 @@ from onnxscript.function_libs.torch_lib import _constants, tensor_typing
 
 DOMAIN = f"{_constants.DOMAIN}.common"
 
-
-class CommonOpset(onnxscript.values.Opset):
-    def __new__(cls):
-        return onnxscript.values.Opset.__new__(cls, DOMAIN, 1)
-
-    def Rank(self, input: tensor_typing.TTensor) -> INT64:
-        return Rank(x)
-
-    def IsScalar(self, input: tensor_typing.TTensor) -> BOOL:
-        return IsScalar(x)
-
-
-common_opset = CommonOpset()
+common_opset = onnxscript.values.Opset(domain=DOMAIN, version=1)
 
 
 @onnxscript.script(common_opset)

--- a/onnxscript/function_libs/torch_lib/ops/common.py
+++ b/onnxscript/function_libs/torch_lib/ops/common.py
@@ -1,0 +1,38 @@
+"""Common operators shared in the torchlib library."""
+
+import onnxscript
+from onnxscript import INT64, BOOL
+from onnxscript import opset18 as op
+import onnxscript.values
+from onnxscript.function_libs.torch_lib import _constants, tensor_typing
+
+DOMAIN = f"{_constants.DOMAIN}.common"
+
+
+class CommonOpset(onnxscript.values.Opset):
+    def __new__(cls):
+        return onnxscript.values.Opset.__new__(cls, DOMAIN, 1)
+
+    def Rank(self, x: tensor_typing.TTensor) -> INT64:
+        return Rank(x)
+
+    def IsScalar(self, x: tensor_typing.TTensor) -> BOOL:
+        return IsScalar(x)
+
+
+common_opset = CommonOpset()
+
+# TODO(justinchuby): How does onnxscript know what an op is a function?
+# Or do we need onnxscript to support calling functions from a different module?
+
+@onnxscript.script(common_opset)
+def Rank(input: tensor_typing.TTensor) -> INT64:
+    """Take the rank of the input tensor."""
+
+    return op.Size(op.Shape(input))
+
+@onnxscript.script(common_opset)
+def IsScalar(input: tensor_typing.TTensor) -> BOOL:
+    """Return whether the input has rank 0, or is a scalar."""
+
+    return op.Size(op.Shape(input)) == 0

--- a/onnxscript/function_libs/torch_lib/ops/common.py
+++ b/onnxscript/function_libs/torch_lib/ops/common.py
@@ -22,10 +22,6 @@ class CommonOpset(onnxscript.values.Opset):
 
 common_opset = CommonOpset()
 
-# TODO(justinchuby): How does onnxscript know what an op is a function?
-# Or do we need onnxscript to support calling functions from a different module?
-
-
 @onnxscript.script(common_opset)
 def Rank(input: tensor_typing.TTensor) -> INT64:
     """Take the rank of the input tensor."""

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -30,6 +30,7 @@ from onnxscript import (
     UINT64,
     graph,
 )
+from onnxscript.function_libs.torch_lib.ops.common import common_opset
 from onnxscript.function_libs.torch_lib.registration import torch_op
 from onnxscript.function_libs.torch_lib.tensor_typing import (
     IntType,
@@ -48,7 +49,6 @@ from onnxscript.function_libs.torch_lib.tensor_typing import (
 )
 from onnxscript.onnx_opset import opset18 as op
 from onnxscript.onnx_types import TensorType
-from onnxscript.function_libs.torch_lib.ops.common import common_opset
 
 _INT64_MAX = 9223372036854775807
 _INT64_MIN = -9223372036854775808

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -48,6 +48,7 @@ from onnxscript.function_libs.torch_lib.tensor_typing import (
 )
 from onnxscript.onnx_opset import opset18 as op
 from onnxscript.onnx_types import TensorType
+from onnxscript.function_libs.torch_lib.ops.common import common_opset
 
 _INT64_MAX = 9223372036854775807
 _INT64_MIN = -9223372036854775808
@@ -320,8 +321,7 @@ def aten_align_to(self: TensorType, names: Sequence[str]) -> TensorType:
 def aten_all(self: TTensor) -> BOOL:
     """all(Tensor self) -> Tensor"""
 
-    self_rank = op.Size(op.Shape(self))
-    if self_rank == 0:
+    if common_opset.IsScalar(self):
         result = op.Cast(self, to=BOOL.dtype)
     else:
         self_bool = op.Cast(self, to=BOOL.dtype)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -30,7 +30,7 @@ from onnxscript import (
     UINT64,
     graph,
 )
-from onnxscript.function_libs.torch_lib.ops.common import common_opset
+from onnxscript.function_libs.torch_lib.ops import common as common_ops
 from onnxscript.function_libs.torch_lib.registration import torch_op
 from onnxscript.function_libs.torch_lib.tensor_typing import (
     IntType,
@@ -53,6 +53,8 @@ from onnxscript.onnx_types import TensorType
 _INT64_MAX = 9223372036854775807
 _INT64_MIN = -9223372036854775808
 _MATH_PI = math.pi
+IsScalar = common_ops.IsScalar
+Rank = common_ops.Rank
 
 
 @torch_op("aten::_local_scalar_dense")
@@ -321,7 +323,7 @@ def aten_align_to(self: TensorType, names: Sequence[str]) -> TensorType:
 def aten_all(self: TTensor) -> BOOL:
     """all(Tensor self) -> Tensor"""
 
-    if common_opset.IsScalar(self):
+    if IsScalar(self):
         result = op.Cast(self, to=BOOL.dtype)
     else:
         self_bool = op.Cast(self, to=BOOL.dtype)

--- a/onnxscript/function_libs/torch_lib/registration.py
+++ b/onnxscript/function_libs/torch_lib/registration.py
@@ -7,6 +7,7 @@ from types import FunctionType
 from typing import Any, Callable, Generator, Optional
 
 import onnxscript
+from onnxscript.function_libs.torch_lib import _constants
 
 # Regex that will match "<namespace>::<op_name>[.<overload>]"
 _QUALIFIED_OPERATOR_NAME_REGEX = re.compile(
@@ -119,7 +120,7 @@ def torch_op(
         func: FunctionType,
     ) -> onnxscript.OnnxFunction | onnxscript.values.TracedOnnxFunction:
         # Compile the function
-        custom_opset = onnxscript.values.Opset(domain="pkg.onnxscript.torch_lib", version=1)
+        custom_opset = onnxscript.values.Opset(domain=_constants.DOMAIN, version=1)
 
         processed_func: onnxscript.OnnxFunction | onnxscript.values.TracedOnnxFunction
         if trace_only:


### PR DESCRIPTION
This change introduces two shared operators `Rank` and `IsScalar`. They are used to replace the `Size(Shape())` pattern for code reuse and readability.

I used a hack to always include these shared functions in the model proto because without #834 we cannot dynamically add these functions to the model as they are used. I added a TODO for this.

The first usage is in `aten_all`. I will update the rest of the functions in a separate PR.

#1095 