### PR TITLE
Bump ORT nightly version to 1.17.0.dev20231218002 | chore(ci)

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,7 @@ COMMON_TEST_DEPENDENCIES = (
     "typing_extensions",
     "beartype!=0.16.0",
     "types-PyYAML",
-    "expecttest",
+    "expecttest==0.1.6",
     "hypothesis",
     "packaging",
     "parameterized",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1223,16 +1223,30 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo(
         "nn.functional.relu",
         nn_ops.aten_relu,
-    ).skip(
+    )
+    .xfail(
         dtypes=(torch.int64,),
+        enabled_if=version_utils.onnxruntime_older_than("1.17"),
         reason="fixme: ORT did not implement Relu for int64. https://github.com/microsoft/onnxruntime/issues/16654",
+    )
+    .xfail(
+        dtypes=(torch.int64,),
+        test_class_name="TestOutputConsistencyEager",
+        reason="fixme: ORT fails with 'Could not find an implementation for Relu(14) node'",
     ),
     TorchLibOpInfo(
         "nn.functional.relu6",
         nn_ops.aten_relu6,
-    ).skip(
+    )
+    .xfail(
         dtypes=(torch.int64,),
+        enabled_if=version_utils.onnxruntime_older_than("1.17"),
         reason="fixme: ORT did not implement Relu for int64. https://github.com/microsoft/onnxruntime/issues/16654",
+    )
+    .xfail(
+        dtypes=(torch.int64,),
+        test_class_name="TestOutputConsistencyEager",
+        reason="fixme: ORT fails with 'Could not find an implementation for Relu(14) node'",
     ),
     TorchLibOpInfo(
         "ops.aten.replication_pad1d",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1223,14 +1223,14 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo(
         "nn.functional.relu",
         nn_ops.aten_relu,
-    ).xfail(
+    ).skip(
         dtypes=(torch.int64,),
         reason="fixme: ORT did not implement Relu for int64. https://github.com/microsoft/onnxruntime/issues/16654",
     ),
     TorchLibOpInfo(
         "nn.functional.relu6",
         nn_ops.aten_relu6,
-    ).xfail(
+    ).skip(
         dtypes=(torch.int64,),
         reason="fixme: ORT did not implement Relu for int64. https://github.com/microsoft/onnxruntime/issues/16654",
     ),

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -722,6 +722,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     )
     .xfail(
         dtypes=(torch.float16,),
+        enabled_if=version_utils.onnxruntime_older_than("1.17"),
         reason="fixme: SplitToSequence op inference failed. https://github.com/microsoft/onnxruntime/issues/16006",
     )
     .xfail(
@@ -1470,6 +1471,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     )
     .xfail(
         dtypes=(torch.float16,),
+        enabled_if=version_utils.onnxruntime_older_than("1.17"),
         reason="fixme: ORT failed to produce the correct argument type: https://github.com/microsoft/onnxruntime/issues/16006",
     )
     .xfail(
@@ -1482,11 +1484,13 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     )
     .xfail(
         dtypes=(torch.float16,),
+        enabled_if=version_utils.onnxruntime_older_than("1.17"),
         reason="fixme: ORT failed to produce the correct argument type: https://github.com/microsoft/onnxruntime/issues/16006",
     )
     .xfail(
         variant_name="list_args",
         dtypes=(torch.float16,),
+        enabled_if=version_utils.onnxruntime_older_than("1.17"),
         reason="fixme: ORT failed to produce the correct argument type: https://github.com/microsoft/onnxruntime/issues/16006",
     )
     .xfail(
@@ -1563,6 +1567,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     )
     .xfail(
         dtypes=(torch.float16,),
+        enabled_if=version_utils.onnxruntime_older_than("1.17"),
         reason="fixme: SplitToSequence op inference failed. https://github.com/microsoft/onnxruntime/issues/16006",
     )
     .xfail(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ sphinx>=6
 beartype!=0.16.0
 
 # Testing
-expecttest
+expecttest==0.1.6
 hypothesis
 parameterized
 pytest-cov

--- a/requirements/ci/requirements-onnx-weekly.txt
+++ b/requirements/ci/requirements-onnx-weekly.txt
@@ -1,1 +1,1 @@
-onnx-weekly==1.16.0.dev20231218
+onnx-weekly==1.16.0.dev20231211

--- a/requirements/ci/requirements-ort-nightly.txt
+++ b/requirements/ci/requirements-ort-nightly.txt
@@ -1,3 +1,3 @@
 # https://aiinfra.visualstudio.com/PublicPackages/_artifacts/feed/ORT-Nightly/PyPI/ort-nightly/overview
 --index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
-ort-nightly==1.16.0.dev20230908001
+ort-nightly==1.17.0.dev20231218002


### PR DESCRIPTION
Pin `expecttest==0.1.6` because version `0.2` does not play very well with the pytorch version in CI.