### PR TITLE
Handle name conflict (attribute parameter) when converting back to python

### DIFF
--- a/onnxscript/backend/onnx_export.py
+++ b/onnxscript/backend/onnx_export.py
@@ -190,6 +190,7 @@ def _attribute_value(attr: onnx.AttributeProto):
     # - onnx.AttributeProto.TYPE_PROTOS
     raise NotImplementedError(f"Unable to return a value for attribute {attr!r}.")
 
+
 def _update_names_used_in_graph(names: set[str], graph: GraphProto) -> None:
     """Returns the names used in a graph."""
     names.update(x.name for x in graph.input)
@@ -197,6 +198,7 @@ def _update_names_used_in_graph(names: set[str], graph: GraphProto) -> None:
     names.update(x.name for x in graph.initializer)
     for node in graph.node:
         _update_names_used_in_node(names, node)
+
 
 def _update_names_used_in_node(names: set[str], node: onnx.NodeProto) -> None:
     names.update(node.input)
@@ -207,16 +209,19 @@ def _update_names_used_in_node(names: set[str], node: onnx.NodeProto) -> None:
         for g in attr.graphs:
             _update_names_used_in_graph(names, g)
 
+
 def _update_names_used_in_function(names: set[str], fun: FunctionProto) -> None:
     names.update(fun.input)
     names.update(fun.output)
     for node in fun.node:
         _update_names_used_in_node(names, node)
 
+
 def _names_used_in_function(fun: FunctionProto) -> set[str]:
     names = set()
     _update_names_used_in_function(names, fun)
     return names
+
 
 class Exporter:
     """Class used for recursive traversal of Proto structures."""
@@ -231,6 +236,7 @@ class Exporter:
 
     def _handle_attrname_conflict(self, renamer):
         """Add ref-attr-name-conflict handling logic to renaming function."""
+
         def new_renamer(name):
             new_name = renamer(name)
             if new_name not in self._attr_renaming:
@@ -246,7 +252,8 @@ class Exporter:
                 counter += 1
             self._attr_renaming[new_name] = candidate
             self._names_used.add(candidate)
-            return candidate            
+            return candidate
+
         return new_renamer
 
     def _rename_variable_s(self, name):
@@ -262,7 +269,9 @@ class Exporter:
         return f"{self._rename_domain(domain)}{version}"
 
     def _python_make_node_name(self, domain, version, name, node=False):
-        name = _rename_variable(name)  # TODO: Is this a typo? Is it supposed to be self._rename_variable(name)?
+        name = _rename_variable(
+            name
+        )  # TODO: Is this a typo? Is it supposed to be self._rename_variable(name)?
         if node:
             if version is None:
                 version = 1
@@ -524,8 +533,10 @@ class Exporter:
         renamed_names_used = [self._rename_variable(x) for x in used_proto_names]
         self._names_used = set(renamed_names_used)
         result = []
+
         def add_line(line: str) -> None:
             result.append(line)
+
         opset_name = self.make_opset_name(funproto.domain, 1)
         add_line(f"@script({opset_name})")
         fun_name = self._python_make_node_name(funproto.domain, 1, funproto.name)

--- a/onnxscript/backend/onnx_export.py
+++ b/onnxscript/backend/onnx_export.py
@@ -218,7 +218,7 @@ def _update_names_used_in_function(names: set[str], fun: FunctionProto) -> None:
 
 
 def _names_used_in_function(fun: FunctionProto) -> set[str]:
-    names = set()
+    names: set[str] = set()
     _update_names_used_in_function(names, fun)
     return names
 
@@ -231,8 +231,9 @@ class Exporter:
         self._rename_variable = self._handle_attrname_conflict(rename_function)
         self.inline_const = inline_const
         self.constants: dict[str, str] = {}
-        self._attr_renaming: dict[str, str] = {}  # For current function.
+        self._attr_renaming: dict[str, str | None] = {}  # For current function.
         self._names_used: set[str] = set()  # For current function.
+        self.opsets: dict[str, int] = {}
 
     def _handle_attrname_conflict(self, renamer):
         """Add ref-attr-name-conflict handling logic to renaming function."""

--- a/onnxscript/backend/onnx_export_test.py
+++ b/onnxscript/backend/onnx_export_test.py
@@ -168,7 +168,7 @@ class TestOnnxBackEnd(unittest.TestCase):
             return Z
 
         self._round_trip_check(fun_with_double_attr_promotion)
-        
+
     def test_qualified_domain(self):
         """Test use of qualified domain name."""
         op = onnxscript.opset17

--- a/onnxscript/backend/onnx_export_test.py
+++ b/onnxscript/backend/onnx_export_test.py
@@ -103,7 +103,7 @@ def run_function(obj, *inputs):
     return got
 
 
-def extract_functions(name: str, content: str, test_folder: pathlib.Path):
+def write_functions(name: str, content: str, test_folder: pathlib.Path):
     """Write the content into a file and import all OnnxFunctions from it."""
     if not test_folder.exists():
         test_folder.mkdir(exist_ok=True, parents=True)
@@ -112,6 +112,8 @@ def extract_functions(name: str, content: str, test_folder: pathlib.Path):
     file = test_folder / f"{name}.py"
     file.write_text(content, encoding="utf-8")
 
+def extract_functions(name: str, content: str, test_folder: pathlib.Path):
+    write_functions(name, content, test_folder)
     import_name = f"onnxscript.tests.{test_folder.parts[-1]}.{name}"
     try:
         mod = importlib.import_module(import_name)
