### PR TITLE
Fix fp16 aten_native_batch_norm when bias is None and training is True

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5555,10 +5555,14 @@ def aten_native_batch_norm(
     """native_batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps) -> (Tensor, Tensor, Tensor)"""
 
     if weight is None:  # Set to 1.0 as default
-        weight = op.Expand(op.Constant(value_floats=[1.0]), op.Shape(input, start=1, end=2))
+        weight = op.CastLike(
+            op.Expand(op.Constant(value_floats=[1.0]), op.Shape(input, start=1, end=2)), input
+        )
 
     if bias is None:  # Set to 0.0 as default
-        bias = op.Expand(op.Constant(value_floats=[0.0]), op.Shape(input, start=1, end=2))
+        bias = op.CastLike(
+            op.Expand(op.Constant(value_floats=[0.0]), op.Shape(input, start=1, end=2)), input
+        )
 
     axes = list(range(len(input.shape)))
     axes.pop(1)
@@ -5609,13 +5613,14 @@ def _aten_native_batch_norm_training_onnx(
         training_mode=training,
     )
     # Compute var and rstd
-    mean = op.ReduceMean(input, axes)
-    input_sub_mean = op.Sub(input, mean)
+    upcast_input = op.Cast(input, to=FLOAT.dtype)
+    mean = op.ReduceMean(upcast_input, axes)
+    input_sub_mean = op.Sub(upcast_input, mean)
     sqr = op.Mul(input_sub_mean, input_sub_mean)
     var = op.ReduceMean(sqr, axes, keepdims=False)
     rstd = op.Div(1.0, op.Sqrt(var + eps))
     # Get mean again with size = [1, C]
-    mean = op.ReduceMean(input, axes, keepdims=False)
+    mean = op.ReduceMean(upcast_input, axes, keepdims=False)
     return norm, mean, rstd
 
 
@@ -5724,13 +5729,14 @@ def _aten__native_batch_norm_training_functional_onnx(
         training_mode=training,
     )
     # Compute var and rstd
-    mean = op.ReduceMean(input, axes)
-    input_sub_mean = op.Sub(input, mean)
+    upcast_input = op.Cast(input, to=FLOAT.dtype)
+    mean = op.ReduceMean(upcast_input, axes)
+    input_sub_mean = op.Sub(upcast_input, mean)
     sqr = op.Mul(input_sub_mean, input_sub_mean)
     var = op.ReduceMean(sqr, axes, keepdims=False)
     rstd = op.Div(1.0, op.Sqrt(var + eps))
     # Get mean again with size = [1, C]
-    mean = op.ReduceMean(input, axes, keepdims=False)
+    mean = op.ReduceMean(upcast_input, axes, keepdims=False)
     # NOTE: Fixed to be FLOAT dtype
     running_mean = op.Cast(running_mean, to=FLOAT.dtype)
     running_var = op.Cast(running_var, to=FLOAT.dtype)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5555,13 +5555,15 @@ def aten_native_batch_norm(
     """native_batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps) -> (Tensor, Tensor, Tensor)"""
 
     if weight is None:  # Set to 1.0 as default
-        weight = op.CastLike(
-            op.Expand(op.Constant(value_floats=[1.0]), op.Shape(input, start=1, end=2)), input
+        weight = op.Expand(
+            op.CastLike(op.Constant(value_floats=[1.0]), input),
+            op.Shape(input, start=1, end=2),
         )
 
     if bias is None:  # Set to 0.0 as default
-        bias = op.CastLike(
-            op.Expand(op.Constant(value_floats=[0.0]), op.Shape(input, start=1, end=2)), input
+        bias = op.Expand(
+            op.CastLike(op.Constant(value_floats=[0.0]), input),
+            op.Shape(input, start=1, end=2),
         )
 
     axes = list(range(len(input.shape)))
@@ -5613,6 +5615,8 @@ def _aten_native_batch_norm_training_onnx(
         training_mode=training,
     )
     # Compute var and rstd
+    # Mean, var, and rstd computation and results are expected to be
+    # in higher precision when inputs are float16.
     upcast_input = op.Cast(input, to=FLOAT.dtype)
     mean = op.ReduceMean(upcast_input, axes)
     input_sub_mean = op.Sub(upcast_input, mean)
@@ -5729,6 +5733,8 @@ def _aten__native_batch_norm_training_functional_onnx(
         training_mode=training,
     )
     # Compute var and rstd
+    # Mean, var, and rstd computation and results are expected to be
+    # in higher precision when inputs are float16.
     upcast_input = op.Cast(input, to=FLOAT.dtype)
     mean = op.ReduceMean(upcast_input, axes)
     input_sub_mean = op.Sub(upcast_input, mean)

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1810,7 +1810,6 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "native_batch_norm",
         core_ops.aten_native_batch_norm,
         trace_only=True,
-        tolerance={torch.float16: (9e-3, 7e-4)},
     ),
     TorchLibOpInfo(
         "ops.aten._native_batch_norm_legit", core_ops.aten_native_batch_norm, trace_only=True


### PR DESCRIPTION
Fixes `nfnet` in https://github.com/microsoft/onnx-converters-private/issues/196

Two changes:

- Cast locally created `weight` and `bias` to `input` dtype.
- Upcast `input` when computing `mean` and `var`.

No idea how this was not covered by unittest. The test case seems to be there.

Minimized repro:

```python
import torch

class Module(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.bn = torch.nn.BatchNorm2d(3, track_running_stats=False)

    def forward(self, x):
        # return self.bn(x)
        return torch.nn.functional.batch_norm(x, None, None, self.bn.weight, training=True)
    
model = Module().cuda().to(dtype=torch.float16).eval()
x = torch.randn(1, 3, 224, 224, dtype=torch.float16).cuda()

op = torch.onnx.dynamo_export(model, x)
op.save("report_bn.onnx")
op.save_diagnostics("report_bn.sarif")


import onnxruntime
sess = onnxruntime.InferenceSession("report_bn.onnx")
sess.run(None, {"l_x_": x.cpu().numpy()})

```