### PR TITLE
Implement hardsigmoid and hardswish | feat(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -596,10 +596,11 @@ def aten_glu_jvp(glu: TensorType, x: TensorType, dx: TensorType, dim: int) -> Te
     raise NotImplementedError()
 
 
-def aten_hardsigmoid(self: TensorType) -> TensorType:
+@torch_op("aten::hardsigmoid")
+def aten_hardsigmoid(self: TFloat) -> TFloat:
     """hardsigmoid(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.HardSigmoid(self, alpha=1 / 6, beta=1 / 2)
 
 
 def aten_hardsigmoid_backward(grad_output: TensorType, self: TensorType) -> TensorType:
@@ -608,10 +609,11 @@ def aten_hardsigmoid_backward(grad_output: TensorType, self: TensorType) -> Tens
     raise NotImplementedError()
 
 
-def aten_hardswish(self: TensorType) -> TensorType:
+@torch_op("aten::hardswish")
+def aten_hardswish(self: TFloat) -> TFloat:
     """hardswish(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.HardSwish(self)
 
 
 def aten_hardswish_backward(grad_output: TensorType, self: TensorType) -> TensorType:

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1177,6 +1177,8 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         core_ops.aten_embedding,
         input_wrangler=_embedding_input_wrangler,
     ),
+    TorchLibOpInfo("nn.functional.hardsigmoid", nn_ops.aten_hardsigmoid),
+    TorchLibOpInfo("nn.functional.hardswish", nn_ops.aten_hardswish),
     TorchLibOpInfo("nn.functional.hardtanh", nn_ops.aten_hardtanh),
     TorchLibOpInfo("nn.functional.leaky_relu", nn_ops.aten_leaky_relu),
     TorchLibOpInfo(


### PR DESCRIPTION
Fixes https://github.com/microsoft/onnxscript/issues/1210. 

For hardsigmoid, `y = max(0, min(1, alpha * x + beta))` where `alpha=1/6` and `beta=0.5` is equivalent with the pytorch definition 
![image](https://github.com/microsoft/onnxscript/assets/11205048/8b9c7240-f0bb-4181-9018-3165bf9e521f)
