### PR TITLE
Add castlike to var | fix(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -8423,7 +8423,7 @@ def _aten_var_mean_dim_onnx(
         dim_size = op.Gather(self_shape, dim, axis=0)
         numel_float = op.CastLike(op.ReduceProd(dim_size, keepdims=False), self)
         mul = op.Mul(var, numel_float)
-        sub = op.Sub(numel_float, correction)
+        sub = op.Sub(numel_float, op.CastLike(correction, self))
         var = op.Div(mul, sub)
 
     return var, mean
@@ -8461,7 +8461,7 @@ def _aten_var_dim_onnx(
         dim_size = op.Gather(self_shape, dim, axis=0)
         numel_float = op.CastLike(op.ReduceProd(dim_size, keepdims=False), self)
         mul = op.Mul(var, numel_float)
-        sub = op.Sub(numel_float, correction)
+        sub = op.Sub(numel_float, op.CastLike(correction, self))
         var = op.Div(mul, sub)
 
     return var


### PR DESCRIPTION
Follow up of #1186 to fix the dtype mismatch in Sub in the `var`/`var.correction` implementation.