### PR TITLE
Fully support on complex dtype | feat(graph_building)

### DIFF
--- a/onnxscript/function_libs/torch_lib/graph_building.py
+++ b/onnxscript/function_libs/torch_lib/graph_building.py
@@ -34,6 +34,7 @@ ValidArgumentType: TypeAlias = Union[
     Sequence["TorchScriptTensor"],
     Sequence[float],
     Sequence[int],
+    complex,
     str,
     int,
     float,
@@ -45,6 +46,7 @@ ValidInputType: TypeAlias = Union[
     Sequence["TorchScriptTensor"],
     Sequence[float],
     Sequence[int],
+    complex,
     str,
     int,
     float,
@@ -56,6 +58,7 @@ ValidTorchValueType: TypeAlias = Union[
     Sequence[torch.Value],
     Sequence[float],
     Sequence[int],
+    complex,
     str,
     int,
     float,
@@ -654,6 +657,10 @@ class TorchScriptGraph:
             isinstance(val, float) for val in constant
         ):
             constant_tensor = torch.tensor(constant, dtype=torch.float)
+        elif isinstance(constant, complex):
+            # NOTE: ONNX doesn't support tensor of complex64/complex128, so we
+            # convert them to float32/float64 with real representation.
+            constant_tensor = torch.view_as_real(torch.tensor(constant).resolve_conj())
         else:
             raise TypeError(
                 f"Constant input '{constant}' of type '{type(constant)}' is not supported"

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -7106,7 +7106,9 @@ def aten_scalar_tensor_complex(
     s: Union[FLOAT, DOUBLE], dtype: int = COMPLEX64.dtype
 ) -> RealType:
     """scalar_tensor(Scalar s, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
-
+    # NOTE: When the input is originally in complex, this function is invoked,
+    # on the other hand, when the input is originally in real, aten_scalar_tensor
+    # is invoked.
     if dtype == COMPLEX128.dtype:
         casted = op.Cast(s, to=DOUBLE.dtype)
     if dtype == COMPLEX64.dtype:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -7106,8 +7106,8 @@ def aten_scalar_tensor_complex(
     s: Union[FLOAT, DOUBLE], dtype: int = COMPLEX64.dtype
 ) -> RealType:
     """scalar_tensor(Scalar s, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
-    # NOTE: When the input is originally in complex, this function is invoked,
-    # on the other hand, when the input is originally in real, aten_scalar_tensor
+    # NOTE: When the input is originally in complex, this function is invoked.
+    # On the other hand, when the input is originally in real, aten_scalar_tensor is used.
     # is invoked.
     if dtype == COMPLEX128.dtype:
         s = op.Cast(s, to=DOUBLE.dtype)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -7110,10 +7110,14 @@ def aten_scalar_tensor_complex(
     # On the other hand, when the input is originally in real, aten_scalar_tensor is used.
     # is invoked.
     if dtype == COMPLEX128.dtype:
-        s = op.Cast(s, to=DOUBLE.dtype)
+        result = op.Cast(s, to=DOUBLE.dtype)
     elif dtype == COMPLEX64.dtype:
-        s = op.Cast(s, to=FLOAT.dtype)
-    return s
+        result = op.Cast(s, to=FLOAT.dtype)
+    else:
+        # NOTE: No-op for non-complex dtype
+        # It's potentially a bug if it comes here with no-op.
+        result = s
+    return result
 
 
 @torch_op("aten::scalar_tensor", trace_only=True)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -17,6 +17,8 @@ from typing import Any, Optional, Sequence, Tuple, Union
 from onnxscript import (
     BFLOAT16,
     BOOL,
+    COMPLEX64,
+    COMPLEX128,
     DOUBLE,
     FLOAT,
     FLOAT16,
@@ -1410,6 +1412,15 @@ def aten_cartesian_prod(tensors: Sequence[TensorType]) -> TensorType:
     """cartesian_prod(Tensor[] tensors) -> Tensor"""
 
     raise NotImplementedError()
+
+
+@torch_op("aten::cat", trace_only=True, complex=True)
+def aten_cat_complex(tensors: Sequence[TTensor], dim: int = 0) -> TTensor:
+    """cat(Tensor[] tensors, int dim=0) -> Tensor"""
+    # Real representation unsqueezes the last dimension
+    if dim < 0:
+        dim = dim - 1
+    return aten_cat(tensors, dim=dim)
 
 
 @torch_op("aten::cat")
@@ -7090,6 +7101,19 @@ def aten_scalar_tensor(s: float, dtype: int = FLOAT.dtype) -> RealType:
     return common_ops.cast_to(s, dtype=dtype)
 
 
+@torch_op("aten::scalar_tensor", trace_only=True, complex=True)
+def aten_scalar_tensor_complex(
+    s: Union[FLOAT, DOUBLE], dtype: int = COMPLEX64.dtype
+) -> RealType:
+    """scalar_tensor(Scalar s, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
+
+    if dtype == COMPLEX128.dtype:
+        casted = op.Cast(s, to=DOUBLE.dtype)
+    if dtype == COMPLEX64.dtype:
+        casted = op.Cast(s, to=FLOAT.dtype)
+    return casted
+
+
 @torch_op("aten::scalar_tensor", trace_only=True)
 def aten_scalar_tensor_sym_number(s: RealType, dtype: int = FLOAT.dtype) -> RealType:
     """scalar_tensor(Scalar s, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
@@ -7518,6 +7542,15 @@ def aten_sspaddmm(
     """sspaddmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor"""
 
     raise NotImplementedError()
+
+
+@torch_op("aten::stack", trace_only=True, complex=True)
+def aten_stack_complex(tensors: Sequence[TTensorOrString], dim: int = 0) -> TTensorOrString:
+    """stack(Tensor[] tensors, int dim=0) -> Tensor"""
+    # Real representation unsqueezes the last dimension
+    if dim < 0:
+        dim = dim - 1
+    return aten_stack(tensors, dim)
 
 
 @torch_op("aten::stack")
@@ -8088,7 +8121,7 @@ def aten_triplet_margin_loss(
 
 
 @torch_op("aten::triu")
-def aten_triu(self: TensorType, diagonal: int = 0) -> TensorType:
+def aten_triu(self: TTensor, diagonal: int = 0) -> TTensor:
     """triu(Tensor self, int diagonal=0) -> Tensor"""
 
     return op.Trilu(self, diagonal, upper=1)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -7110,10 +7110,10 @@ def aten_scalar_tensor_complex(
     # on the other hand, when the input is originally in real, aten_scalar_tensor
     # is invoked.
     if dtype == COMPLEX128.dtype:
-        casted = op.Cast(s, to=DOUBLE.dtype)
-    if dtype == COMPLEX64.dtype:
-        casted = op.Cast(s, to=FLOAT.dtype)
-    return casted
+        s = op.Cast(s, to=DOUBLE.dtype)
+    elif dtype == COMPLEX64.dtype:
+        s = op.Cast(s, to=FLOAT.dtype)
+    return s
 
 
 @torch_op("aten::scalar_tensor", trace_only=True)

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -20,6 +20,20 @@ S = 5
 M = 10
 
 
+def sample_inputs_scalar_tensor(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+    del device
+    del requires_grad
+    # Not including a scalar tensor in vals because meta tests start failing due to
+    # lack of meta support for _local_scalar_dense
+    # torch.tensor(2, device=device)
+    vals = (-5j, 0j, 1j)
+
+    for item in vals:
+        yield opinfo_core.SampleInput(item, dtype=dtype)
+
+
 def sample_inputs_bernoulli_p(op_info, device, dtype, requires_grad, **kwargs):
     del op_info
 
@@ -1879,6 +1893,14 @@ OP_DB: List[opinfo_core.OpInfo] = [
         aten_name="max_pool3d_with_indices",
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
         sample_inputs_func=sample_inputs_max_pool3d_with_indices,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.scalar_tensor",
+        aten_name="scalar_tensor",
+        dtypes=common_dtype.complex_types(),
+        sample_inputs_func=sample_inputs_scalar_tensor,
+        supports_autograd=False,
         supports_out=False,
     ),
 ]

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_common.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_common.py
@@ -263,6 +263,8 @@ def convert_tensor_to_numpy(input: Any) -> Any:
             # from complex to real representation
             input = torch.view_as_real(input)
         return input.detach().cpu().numpy()
+    if isinstance(input, complex):
+        return torch.view_as_real(torch.tensor(input)).detach().cpu().numpy()
     if isinstance(input, (tuple, list)):
         if len(input) == 0:
             return np.array((), dtype=np.int64)

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1407,7 +1407,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ),
     TorchLibOpInfo(
         "scalar_tensor",
-        core_ops.aten_scalar_tensor,
+        core_ops.aten_scalar_tensor,  # aten_scalar_tensor_complex supports complex input
         input_wrangler=_scalar_tensor_input_wrangler,
         trace_only=True,
         complex=True,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -715,6 +715,10 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         matcher=lambda sample: sample.input[0].equal(torch.tensor([])),
         reason="fixme: ORT aborts with zero-dim tensors. https://github.com/microsoft/onnxruntime/issues/16619",
     ),
+    TorchLibOpInfo("cat", core_ops.aten_cat_complex, trace_only=True, complex=True).skip(
+        matcher=lambda sample: sample.input[0].equal(torch.tensor([])),
+        reason="fixme: ORT aborts with zero-dim tensors. https://github.com/microsoft/onnxruntime/issues/16619",
+    ),
     TorchLibOpInfo("ceil", core_ops.aten_ceil),
     TorchLibOpInfo(
         "chunk",
@@ -1428,6 +1432,16 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         complex=True,
     ),
     TorchLibOpInfo(
+        "scalar_tensor",
+        core_ops.aten_scalar_tensor_complex,
+        input_wrangler=_scalar_tensor_input_wrangler,
+        trace_only=True,
+        complex=True,
+    ).skip(
+        matcher=lambda sample: not isinstance(sample.input, torch.Tensor),
+        reason="this Aten overload only support complex input (real representation)",
+    ),
+    TorchLibOpInfo(
         "scatter_add",
         core_ops.aten_scatter_add,
     )
@@ -1541,6 +1555,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="this Aten overload only support one tensor as input by design",
     ),
     TorchLibOpInfo("stack", core_ops.aten_stack),
+    TorchLibOpInfo("stack", core_ops.aten_stack_complex, complex=True, trace_only=True),
     TorchLibOpInfo("sub", core_ops.aten_sub),
     TorchLibOpInfo("sub", core_ops.aten_sub_complex, complex=True, trace_only=True),
     # TorchLibOpInfo("sym_size", core_ops.aten_sym_size),  # no test case in OPS_DB

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1426,20 +1426,16 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ),
     TorchLibOpInfo(
         "scalar_tensor",
-        core_ops.aten_scalar_tensor,  # aten_scalar_tensor_complex supports complex input
+        core_ops.aten_scalar_tensor,
         input_wrangler=_scalar_tensor_input_wrangler,
         trace_only=True,
         complex=True,
     ),
     TorchLibOpInfo(
-        "scalar_tensor",
+        "ops.aten.scalar_tensor",
         core_ops.aten_scalar_tensor_complex,
-        input_wrangler=_scalar_tensor_input_wrangler,
         trace_only=True,
         complex=True,
-    ).skip(
-        matcher=lambda sample: not isinstance(sample.input, torch.Tensor),
-        reason="this Aten overload only support complex input (real representation)",
     ),
     TorchLibOpInfo(
         "scatter_add",


### PR DESCRIPTION
Previous to this PR, the graph didn't support complex dtype attributes, and dim offset of cat/stack is not considered in complex dtype.

Adds:
(1) Support complex constant (convert to real reprentation)
(2) Add cat/stack complex support

NOTE: `aten_scalar_tensor_complex` only supports complex input, and if input is real to convert to complex, `aten_scalar_tensor` is invoked instead, just like we have in tests. 