### PR TITLE
Fix linspace for float inputs | fix(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -4504,7 +4504,9 @@ def aten_linear_backward(
 
 
 @torch_op("aten::linspace", trace_only=True)
-def aten_linspace(start: TFloat, end: TFloat, steps: int, dtype: int = FLOAT.dtype) -> TensorType:
+def aten_linspace(
+    start: TFloat, end: TFloat, steps: int, dtype: int = FLOAT.dtype
+) -> TensorType:
     """linspace(Scalar start, Scalar end, int steps, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
 
     # Reference: https://github.com/pytorch/pytorch/blob/b35ca2cb941b5ba90858322810ca85c31e4541fd/torch/_refs/__init__.py#L4896
@@ -4514,12 +4516,13 @@ def aten_linspace(start: TFloat, end: TFloat, steps: int, dtype: int = FLOAT.dty
         return aten_full(op.Constant(value_ints=[steps]), start, dtype=dtype)
 
     rg = aten_arange_start(0, steps, dtype=dtype)
-    start = op.Cast(start, to=FLOAT.dtype)
-    end = op.Cast(end, to=FLOAT.dtype)
-    steps_float = op.Cast(steps, to=FLOAT.dtype)
-    one = op.Constant(value_float=1.0)
-    two = op.Constant(value_float=2.0)
-    step = op.Div(op.Sub(end, start), op.Constant(value_float=float(steps - 1)))
+    start = op.Cast(start, to=dtype)
+    end = op.Cast(end, to=dtype)
+    steps_float = op.Cast(steps, to=dtype)
+    one = op.Cast(1.0, to=dtype)
+    two = op.Cast(2.0, to=dtype)
+    steps_minus_1 = op.Cast(steps - 1, to=dtype)
+    step = op.Div(op.Sub(end, start), steps_minus_1)
     result = op.Where(
         rg < op.Div(steps_float, two),
         start + step * rg,
@@ -4527,7 +4530,6 @@ def aten_linspace(start: TFloat, end: TFloat, steps: int, dtype: int = FLOAT.dty
     )
 
     return op.Cast(result, to=dtype)
-
 
 
 @torch_op("aten::log")

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -4523,13 +4523,11 @@ def aten_linspace(
     two = op.Cast(2.0, to=dtype)
     steps_minus_1 = op.Cast(steps - 1, to=dtype)
     step = op.Div(op.Sub(end, start), steps_minus_1)
-    result = op.Where(
+    return op.Where(
         rg < op.Div(steps_float, two),
         start + step * rg,
         end - step * (steps_float - one - rg),
     )
-
-    return op.Cast(result, to=dtype)
 
 
 @torch_op("aten::log")

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -4504,40 +4504,30 @@ def aten_linear_backward(
 
 
 @torch_op("aten::linspace", trace_only=True)
-def aten_linspace(
-    start: TRealUnlessFloat16OrInt8, end: TRealUnlessFloat16OrInt8, steps: int, dtype: int = -1
-) -> TensorType:
+def aten_linspace(start: TFloat, end: TFloat, steps: int, dtype: int = FLOAT.dtype) -> TensorType:
     """linspace(Scalar start, Scalar end, int steps, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
 
-    if dtype == -1:
-        zero = op.CastLike(0.0, steps)
-        one = op.CastLike(1.0, steps)
-    elif _range_supported(dtype):
-        zero = op.Cast(0, to=dtype)
-        one = op.Cast(1, to=dtype)
-        start = op.Cast(start, to=dtype)
-        end = op.Cast(end, to=dtype)
-        steps = op.Cast(steps, to=dtype)
-    else:
-        # Cast input to float if dtype is not supported by Range,
-        # because the input dtype may be e.g. bfloat16 / int8 etc.
-        # which Range does not support. The output type is ensured because the output
-        # is casted to the specified dtype.
-        zero = op.Cast(0.0, to=FLOAT.dtype)
-        one = op.Cast(1.0, to=FLOAT.dtype)
-        start = op.Cast(start, to=FLOAT.dtype)
-        end = op.Cast(end, to=FLOAT.dtype)
-        steps = op.Cast(steps, to=FLOAT.dtype)
+    # Reference: https://github.com/pytorch/pytorch/blob/b35ca2cb941b5ba90858322810ca85c31e4541fd/torch/_refs/__init__.py#L4896
+    if steps == 0:
+        return aten_full(op.Constant(value_ints=[0]), 0.0, dtype=dtype)
+    if steps == 1:
+        return aten_full(op.Constant(value_ints=[steps]), start, dtype=dtype)
 
-    range_tensor = op.Range(zero, steps, one)
-
-    start = op.CastLike(start, end)
-    step = op.Div(
-        op.Sub(end, start),
-        op.Sub(steps, one),
+    rg = aten_arange_start(0, steps, dtype=dtype)
+    start = op.Cast(start, to=FLOAT.dtype)
+    end = op.Cast(end, to=FLOAT.dtype)
+    steps_float = op.Cast(steps, to=FLOAT.dtype)
+    one = op.Constant(value_float=1.0)
+    two = op.Constant(value_float=2.0)
+    step = op.Div(op.Sub(end, start), op.Constant(value_float=float(steps - 1)))
+    result = op.Where(
+        rg < op.Div(steps_float, two),
+        start + step * rg,
+        end - step * (steps_float - one - rg),
     )
 
-    return op.Add(op.Mul(range_tensor, step), start)
+    return op.Cast(result, to=dtype)
+
 
 
 @torch_op("aten::log")

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -886,15 +886,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         dtypes=(torch.int64, torch.int32, torch.float16),
         reason="fixme: Results do not match with PyTorch. https://github.com/microsoft/onnxscript/issues/854",
         enabled_if=not version_utils.torch_older_than("2.2"),
-    )
-    .xfail(
-        dtypes=(torch.float16,),
-        reason="op 'Range' doesn't support float16.",
     ),
-    # .skip(
-    #     matcher=lambda sample: len(sample.args) > 1 and sample.args[1] == 1,
-    #     reason="aten::linspace with steps=1 is not supported by its definition.",
-    # ),
     TorchLibOpInfo("log", core_ops.aten_log),
     TorchLibOpInfo("le", core_ops.aten_le),
     TorchLibOpInfo("le_bool", core_ops.aten_le_bool),

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -876,6 +876,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "linspace",
         core_ops.aten_linspace,
         trace_only=True,
+        tolerance={torch.float16: (2e-2, 2e-3)},
     )
     .xfail(
         dtypes=(torch.int64, torch.int32),
@@ -883,7 +884,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     )
     .xfail(
         variant_name="tensor_overload",
-        dtypes=(torch.int64, torch.int32, torch.float16),
+        dtypes=(torch.int64, torch.int32),
         reason="fixme: Results do not match with PyTorch. https://github.com/microsoft/onnxscript/issues/854",
         enabled_if=not version_utils.torch_older_than("2.2"),
     ),

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -890,11 +890,11 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     .xfail(
         dtypes=(torch.float16,),
         reason="op 'Range' doesn't support float16.",
-    )
-    .skip(
-        matcher=lambda sample: len(sample.args) > 1 and sample.args[1] == 1,
-        reason="aten::linspace with steps=1 is not supported by its definition.",
     ),
+    # .skip(
+    #     matcher=lambda sample: len(sample.args) > 1 and sample.args[1] == 1,
+    #     reason="aten::linspace with steps=1 is not supported by its definition.",
+    # ),
     TorchLibOpInfo("log", core_ops.aten_log),
     TorchLibOpInfo("le", core_ops.aten_le),
     TorchLibOpInfo("le_bool", core_ops.aten_le_bool),


### PR DESCRIPTION
Fix linspace for float32 and float16 inputs. Fix https://github.com/microsoft/onnxscript/issues/1190