### PR TITLE
aten::var implementation and aten::roll complex support

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6929,12 +6929,12 @@ def aten_roll(self: TTensor, shifts: INT64, dims: Sequence[int] = ()) -> TTensor
 def aten_roll_complex(self: TTensor, shifts: INT64, dims: Sequence[int] = ()) -> TTensor:
     """roll(Tensor self, int[1] shifts, int[1] dims=[]) -> Tensor"""
 
-    self_real = op.Slice(self, [0], [1], axes=[-1])
-    self_imag = op.Slice(self, [1], [2], axes=[-1])
-
     self_rank = len(self.shape)
     if self_rank == 0:
         return self
+
+    self_real = op.Slice(self, [0], [1], axes=[-1])
+    self_imag = op.Slice(self, [1], [2], axes=[-1])
     elif self.shape[0] == 0:  # empty tensor
         return self
     else:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6930,7 +6930,7 @@ def aten_roll_complex(self: TTensor, shifts: INT64, dims: Sequence[int] = ()) ->
     """roll(Tensor self, int[1] shifts, int[1] dims=[]) -> Tensor"""
 
     self_rank = len(self.shape)
-    if self_rank == 0:
+    if self_rank == 1:
         return self
 
     self_real = op.Slice(self, [0], [1], axes=[-1])
