### PR TITLE
Clean up Shape calls | chore(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -7731,6 +7731,13 @@ def aten_sym_size(self: TReal, dim: int = 0) -> TReal:
     # NOTE: onnxscript doesn't support attribute process,
     # so op.Shape(self, start=dim, end=dim + 1) is not supported.
 
+    # TODO(titaiwang): ORT==1.15 fixes SegFault
+    # https://github.com/microsoft/onnxscript/pull/484#discussion_r1136105039
+    # Change the op to:
+    # shape = op.Shape(self)
+    # idx= op.Reshape(dim, [1])
+    # return op.Gather(shape, idx)
+
     shape = op.Shape(self)
     # Reshape helps dim from int to tensor, and
     # input arguments support attribute processing.


### PR DESCRIPTION
Update calls to `Shape` to use the `start` and `end` arguments to simplify the graph and avoid `Gather` nodes.