### PR TITLE
Upcast Celu for it to support more dtypes | feat(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -351,7 +351,9 @@ def aten_celu(self: FLOAT, alpha: float = 1.0) -> FLOAT:
 
 
 @torch_op("aten::celu")
-def aten_celu_type_promoted(self: TFloatUnlessFloat32, alpha: float = 1.0) -> TFloatUnlessFloat32:
+def aten_celu_type_promoted(
+    self: TFloatUnlessFloat32, alpha: float = 1.0
+) -> TFloatUnlessFloat32:
     """celu(Tensor self, Scalar alpha=1.0) -> Tensor"""
 
     self_upcasted = op.Cast(self, to=FLOAT.dtype)

--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -15,11 +15,11 @@
 from __future__ import annotations
 
 import math
-from typing import Optional, Sequence, Tuple
+from typing import Optional, Sequence, Tuple, TypeVar, Union
 
 import onnx
 
-from onnxscript import FLOAT, INT64
+from onnxscript import BFLOAT16, BOOL, DOUBLE, FLOAT, FLOAT16, INT64
 from onnxscript.function_libs.torch_lib.ops import common as common_ops
 from onnxscript.function_libs.torch_lib.registration import torch_op
 from onnxscript.function_libs.torch_lib.tensor_typing import (
@@ -31,10 +31,13 @@ from onnxscript.function_libs.torch_lib.tensor_typing import (
     TTensor,
 )
 from onnxscript.onnx_opset import opset18 as op
-from onnxscript.onnx_types import BOOL, TensorType
+from onnxscript.onnx_types import TensorType
 
 _MATH_PI = math.pi
 Rank = common_ops.Rank
+
+# All float types but float32
+TFloatUnlessFloat32 = TypeVar("TFloatUnlessFloat32", bound=Union[BFLOAT16, FLOAT16, DOUBLE])
 
 
 @torch_op("aten::aten_adaptive_avg_pool1d")
@@ -345,6 +348,14 @@ def aten_celu(self: FLOAT, alpha: float = 1.0) -> FLOAT:
     """celu(Tensor self, Scalar alpha=1.0) -> Tensor"""
 
     return op.Celu(self, alpha=alpha)  # op.Celu only support float32
+
+
+@torch_op("aten::celu")
+def aten_celu_upcasted(self: TFloatUnlessFloat32, alpha: float = 1.0) -> TFloatUnlessFloat32:
+    """celu(Tensor self, Scalar alpha=1.0) -> Tensor"""
+
+    self_upcasted = op.Cast(self, to=FLOAT.dtype)
+    return op.CastLike(op.Celu(self_upcasted, alpha=alpha), self)
 
 
 @torch_op("aten::col2im", trace_only=True)

--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -351,7 +351,7 @@ def aten_celu(self: FLOAT, alpha: float = 1.0) -> FLOAT:
 
 
 @torch_op("aten::celu")
-def aten_celu_upcasted(self: TFloatUnlessFloat32, alpha: float = 1.0) -> TFloatUnlessFloat32:
+def aten_celu_type_promoted(self: TFloatUnlessFloat32, alpha: float = 1.0) -> TFloatUnlessFloat32:
     """celu(Tensor self, Scalar alpha=1.0) -> Tensor"""
 
     self_upcasted = op.Cast(self, to=FLOAT.dtype)

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1059,7 +1059,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="fixme: RuntimeError: ORT inference error GlobalAveragePool. https://github.com/microsoft/onnxruntime/issues/16449",
     ),
     TorchLibOpInfo("nn.functional.celu", nn_ops.aten_celu),
-    TorchLibOpInfo("nn.functional.celu_upcasted", nn_ops.aten_celu_upcasted),
+    TorchLibOpInfo("nn.functional.celu_type_promoted", nn_ops.aten_celu_type_promoted),
     TorchLibOpInfo(
         "nn.functional.cross_entropy",
         # use cross_entropy as test case instead of cross_entropy_loss (not in OPS_DB)
@@ -2130,7 +2130,7 @@ ops_test_common.duplicate_opinfo(
 ops_test_common.duplicate_opinfo(
     OPS_DB,
     "nn.functional.celu",
-    ("nn.functional.celu_upcasted",),
+    ("nn.functional.celu_type_promoted",),
 )
 ops_test_common.duplicate_opinfo(
     OPS_DB,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1059,6 +1059,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="fixme: RuntimeError: ORT inference error GlobalAveragePool. https://github.com/microsoft/onnxruntime/issues/16449",
     ),
     TorchLibOpInfo("nn.functional.celu", nn_ops.aten_celu),
+    TorchLibOpInfo("nn.functional.celu_upcasted", nn_ops.aten_celu_upcasted),
     TorchLibOpInfo(
         "nn.functional.cross_entropy",
         # use cross_entropy as test case instead of cross_entropy_loss (not in OPS_DB)
@@ -2120,6 +2121,11 @@ ops_test_common.duplicate_opinfo(
     OPS_DB,
     "nn.functional.scaled_dot_product_attention",
     ("nn.functional.scaled_dot_product_attention_bool_mask",),
+)
+ops_test_common.duplicate_opinfo(
+    OPS_DB,
+    "nn.functional.celu",
+    ("nn.functional.celu_upcasted",),
 )
 ops_test_common.duplicate_opinfo(
     OPS_DB,


### PR DESCRIPTION
Celu only supports float in ONNX. This change adds the variant to support more floating types by manually adding casts in the function.