### PR TITLE
Add Op(aten_assert_async) | feat(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -853,7 +853,9 @@ def aten_asinh(self: TFloat) -> TFloat:
 
 
 @torch_op("aten::_assert_async.msg")
-def aten_assert_async(self: TTensor) -> TTensor:
+def aten_assert_async(
+    self: TTensor, assert_msg: str = ""
+) -> TTensor:  # pylint: disable=unused-argument`
     """_assert_async.msg(Tensor self, str assert_msg) -> ()"""
 
     return op.Identity(self)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -852,6 +852,13 @@ def aten_asinh(self: TFloat) -> TFloat:
     return op.Asinh(self)
 
 
+@torch_op("aten::_assert_async.msg")
+def aten_assert_async(self: TTensor) -> TTensor:
+    """_assert_async.msg(Tensor self, str assert_msg) -> ()"""
+
+    return op.Identity(self)
+
+
 @torch_op("aten::atan")
 def aten_atan(self: TFloat) -> TFloat:
     """atan(Tensor self) -> Tensor"""


### PR DESCRIPTION
This is an op invoked whenever assertion is used in models, but with no output.

~~NOTE: Converter side needs extra handles on shape/type filling, as the op doesn't contain meta['val']~~