@@ -8429,7 +8429,7 @@ def _aten_var_mean_dim_onnx(
     return var, mean
 
 
-@torch_op("aten::var", private=True)
+@torch_op("aten::var", private=True, traceable=True)
 def _aten_var_onnx(self: TReal, correction: float, keepdim: bool = False) -> TReal:
     mean = op.ReduceMean(self, keepdims=keepdim)
     sub_mean = op.Sub(self, mean)
@@ -8446,7 +8446,7 @@ def _aten_var_onnx(self: TReal, correction: float, keepdim: bool = False) -> TRe
     return var
 
 
-@torch_op("aten::var.dim", private=True)
+@torch_op("aten::var.dim", private=True, traceable=True)
 def _aten_var_dim_onnx(
     self: TReal, dim: INT64, correction: float, keepdim: bool = False
 ) -> TReal:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6947,9 +6947,8 @@ def aten_roll_complex(self: TTensor, shifts: INT64, dims: Sequence[int] = ()) ->
 
         else:
             # assert len(shifts) == len(dims), but shifts is a tensor, dims is a list
-            for i in range(len(shifts)):  # pylint: disable=consider-using-enumerate
+            for i, dim in enumerate(dims):
                 shift = op.Gather(shifts, i, axis=0)
-                dim = dims[i]
                 self_real = _aten_roll_shift_and_dim_onnx(self_real, shift, dim)
                 self_imag = _aten_roll_shift_and_dim_onnx(self_imag, shift, dim)
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -8292,6 +8292,7 @@ def aten_vander(
 
     raise NotImplementedError()
 
+
 @torch_op("aten::var", trace_only=True)
 def aten_var(self: TReal, unbiased: Optional[bool] = True) -> TReal:
     """var(Tensor self, bool unbiased=True) -> Tensor"""
@@ -8300,6 +8301,7 @@ def aten_var(self: TReal, unbiased: Optional[bool] = True) -> TReal:
     # If not this case, should be explicitly set correction value according to unbiased value
     return _aten_var_onnx(self, correction=float(unbiased), keepdim=False)
     # return float(unbiased)
+
 
 @torch_op("aten::var.dim", trace_only=True)
 def aten_var_dim(
@@ -8310,14 +8312,8 @@ def aten_var_dim(
     if isinstance(dim, int):
         dim = (dim,)
     dim_tensor = op.Constant(value_ints=dim)
-    return _aten_var_dim_onnx(
-        self, dim_tensor, correction=float(unbiased), keepdim=keepdim
-    )
+    return _aten_var_dim_onnx(self, dim_tensor, correction=float(unbiased), keepdim=keepdim)
 
-@torch_op("aten::var.correction", trace_only=True)
-def aten_var_connection(self: TFloat, dim: Optional[int] = None, correction: Optional[float] = None, keepdim = False):
-    """var.correction(Tensor self, int[1]? dim=None, *, Scalar? correction=None, bool keepdim=False) -> Tensor"""
-    ...
 
 @torch_op("aten::var.correction", trace_only=True)
 def aten_var_correction(
@@ -8339,6 +8335,7 @@ def aten_var_correction(
         dim_tensor = op.Constant(value_ints=dim)
         var = _aten_var_dim_onnx(self, dim_tensor, correction, keepdim)
     return var
+
 
 @torch_op("aten::var_mean", trace_only=True)
 def aten_var_mean(self: TReal, unbiased: bool = True) -> Tuple[TReal, TReal]:
@@ -8428,10 +8425,9 @@ def _aten_var_mean_dim_onnx(
 
     return var, mean
 
+
 @torch_op("aten::var", private=True)
-def _aten_var_onnx(
-    self: TReal, correction: float, keepdim: bool = False
-) -> TReal:
+def _aten_var_onnx(self: TReal, correction: float, keepdim: bool = False) -> TReal:
     mean = op.ReduceMean(self, keepdims=keepdim)
     sub_mean = op.Sub(self, mean)
     sqr_mean = op.Mul(sub_mean, sub_mean)
@@ -8466,6 +8462,7 @@ def _aten_var_dim_onnx(
         var = op.Div(mul, sub)
 
     return var
+
 
 def aten_vdot(self: TensorType, other: TensorType) -> TensorType:
     """vdot(Tensor self, Tensor other) -> Tensor"""

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6936,7 +6936,7 @@ def aten_roll_complex(self: TTensor, shifts: INT64, dims: Sequence[int] = ()) ->
     elif self.shape[0] == 0:  # empty tensor
         return self
     else:
-        if isinstance(dims, tuple) and len(dims) == 0:  # Empty list
+        if not dims:
             # assert isinstance(shifts, int)
             shift_real = _aten_roll_shift_no_dim_onnx(self_real, shifts)
             shift_imag = _aten_roll_shift_no_dim_onnx(self_imag, shifts)
@@ -8303,7 +8303,6 @@ def aten_var(self: TReal, unbiased: Optional[bool] = True) -> TReal:
     # Assume bool(True) and int(1) are same in ONNX, so pass "unbiased" directly as "correction"
     # If not this case, should be explicitly set correction value according to unbiased value
     return _aten_var_onnx(self, correction=float(unbiased), keepdim=False)
-    # return float(unbiased)
 
 
 @torch_op("aten::var.dim", trace_only=True)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6920,7 +6920,7 @@ def aten_roll(self: TTensor, shifts: INT64, dims: Sequence[int] = ()) -> TTensor
             return result
         
 @torch_op("aten::roll", trace_only=True, complex=True)
-def aten_roll(self: TTensor, shifts: INT64, dims: Sequence[int] = ()) -> TTensor:
+def aten_roll_complex(self: TTensor, shifts: INT64, dims: Sequence[int] = ()) -> TTensor:
     """roll(Tensor self, int[1] shifts, int[1] dims=[]) -> Tensor"""
 
     self_real = op.Slice(self, [0], [1], axes=[-1])
@@ -8292,16 +8292,17 @@ def aten_vander(
     raise NotImplementedError()
 
 @torch_op("aten::var", trace_only=True)
-def aten_var(self: TReal, unbiased: bool = True) -> TReal:
+def aten_var(self: TReal, unbiased: Optional[bool] = True) -> TReal:
     """var(Tensor self, bool unbiased=True) -> Tensor"""
 
     # Assume bool(True) and int(1) are same in ONNX, so pass "unbiased" directly as "correction"
     # If not this case, should be explicitly set correction value according to unbiased value
-    return _aten_var_onnx(self, correction=float(unbiased), keepdim=False)
+    return _aten_var_onnx(self, correction=float(unbiased), keepdim=False), float(unbiased)
+    # return float(unbiased)
 
 @torch_op("aten::var.dim", trace_only=True)
-def aten_var(
-    self: TReal, dim: int, unbiased: bool = True, keepdim: bool = False
+def aten_var_dim(
+    self: TReal, dim: int, unbiased: Optional[bool] = True, keepdim: Optional[bool] = False
 ) -> TReal:
     """var(Tensor self, int[1]? dim, bool unbiased=True, bool keepdim=False) -> Tensor"""
 
@@ -8425,7 +8426,18 @@ def _aten_var_mean_dim_onnx(
 def _aten_var_onnx(
     self: TReal, correction: float, keepdim: bool = False
 ) -> TReal:
-    var, _ = _aten_var_mean_onnx(self, correction, keepdim)
+    mean = op.ReduceMean(self, keepdims=keepdim)
+    sub_mean = op.Sub(self, mean)
+    sqr_mean = op.Mul(sub_mean, sub_mean)
+    var = op.ReduceMean(sqr_mean, keepdims=keepdim)
+    # Adjust var according to correction value
+    if correction > 0.0:
+        self_shape = op.Shape(self)
+        numel_float = op.CastLike(op.ReduceProd(self_shape, keepdims=False), self)
+        mul = op.Mul(var, numel_float)
+        sub = op.Sub(numel_float, op.CastLike(correction, self))
+        var = op.Div(mul, sub)
+
     return var
 
 
@@ -8433,7 +8445,21 @@ def _aten_var_onnx(
 def _aten_var_dim_onnx(
     self: TReal, dim: INT64, correction: float, keepdim: bool = False
 ) -> TReal:
-    var, _ = _aten_var_mean_dim_onnx(self, dim, correction, keepdim)
+    dim = op.Reshape(dim, op.Constant(value_ints=[-1]))
+    # Computer mean and var
+    mean = op.ReduceMean(self, dim, keepdims=keepdim)
+    sub_mean = op.Sub(self, op.ReduceMean(self, dim, keepdims=True))
+    sqr_mean = op.Mul(sub_mean, sub_mean)
+    var = op.ReduceMean(sqr_mean, dim, keepdims=keepdim)
+    # Adjust var according to correction value
+    if correction > 0.0:
+        self_shape = op.Shape(self)
+        dim_size = op.Gather(self_shape, dim, axis=0)
+        numel_float = op.CastLike(op.ReduceProd(dim_size, keepdims=False), self)
+        mul = op.Mul(var, numel_float)
+        sub = op.Sub(numel_float, correction)
+        var = op.Div(mul, sub)
+
     return var
 
 def aten_vdot(self: TensorType, other: TensorType) -> TensorType:

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -2149,14 +2149,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         trace_only=True,
     )
     .xfail(
-        reason="fixme: Inferred shape and existing shape differ in rank",
-    )
-    .skip(
-        variant_name="unbiased",
-        reason="fixme: Inferred shape and existing shape differ in rank",
-    )
-    .xfail(
-        # kwargs is empty
+        # kwargs must be empty
         matcher=lambda sample: len(sample.kwargs) > 0,
         reason="this Aten overload only support input[0]=tensor and input[1]=bool as input without any kwargs",
     ),
@@ -2176,9 +2169,6 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "var_correction",
         core_ops.aten_var_correction,
         trace_only=True,
-    )
-    .xfail(
-        reason="fixme: Inferred shape and existing shape differ in rank",
     )
     .skip(
         # Don't accept input[1]=bool and 'correction' must be in kwargs

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -2147,8 +2147,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "var",
         core_ops.aten_var,
         trace_only=True,
-    )
-    .xfail(
+    ).xfail(
         # kwargs must be empty
         matcher=lambda sample: len(sample.kwargs) > 0,
         reason="this Aten overload only support input[0]=tensor and input[1]=bool as input without any kwargs",
@@ -2169,8 +2168,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "var_correction",
         core_ops.aten_var_correction,
         trace_only=True,
-    )
-    .skip(
+    ).skip(
         # Don't accept input[1]=bool and 'correction' must be in kwargs
         matcher=lambda sample: len(sample.args) > 0 or "correction" not in sample.kwargs,
         reason="this Aten overload only support when correction attribute exists",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -2030,6 +2030,13 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         input_wrangler=_roll_input_wrangler,
     ),
     TorchLibOpInfo(
+        "roll",
+        core_ops.aten_roll_complex,
+        input_wrangler=_roll_input_wrangler,
+        trace_only=True,
+        complex=True,
+    ),
+    TorchLibOpInfo(
         "scatter_reduce",
         core_ops.aten_scatter_reduce,
         input_wrangler=_scatter_reduce_input_wrangler,
@@ -2126,6 +2133,48 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo(
         "var_mean_correction",
         core_ops.aten_var_mean_correction,
+        trace_only=True,
+    )
+    .xfail(
+        reason="fixme: Inferred shape and existing shape differ in rank",
+    )
+    .skip(
+        # Don't accept input[1]=bool and 'correction' must be in kwargs
+        matcher=lambda sample: len(sample.args) > 0 or "correction" not in sample.kwargs,
+        reason="this Aten overload only support when correction attribute exists",
+    ),
+    TorchLibOpInfo(
+        "var",
+        core_ops.aten_var,
+        trace_only=True,
+    )
+    .xfail(
+        reason="fixme: Inferred shape and existing shape differ in rank",
+    )
+    .skip(
+        variant_name="unbiased",
+        reason="fixme: Inferred shape and existing shape differ in rank",
+    )
+    .xfail(
+        # kwargs is empty
+        matcher=lambda sample: len(sample.kwargs) > 0,
+        reason="this Aten overload only support input[0]=tensor and input[1]=bool as input without any kwargs",
+    ),
+    TorchLibOpInfo(
+        "var_dim",
+        core_ops.aten_var_dim,
+        trace_only=True,
+    ).xfail(
+        # kwargs["dim"] must exist, kwargs["correction"] must not exist
+        matcher=lambda sample: not (
+            sample.kwargs.get("dim", None) is not None
+            and sample.kwargs.get("correction", None) is None
+        ),
+        reason="this Aten overload only support with 'dim' argument and without 'correction' argument",
+    ),
+    TorchLibOpInfo(
+        "var_correction",
+        core_ops.aten_var_correction,
         trace_only=True,
     )
     .xfail(
@@ -2233,6 +2282,7 @@ ops_test_common.duplicate_opinfo(OPS_DB, "ops.aten._softmax", ("ops.aten._softma
 ops_test_common.duplicate_opinfo(OPS_DB, "round", ("round_decimals",))
 ops_test_common.duplicate_opinfo(OPS_DB, "squeeze", ("squeeze_dim",))
 ops_test_common.duplicate_opinfo(OPS_DB, "var_mean", ("var_mean_dim", "var_mean_correction"))
+ops_test_common.duplicate_opinfo(OPS_DB, "var", ("var_dim", "var_correction"))
 ops_test_common.duplicate_opinfo(OPS_DB, "view_as_complex", ("view_as_complex_copy",))
 ops_test_common.duplicate_opinfo(OPS_DB, "view_as_real", ("view_as_real_copy",))
 


### PR DESCRIPTION
As mentioned on [#1173](https://github.com/microsoft/onnxscript/issues/1173), I'm trying to add aten::var and aten::roll (complex support) in order to export one model from PyTorch to ONNX. The model uses fft functions, which requires opset 18 and torch dynamo usage.

fixes https://github.com/microsoft/onnxscript/issues/1175 fixes https://github.com/microsoft/onnxscript/issues/1174