### PR TITLE
Remove proto2text | chore!

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -8,7 +8,6 @@ include_patterns = [
     '**/*.pyi',
 ]
 exclude_patterns = [
-    'docs/**',
     'onnxscript/tests/models/**',
 ]
 command = [

--- a/README.md
+++ b/README.md
@@ -65,9 +65,8 @@ pytest onnxscript
 import onnx
 
 # We use ONNX opset 15 to define the function below.
-from onnxscript import FLOAT
+from onnxscript import FLOAT, script
 from onnxscript import opset15 as op
-from onnxscript import script
 
 
 # We use the script decorator to indicate that

--- a/docs/examples/01_plot_selu.py
+++ b/docs/examples/01_plot_selu.py
@@ -32,6 +32,6 @@ onnx_fun = Selu.to_function_proto()
 
 # %%
 # Let's see what the translated function looks like:
-from onnxscript import proto2text  # noqa: E402
+import onnx  # noqa: E402
 
-print(proto2text(onnx_fun))
+print(onnx.printer.to_text(onnx_fun))

--- a/docs/examples/02_plot_square_loss.py
+++ b/docs/examples/02_plot_square_loss.py
@@ -16,7 +16,7 @@ from onnxruntime import InferenceSession
 
 from onnxscript import FLOAT
 from onnxscript import opset15 as op
-from onnxscript import proto2text, script
+from onnxscript import script
 
 
 @script()
@@ -32,7 +32,7 @@ model = square_loss.to_model_proto()
 
 # %%
 # Let's see what the generated model looks like.
-print(proto2text(model))
+print(onnx.printer.to_text(model))
 
 # %%
 # We can run shape-inference and type-check the model using the standard ONNX API.

--- a/docs/examples/02_plot_square_loss.py
+++ b/docs/examples/02_plot_square_loss.py
@@ -14,9 +14,8 @@ import numpy as np
 import onnx
 from onnxruntime import InferenceSession
 
-from onnxscript import FLOAT
+from onnxscript import FLOAT, script
 from onnxscript import opset15 as op
-from onnxscript import script
 
 
 @script()

--- a/docs/examples/03_export_lib.py
+++ b/docs/examples/03_export_lib.py
@@ -8,9 +8,8 @@ and export it.
 **This is preliminary. Proto extensions are required to fully support LibProto.**
 """
 
-from onnxscript import export_onnx_lib
+from onnxscript import export_onnx_lib, script
 from onnxscript import opset15 as op
-from onnxscript import script
 from onnxscript.values import Opset
 
 # %%

--- a/docs/examples/04_plot_eager_mode_evaluation.py
+++ b/docs/examples/04_plot_eager_mode_evaluation.py
@@ -12,9 +12,8 @@ The example below illustrates this. We first define an *onnxscript* function:
 """
 import numpy as np
 
-from onnxscript import FLOAT
+from onnxscript import FLOAT, script
 from onnxscript import opset15 as op
-from onnxscript import script
 
 
 @script()

--- a/docs/examples/05_plot_model_props.py
+++ b/docs/examples/05_plot_model_props.py
@@ -17,7 +17,7 @@ be specified in this fashion.
 
 from onnxscript import FLOAT
 from onnxscript import opset15 as op
-from onnxscript import proto2text, script
+from onnxscript import script
 
 
 @script(ir_version=7, producer_name="OnnxScript", producer_version="0.1")
@@ -29,4 +29,4 @@ def square_loss(X: FLOAT["N"], Y: FLOAT["N"]) -> FLOAT[1]:  # noqa: F821
 # %%
 # Let's see what the generated model looks like.
 model = square_loss.to_model_proto()
-print(proto2text(model))
+print(onnx.printer.to_text(model))

--- a/docs/examples/05_plot_model_props.py
+++ b/docs/examples/05_plot_model_props.py
@@ -15,9 +15,10 @@ be specified in this fashion.
 # %%
 # First, we define the implementation of a square-loss function in onnxscript.
 
-from onnxscript import FLOAT
+import onnx
+
+from onnxscript import FLOAT, script
 from onnxscript import opset15 as op
-from onnxscript import script
 
 
 @script(ir_version=7, producer_name="OnnxScript", producer_version="0.1")

--- a/docs/examples/06_plot_model_local_funs.py
+++ b/docs/examples/06_plot_model_local_funs.py
@@ -16,7 +16,7 @@ included in the generated model.
 
 from onnxscript import FLOAT
 from onnxscript import opset15 as op
-from onnxscript import proto2text, script
+from onnxscript import script
 from onnxscript.values import Opset
 
 # A dummy opset used for model-local functions
@@ -43,17 +43,17 @@ def l2norm(x: FLOAT["N"], y: FLOAT["N"]) -> FLOAT[1]:  # noqa: F821
 # Let's see what the generated model looks like by default:
 
 model = l2norm.to_model_proto()
-print(proto2text(model))
+print(onnx.printer.to_text(model))
 
 # %%
 # Let's now explicitly specify which functions to include.
 # First, generate a model with no model-local functions:
 
 model = l2norm.to_model_proto(functions=[])
-print(proto2text(model))
+print(onnx.printer.to_text(model))
 
 # %%
 # Now, generate a model with one model-local function:
 
 model = l2norm.to_model_proto(functions=[sum])
-print(proto2text(model))
+print(onnx.printer.to_text(model))

--- a/docs/examples/06_plot_model_local_funs.py
+++ b/docs/examples/06_plot_model_local_funs.py
@@ -14,9 +14,10 @@ included in the generated model.
 # %%
 # First, let us define an ONNXScript function that calls other ONNXScript functions.
 
-from onnxscript import FLOAT
+import onnx
+
+from onnxscript import FLOAT, script
 from onnxscript import opset15 as op
-from onnxscript import script
 from onnxscript.values import Opset
 
 # A dummy opset used for model-local functions

--- a/docs/tutorial/examples/forloop.py
+++ b/docs/tutorial/examples/forloop.py
@@ -6,7 +6,7 @@ from onnxscript import script
 def sumprod(x, N):
     sum = op.Identity(x)
     prod = op.Identity(x)
-    for i in range(N):
+    for _ in range(N):
         sum = sum + x
         prod = prod * x
     return sum, prod

--- a/docs/tutorial/examples/forwhileloop.py
+++ b/docs/tutorial/examples/forwhileloop.py
@@ -6,7 +6,7 @@ from onnxscript import script
 def sumprod_break(x, N):
     sum = op.Identity(x)
     prod = op.Identity(x)
-    for i in range(N):
+    for _ in range(N):
         sum = sum + x
         prod = prod * x
         cond = op.ReduceSum(prod) > 1e7

--- a/docs/tutorial/examples/hardmax_end_to_end.py
+++ b/docs/tutorial/examples/hardmax_end_to_end.py
@@ -1,9 +1,8 @@
 import onnx
 
 # We use ONNX opset 15 to define the function below.
-from onnxscript import FLOAT
+from onnxscript import FLOAT, script
 from onnxscript import opset15 as op
-from onnxscript import script
 
 
 # We use the script decorator to indicate that

--- a/docs/tutorial/examples/outerscope_redef_error.py
+++ b/docs/tutorial/examples/outerscope_redef_error.py
@@ -1,5 +1,5 @@
+from onnxscript import graph, script
 from onnxscript import opset15 as op
-from onnxscript import script
 
 try:
 

--- a/docs/tutorial/examples/scanloop.py
+++ b/docs/tutorial/examples/scanloop.py
@@ -1,5 +1,5 @@
+from onnxscript import graph, script
 from onnxscript import opset15 as op
-from onnxscript import script
 
 
 @script()

--- a/onnxscript/__init__.py
+++ b/onnxscript/__init__.py
@@ -58,7 +58,7 @@ from .onnx_types import (
 
 # isort: on
 
-from ._internal.utils import external_tensor, proto2text
+from ._internal.utils import external_tensor
 from .values import OnnxFunction, TracedOnnxFunction
 
 try:
@@ -73,7 +73,6 @@ __all__ = [
     "OnnxFunction",
     "TracedOnnxFunction",
     "proto2python",
-    "proto2text",
     "external_tensor",
     "graph",
     "BFLOAT16",

--- a/onnxscript/_internal/utils.py
+++ b/onnxscript/_internal/utils.py
@@ -14,16 +14,6 @@ from onnx import FunctionProto, ModelProto, TensorProto, ValueInfoProto
 
 from onnxscript import tensor
 
-# print utility unavailable in ONNX 1.12 or earlier:
-# pylint: disable=unused-import, ungrouped-imports
-try:
-    from onnx.printer import to_text as proto2text
-except ImportError:
-
-    def proto2text(_: Any) -> str:  # type: ignore[misc]
-        return "<print utility unavailable>"
-
-
 # pylint: enable=unused-import, ungrouped-imports
 
 

--- a/onnxscript/backend/onnx_export_test.py
+++ b/onnxscript/backend/onnx_export_test.py
@@ -11,6 +11,7 @@ import re
 import unittest
 from typing import Pattern
 
+import onnx
 import onnxruntime as ort
 import parameterized
 from onnxruntime.capi import onnxruntime_pybind11_state
@@ -273,7 +274,7 @@ class TestOnnxBackEnd(unittest.TestCase):
         except Exception as e:
             raise AssertionError(
                 f"Unable to load onnx for test {backend_test.name!r}.\n"
-                f"{onnxscript.proto2text(proto)}\n"
+                f"{onnx.printer.to_text(proto)}\n"
                 f"-----\n"
                 f"{backend_test.onnx_model}"
             ) from e
@@ -298,7 +299,7 @@ class TestOnnxBackEnd(unittest.TestCase):
             except Exception as e:
                 raise AssertionError(
                     f"Unable to run test {backend_test.name!r} after conversion.\n"
-                    f"{onnxscript.proto2text(proto)}"
+                    f"{onnx.printer.to_text(proto)}"
                 ) from e
 
         backend_test.run(_load_function, _run_function)

--- a/onnxscript/evaluator.py
+++ b/onnxscript/evaluator.py
@@ -480,7 +480,7 @@ def _call_ort(
         raise EagerModeError(
             f"Unable to create onnxruntime InferenceSession "
             f"for executing {schema.domain}.{schema.name} op "
-            f"with onnx model\n{utils.proto2text(model)}"
+            f"with onnx model\n{onnx.printer.to_text(model)}"
         ) from e
 
     try:

--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -1029,7 +1029,7 @@ class TorchScriptGraph:
             warnings.warn(f"ONNX model is invalid: {e}", stacklevel=1)
             logging.debug(
                 "ONNX model:\n%s\n\nTorchScript graph:\n%s",
-                onnxscript.proto2text(onnx_model),
+                onnx.printer.to_text(onnx_model),
                 self.torch_graph,
             )
         return onnx_model

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_common.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_common.py
@@ -359,7 +359,7 @@ def _format_model_and_input_information(onnx_model, inputs):
         f"Inputs:\n"
         f"{pprint.pformat(inputs)}\n"
         f"Model:\n"
-        f"{onnxscript.proto2text(onnx_model)}"
+        f"{onnx.printer.to_text(onnx_model)}"
     )
 
 
@@ -526,7 +526,7 @@ def graph_executor(
             onnx.checker.check_model(onnx_model, full_check=True)
         except (onnx.checker.ValidationError, onnx.shape_inference.InferenceError) as e:
             raise AssertionError(
-                f"ONNX model is invalid. Model:\n{onnxscript.proto2text(onnx_model)}"
+                f"ONNX model is invalid. Model:\n{onnx.printer.to_text(onnx_model)}"
             ) from e
 
         try:


### PR DESCRIPTION
Remove proto2text because it is simply an alias of `onnx.printer.to_text`.