### PR TITLE
Clean up isinstance checks for tuples | feat(torchlib)

### DIFF
--- a/onnxscript/evaluator.py
+++ b/onnxscript/evaluator.py
@@ -369,7 +369,7 @@ def _onnxscript_to_numpy_value(v):
     if isinstance(v, list):
         return [_onnxscript_to_numpy_value(x) for x in v]
     if isinstance(v, tuple):
-        if len(v) > 0 and type(v[0]) is int:  # noqa: E721
+        if len(v) > 0 and type(v[0]) is int:  # noqa: E721  # pylint: disable=unidiomatic-typecheck
             return np.array(v, dtype=np.int64)
         return np.array(v)
     if v is None:

--- a/onnxscript/evaluator.py
+++ b/onnxscript/evaluator.py
@@ -369,6 +369,8 @@ def _onnxscript_to_numpy_value(v):
     if isinstance(v, list):
         return [_onnxscript_to_numpy_value(x) for x in v]
     if isinstance(v, tuple):
+        if len(v) > 0 and type(v[0]) is int:  # noqa: E721
+            return np.array(v, dtype=np.int64)
         return np.array(v)
     if v is None:
         # Treated as a static-optional value.

--- a/onnxscript/evaluator.py
+++ b/onnxscript/evaluator.py
@@ -368,6 +368,8 @@ def _onnxscript_to_numpy_value(v):
         return v.value
     if isinstance(v, list):
         return [_onnxscript_to_numpy_value(x) for x in v]
+    if isinstance(v, tuple):
+        return np.array(v)
     if v is None:
         # Treated as a static-optional value.
         # Dynamic optional None not yet supported.

--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -374,7 +374,6 @@ class TorchScriptTracingEvaluator(evaluator.Evaluator):
         assert op_schema is not None
         for name, value in attributes.items():
             attribute = op_schema.attributes[name]
-            # Cast int to float if needed
             if attribute.type == onnx.defs.OpSchema.AttrType.FLOAT:
                 # Cast int to float if the attribute is FLOAT
                 attributes[name] = float(value)

--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -368,13 +368,22 @@ class TorchScriptTracingEvaluator(evaluator.Evaluator):
         ) = param_manipulation.separate_input_attributes_from_arguments(
             param_schemas, args, kwargs, fill_defaults=True, allow_extra_kwargs=True
         )
-        name_to_schema = {param.name: param for param in param_schemas}
+
+        # Cast attributes to the correct type based on function signature
+        op_schema = function.op_schema
+        assert op_schema is not None
         for name, value in attributes.items():
-            param = name_to_schema[name]
+            attribute = op_schema.attributes[name]
             # Cast int to float if needed
-            if param.type in {float, "float"}:
-                # FIXME(justinchuby): Create invariant on the type of param.type to simplify this
+            if attribute.type == onnx.defs.OpSchema.AttrType.FLOAT:
+                # Cast int to float is the attribute is FLOAT
                 attributes[name] = float(value)
+            if attribute.type == onnx.defs.OpSchema.AttrType.INTS and isinstance(value, int):
+                attributes[name] = (value,)
+            if attribute.type == onnx.defs.OpSchema.AttrType.FLOATS and isinstance(
+                value, float
+            ):
+                attributes[name] = (value,)
         return self._graph.add_function_call(function, inputs, attributes)
 
 

--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -376,7 +376,7 @@ class TorchScriptTracingEvaluator(evaluator.Evaluator):
             attribute = op_schema.attributes[name]
             # Cast int to float if needed
             if attribute.type == onnx.defs.OpSchema.AttrType.FLOAT:
-                # Cast int to float is the attribute is FLOAT
+                # Cast int to float if the attribute is FLOAT
                 attributes[name] = float(value)
             if attribute.type == onnx.defs.OpSchema.AttrType.INTS and isinstance(value, int):
                 attributes[name] = (value,)

--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -377,6 +377,11 @@ class TorchScriptTracingEvaluator(evaluator.Evaluator):
             if attribute.type == onnx.defs.OpSchema.AttrType.FLOAT:
                 # Cast int to float if the attribute is FLOAT
                 attributes[name] = float(value)
