### PR TITLE
ModifyOp(embedding_bag) | feat(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -2914,7 +2914,6 @@ def _aten_embedding_bag_onnx(
 @torch_op(
     (
         "aten::embedding_bag.padding_idx",
-        "aten::_embedding_bag",
         "aten::_embedding_bag_forward_only",
     ),
     trace_only=True,


### PR DESCRIPTION
Remove registery (_embedding_bag) from aten_embedding_bad_padding_idx() function, because ```embedding_bag``` should not has the parameter ```padding_idx```.