@@ -137,6 +139,12 @@ class TestOnnxBackEnd(unittest.TestCase):
     test_folder = root_folder / "tests" / "onnx_backend_test_code"
     temp_folder = root_folder / "tests" / "export"
 
+    def _proto_to_os_and_back(self, proto: onnxscript.FunctionProto, **export_options):
+        """Convert a proto to onnxscript code and convert it back to a proto."""
+        code = onnx_export.export2python(proto, **export_options)
+        map = extract_functions(proto.name, code, TestOnnxBackEnd.temp_folder)
+        return map[proto.name]
+
     def _round_trip_check(self, script_function, **export_options):
         proto = script_function.to_function_proto()
         code = onnx_export.export2python(proto, **export_options)
@@ -154,6 +162,17 @@ class TestOnnxBackEnd(unittest.TestCase):
 
         self._round_trip_check(fun_with_attr_param)
 
+    def test_double_attr_val_promotion(self):
+        op = onnxscript.opset17
+
+        @onnxscript.script()
+        def fun_with_double_attr_promotion(X, dtype: int):
+            Y = op.Add(X, dtype)
+            Z = op.Add(Y, dtype)
+            return Z
+
+        self._round_trip_check(fun_with_double_attr_promotion)
+        
     def test_qualified_domain(self):
         """Test use of qualified domain name."""
         op = onnxscript.opset17

--- a/onnxscript/backend/onnx_export_test.py
+++ b/onnxscript/backend/onnx_export_test.py
@@ -103,17 +103,13 @@ def run_function(obj, *inputs):
     return got
 
 
-def write_functions(name: str, content: str, test_folder: pathlib.Path):
-    """Write the content into a file and import all OnnxFunctions from it."""
+def extract_functions(name: str, content: str, test_folder: pathlib.Path):
     if not test_folder.exists():
         test_folder.mkdir(exist_ok=True, parents=True)
         init = test_folder / "__init__.py"
         init.touch(exist_ok=True)
     file = test_folder / f"{name}.py"
     file.write_text(content, encoding="utf-8")
-
-def extract_functions(name: str, content: str, test_folder: pathlib.Path):
-    write_functions(name, content, test_folder)
     import_name = f"onnxscript.tests.{test_folder.parts[-1]}.{name}"
     try:
         mod = importlib.import_module(import_name)

--- a/onnxscript/testing.py
+++ b/onnxscript/testing.py
@@ -117,12 +117,9 @@ def _same_value_info(vi1, vi2):
     )
 
 
-def _same_attr(attr1, attr2, graph_equality, ref_equality):
+def _same_attr(attr1, attr2, graph_equality):
     # no name check; names used to match attributes already.
-    if not _same_optional("ref_attr_name", attr1, attr2, ref_equality):
-        return False
-
-    for field in ["type", "f", "i", "s"]:
+    for field in ["type", "ref_attr_name", "f", "i", "s"]:
         if not _same_optional(field, attr1, attr2):
             return False
 
@@ -149,7 +146,7 @@ def _same_attr(attr1, attr2, graph_equality, ref_equality):
     return True
 
 
-def _same_attrs(attrs1, attrs2, graph_equality, ref_equality):
+def _same_attrs(attrs1, attrs2, graph_equality):
     if len(attrs1) != len(attrs2):
         return False
     attrs1map = {a.name: a for a in attrs1}
@@ -157,7 +154,7 @@ def _same_attrs(attrs1, attrs2, graph_equality, ref_equality):
         if attr2.name not in attrs1map:
             return False
         attr1 = attrs1map[attr2.name]
-        if not _same_attr(attr1, attr2, graph_equality, ref_equality):
+        if not _same_attr(attr1, attr2, graph_equality):
             return False
     return True
 
@@ -191,15 +188,6 @@ class _Matcher:
         self.node_mapping: dict[onnx.NodeProto, onnx.NodeProto] = {}
         self.outer_scope = outer_scope
 
-    def same_ref_attr(self, ref_attr_name1, ref_attr_name2) -> bool:
-        def find(fun, name):
-            for i, attr_name in enumerate(fun.attribute):
-                if attr_name == name:
-                    return i
-            # TODO: handle attribute_protos
-            return None
-        return find(self.fg1, ref_attr_name1) == find(self.fg2, ref_attr_name2)
-
     def same_value(self, var1, var2):
         """Match two variables (strings)."""
         if var1 not in self.defmap1 or var2 not in self.defmap2:
@@ -227,7 +215,7 @@ class _Matcher:
         if node1.domain != node2.domain:
             return False
         # check attrs
-        if not _same_attrs(node1.attribute, node2.attribute, self.same_sub_graph, self.same_ref_attr):
+        if not _same_attrs(node1.attribute, node2.attribute, self.same_sub_graph):
             return False
         if not self.same_value_list(node1.input, node2.input):
             return False
@@ -273,7 +261,7 @@ class _Matcher:
 
         if len(self.fg1.input) != len(self.fg2.input):
             return False
-        if len(self.fg1.attribute) != len(self.fg2.attribute):
+        if set(self.fg1.attribute) != set(self.fg2.attribute):
             return False
 
         # Opset imports must be same (but possibly in different order):


### PR DESCRIPTION
Attribute parameters and normal values (like tensors) use the same namespace in onnxscript/python. This can cause a conflict when converting ONNX proto back to onnxscript (since these are different namespaces in ONNX). Examples of where this happens shown in test-case below: eg., when an attribute-parameter "yyy" is used as a value, the onnxscript translator introduces a value called "yyy" which is bound to the attribute-value "yyy".

Fix this in the exporter.