+
+            # In PyTorch, an attribute annotated as `int[1]?` accepts an integer
+            # or a sequence. When the attribute is an integer, it is treated as
+            # a single element sequence. ONNX requires an attribute to either be
+            # an integer or a sequence. So we promote the value to a sequence here.
             if attribute.type == onnx.defs.OpSchema.AttrType.INTS and isinstance(value, int):
                 attributes[name] = (value,)
             if attribute.type == onnx.defs.OpSchema.AttrType.FLOATS and isinstance(

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -8389,6 +8389,7 @@ def aten_var_mean_dim(
 @torch_op("aten::var_mean.correction", trace_only=True)
 def aten_var_mean_correction(
     self: TReal,
+    # FIXME(justinchuby): Make dim Optional[Sequence[int]]
     dim: Optional[int] = None,
     correction: Optional[float] = None,
     keepdim: bool = False,

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -8298,19 +8298,20 @@ def aten_var(self: TReal, unbiased: Optional[bool] = True) -> TReal:
 
 @torch_op("aten::var.dim", trace_only=True)
 def aten_var_dim(
-    self: TReal, dim: int, unbiased: Optional[bool] = True, keepdim: Optional[bool] = False
+    self: TReal,
+    dim: Sequence[int],
+    unbiased: Optional[bool] = True,
+    keepdim: Optional[bool] = False,
 ) -> TReal:
     """var(Tensor self, int[1]? dim, bool unbiased=True, bool keepdim=False) -> Tensor"""
 
-    if isinstance(dim, int):
-        dim = (dim,)
-    dim_tensor = op.Constant(value_ints=dim)
-    return _aten_var_dim_onnx(self, dim_tensor, correction=float(unbiased), keepdim=keepdim)
+    return _aten_var_dim_onnx(self, dim=dim, correction=float(unbiased), keepdim=keepdim)
 
 
 @torch_op("aten::var.correction", trace_only=True)
 def aten_var_correction(
     self: TReal,
+    # FIXME(justinchuby): Make dim Optional[Sequence[int]]
     dim: Optional[int] = None,
     correction: Optional[float] = None,
     keepdim: bool = False,
@@ -8321,12 +8322,47 @@ def aten_var_correction(
         correction = 1.0
 
     if dim is None:
-        var = _aten_var_onnx(self, correction, keepdim)
+        var = _aten_var_onnx(self, correction=correction, keepdim=keepdim)
     else:
-        if isinstance(dim, int):
-            dim = (dim,)
-        dim_tensor = op.Constant(value_ints=dim)
-        var = _aten_var_dim_onnx(self, dim_tensor, correction, keepdim)
+        var = _aten_var_dim_onnx(self, dim=dim, correction=correction, keepdim=keepdim)
+    return var
+
+
+@torch_op("aten::var", private=True, traceable=True)
+def _aten_var_onnx(self: TReal, correction: float, keepdim: bool = False) -> TReal:
+    mean = op.ReduceMean(self, keepdims=keepdim)
+    sub_mean = op.Sub(self, mean)
+    sqr_mean = op.Mul(sub_mean, sub_mean)
+    var = op.ReduceMean(sqr_mean, keepdims=keepdim)
+    # Adjust var according to correction value
+    if correction > 0.0:
+        self_shape = op.Shape(self)
+        numel_float = op.CastLike(op.ReduceProd(self_shape, keepdims=False), self)
+        mul = op.Mul(var, numel_float)
+        sub = op.Sub(numel_float, op.CastLike(correction, self))
+        var = op.Div(mul, sub)
+
+    return var
+
+
+@torch_op("aten::var.dim", private=True, traceable=True)
+def _aten_var_dim_onnx(
+    self: TReal, dims: Sequence[int], correction: float, keepdim: bool = False
+) -> TReal:
+    dims = op.Reshape(dims, op.Constant(value_ints=[-1]))
+    # Computer mean and var
+    sub_mean = op.Sub(self, op.ReduceMean(self, dims, keepdims=True))
+    sqr_mean = op.Mul(sub_mean, sub_mean)
+    var = op.ReduceMean(sqr_mean, dims, keepdims=keepdim)
+    # Adjust var according to correction value
+    if correction > 0.0:
+        self_shape = op.Shape(self)
+        dim_size = op.Gather(self_shape, dims, axis=0)
+        numel_float = op.CastLike(op.ReduceProd(dim_size, keepdims=False), self)
+        mul = op.Mul(var, numel_float)
+        sub = op.Sub(numel_float, op.CastLike(correction, self))
+        var = op.Div(mul, sub)
+
     return var
 
 
@@ -8411,44 +8447,6 @@ def _aten_var_mean_dim_onnx(
         var = op.Div(mul, sub)
 
     return var, mean
-
-
-@torch_op("aten::var", private=True, traceable=True)
-def _aten_var_onnx(self: TReal, correction: float, keepdim: bool = False) -> TReal:
-    mean = op.ReduceMean(self, keepdims=keepdim)
-    sub_mean = op.Sub(self, mean)
-    sqr_mean = op.Mul(sub_mean, sub_mean)
-    var = op.ReduceMean(sqr_mean, keepdims=keepdim)
-    # Adjust var according to correction value
-    if correction > 0.0:
-        self_shape = op.Shape(self)
-        numel_float = op.CastLike(op.ReduceProd(self_shape, keepdims=False), self)
-        mul = op.Mul(var, numel_float)
-        sub = op.Sub(numel_float, op.CastLike(correction, self))
-        var = op.Div(mul, sub)
-
-    return var
-
-
-@torch_op("aten::var.dim", private=True, traceable=True)
-def _aten_var_dim_onnx(
-    self: TReal, dim: INT64, correction: float, keepdim: bool = False
-) -> TReal:
-    dim = op.Reshape(dim, op.Constant(value_ints=[-1]))
-    # Computer mean and var
-    sub_mean = op.Sub(self, op.ReduceMean(self, dim, keepdims=True))
-    sqr_mean = op.Mul(sub_mean, sub_mean)
-    var = op.ReduceMean(sqr_mean, dim, keepdims=keepdim)
-    # Adjust var according to correction value
-    if correction > 0.0:
-        self_shape = op.Shape(self)
-        dim_size = op.Gather(self_shape, dim, axis=0)
-        numel_float = op.CastLike(op.ReduceProd(dim_size, keepdims=False), self)
-        mul = op.Mul(var, numel_float)
-        sub = op.Sub(numel_float, op.CastLike(correction, self))
-        var = op.Div(mul, sub)
-
-    return var
 
 
 def aten_vdot(self: TensorType, other: TensorType) -> TensorType:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -8283,18 +8283,13 @@ def aten_var_mean(self: TReal, unbiased: bool = True) -> Tuple[TReal, TReal]:
 
 @torch_op("aten::var_mean.dim", trace_only=True)
 def aten_var_mean_dim(
-    self: TReal, dim: int, unbiased: bool = True, keepdim: bool = False
+    self: TReal, dim: Sequence[int], unbiased: bool = True, keepdim: bool = False
 ) -> Tuple[TReal, TReal]:
     """var_mean.dim(Tensor self, int[1]? dim, bool unbiased=True, bool keepdim=False) -> (Tensor, Tensor)"""
 
     # Although dim is Optional in signature, but we assume it must have value for this overload
     # Assert(dim is not None)
-    if isinstance(dim, int):
-        dim = (dim,)
-    dim_tensor = op.Constant(value_ints=dim)
-    return _aten_var_mean_dim_onnx(
-        self, dim_tensor, correction=float(unbiased), keepdim=keepdim
-    )
+    return _aten_var_mean_dim_onnx(self, dims=dim, correction=float(unbiased), keepdim=keepdim)
 
 
 @torch_op("aten::var_mean.correction", trace_only=True)
@@ -8310,12 +8305,11 @@ def aten_var_mean_correction(
         correction = 1.0
 
     if dim is None:
-        var, mean = _aten_var_mean_onnx(self, correction, keepdim)
+        var, mean = _aten_var_mean_onnx(self, correction=correction, keepdim=keepdim)
     else:
-        if isinstance(dim, int):
-            dim = (dim,)
-        dim_tensor = op.Constant(value_ints=dim)
-        var, mean = _aten_var_mean_dim_onnx(self, dim_tensor, correction, keepdim)
+        var, mean = _aten_var_mean_dim_onnx(
+            self, dims=dim, correction=correction, keepdim=keepdim
+        )
     return var, mean
 
 
@@ -8341,18 +8335,18 @@ def _aten_var_mean_onnx(
 
 @torch_op("aten::var_mean.dim", private=True)
 def _aten_var_mean_dim_onnx(
-    self: TReal, dim: INT64, correction: float, keepdim: bool = False
+    self: TReal, dims: Sequence[int], correction: float, keepdim: bool = False
 ) -> Tuple[TReal, TReal]:
-    dim = op.Reshape(dim, op.Constant(value_ints=[-1]))
+    dims = op.Reshape(dims, op.Constant(value_ints=[-1]))
     # Computer mean and var
-    mean = op.ReduceMean(self, dim, keepdims=keepdim)
-    sub_mean = op.Sub(self, op.ReduceMean(self, dim, keepdims=True))
+    mean = op.ReduceMean(self, dims, keepdims=keepdim)
+    sub_mean = op.Sub(self, op.ReduceMean(self, dims, keepdims=True))
     sqr_mean = op.Mul(sub_mean, sub_mean)
-    var = op.ReduceMean(sqr_mean, dim, keepdims=keepdim)
+    var = op.ReduceMean(sqr_mean, dims, keepdims=keepdim)
     # Adjust var according to correction value
     if correction > 0.0:
         self_shape = op.Shape(self)
-        dim_size = op.Gather(self_shape, dim, axis=0)
+        dim_size = op.Gather(self_shape, dims, axis=0)
         numel_float = op.CastLike(op.ReduceProd(dim_size, keepdims=False), self)
         mul = op.Mul(var, numel_float)
         sub = op.Sub(numel_float, correction)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -8305,7 +8305,7 @@ def aten_var_dim(
 ) -> TReal:
     """var(Tensor self, int[1]? dim, bool unbiased=True, bool keepdim=False) -> Tensor"""
 
-    return _aten_var_dim_onnx(self, dim=dim, correction=float(unbiased), keepdim=keepdim)
+    return _aten_var_dim_onnx(self, dims=dim, correction=float(unbiased), keepdim=keepdim)
 
 
 @torch_op("aten::var.correction", trace_only=True)
@@ -8324,7 +8324,7 @@ def aten_var_correction(
     if dim is None:
         var = _aten_var_onnx(self, correction=correction, keepdim=keepdim)
     else:
-        var = _aten_var_dim_onnx(self, dim=dim, correction=correction, keepdim=keepdim)
+        var = _aten_var_dim_onnx(self, dims=dim, correction=correction, keepdim=keepdim)
     return var
 
 

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -2144,15 +2144,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "var_mean",
         core_ops.aten_var_mean,
         trace_only=True,
-    )
-    .xfail(
-        reason="fixme: Inferred shape and existing shape differ in rank",
-    )
-    .skip(
-        variant_name="unbiased",
-        reason="fixme: Inferred shape and existing shape differ in rank",
-    )
-    .xfail(
+    ).xfail(
         # kwargs is empty
         matcher=lambda sample: len(sample.kwargs) > 0,
         reason="this Aten overload only support input[0]=tensor and input[1]=bool as input without any kwargs",
@@ -2173,11 +2165,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "var_mean_correction",
         core_ops.aten_var_mean_correction,
         trace_only=True,
-    )
-    .xfail(
-        reason="fixme: Inferred shape and existing shape differ in rank",
-    )
-    .skip(
+    ).skip(
         # Don't accept input[1]=bool and 'correction' must be in kwargs
         matcher=lambda sample: len(sample.args) > 0 or "correction" not in sample.kwargs,
         reason="this Aten overload only support when correction attribute exists",


### PR DESCRIPTION
Clean up isinstance checks for tuples to turn some trace_only functions into script functions. This is done by updating the tracing evaluator to turn int attributes into sequences according to the function op schema.

Remove xfails for var_mean.

Fixes https://github.com/microsoft/onnxscript/issues/1191