### PR TITLE
Add Op(aten::_to_copy) | feat(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -2072,10 +2072,9 @@ def aten__to_copy(
     """_to_copy(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool non_blocking=False, MemoryFormat? memory_format=None) -> Tensor"""
 
     if dtype == -1:
-        self = op.Identity(self)
+        return op.Identity(self)
     else:
-        self = op.Cast(self, to=dtype)
-    return self
+        return common_ops.cast_to(self, dtype=dtype)
 
 
 def aten_copysign(self: TensorType, other: TensorType) -> TensorType:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -2053,13 +2053,28 @@ def aten_convolution_overrideable(
     raise NotImplementedError()
 
 
-@torch_op(("aten::copy", "aten::_to_copy"))
+@torch_op("aten::copy")
 def aten_copy(
     self: TTensor, src: TTensor, non_blocking: bool = False  # pylint: disable=unused-argument
 ) -> TTensor:
     """copy(Tensor self, Tensor src, bool non_blocking=False) -> Tensor"""
 
     self = op.Identity(src)
+    return self
+
+
+@torch_op("aten::_to_copy", trace_only=True)
+def aten__to_copy(
+    self: TTensor,
+    dtype: int = -1,
+    non_blocking: bool = False,  # pylint: disable=unused-argument
+) -> TTensor:
+    """_to_copy(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool non_blocking=False, MemoryFormat? memory_format=None) -> Tensor"""
+
+    if dtype == -1:
+        self = op.Identity(self)
+    else:
+        self = op.Cast(self, to=dtype)
     return self
 
 


### PR DESCRIPTION
`aten::_to_copy.default` needs attributes, so this PR creates one to replace the old one.

https://github.com/pytorch/pytorch/blob/fe5d8850e27d98439166c76ccc5e167fd3960df8/aten/src/ATen/native/native_functions.yaml#L7479-L7486

https://github.com/pytorch/pytorch/pull/62262/files#diff-2f3dbd85efb9b5172f2264eedd3be47dd765e6ab7cc8bf3ade5e62c28ae35991