### PR TITLE
Refactor and fix upsample 2d | fix(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -2254,7 +2254,8 @@ def aten_upsample_bicubic2d(
 ) -> TReal:
     """upsample_bicubic2d(Tensor self, SymInt[2] output_size, bool align_corners, float? scales_h=None, float? scales_w=None) -> Tensor"""
 
-    # Based on experimentation, scales_h and scales_w are always ignored in PyTorch
+    # NOTE: Based on experimentation, scales_h and scales_w are always ignored in PyTorch,
+    # unless when align_corners is True, in which case we do not know what is going on.
     coordinate_transformation_mode = _get_upsample_align_corners_mode(align_corners)
     return _aten_upsample_output_size(
         self,

--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -2316,7 +2316,8 @@ def aten_upsample_bilinear2d(
 ) -> TReal:
     """upsample_bilinear2d(Tensor self, SymInt[2] output_size, bool align_corners, float? scales_h=None, float? scales_w=None) -> Tensor"""
 
-    # Based on experimentation, scales_h and scales_w are always ignored in PyTorch
+    # NOTE: Based on experimentation, scales_h and scales_w are always ignored in PyTorch,
+    # unless when align_corners is True, in which case we do not know what is going on.
     coordinate_transformation_mode = _get_upsample_align_corners_mode(align_corners)
     return _aten_upsample_output_size(
         self,

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -1461,22 +1461,22 @@ def sample_inputs_upsample_2d(op_info, device, dtype, requires_grad, **kwargs):
 
     for align_corners in align_corners_options:
         yield opinfo_core.SampleInput(
-            make_arg(shape(D, rank)), shape(S, rank, False), align_corners
+            make_arg(shape(D, rank)), shape(S, rank, False), align_corners=align_corners
         )
         yield opinfo_core.SampleInput(
             make_arg(shape(D, rank)),
             shape(L, rank, False),
-            align_corners,
+            align_corners=align_corners,
         )
         yield opinfo_core.SampleInput(
             make_arg(shape(D, rank)),
-            args=(shape(L, rank, False), align_corners),
-            kwargs=dict(scales_h=0.6, scales_w=4.2),
+            args=(shape(L, rank, False),),
+            kwargs=dict(align_corners=align_corners, scales_h=0.6, scales_w=4.2),
         )
         yield opinfo_core.SampleInput(
             make_arg(shape(D, rank)),
-            args=(shape(L, rank, False), align_corners),
-            kwargs=dict(scales_h=4.2, scales_w=0.6),
+            args=(shape(L, rank, False),),
+            kwargs=dict(align_corners=align_corners, scales_h=4.2, scales_w=0.6),
         )
 
 

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -1470,15 +1470,13 @@ def sample_inputs_upsample_2d(op_info, device, dtype, requires_grad, **kwargs):
         )
         yield opinfo_core.SampleInput(
             make_arg(shape(D, rank)),
-            None,  # output_size
-            align_corners,
-            1.7, 1.7,  # scaler
+            args=(shape(L, rank, False), align_corners),
+            kwargs=dict(scales_h=0.6, scales_w=4.2),
         )
         yield opinfo_core.SampleInput(
             make_arg(shape(D, rank)),
-            None,  # if this is None, the scalar must be list
-            align_corners,
-            0.6, 0.6,
+            args=(shape(L, rank, False), align_corners),
+            kwargs=dict(scales_h=4.2, scales_w=0.6),
         )
 
 
@@ -1508,29 +1506,43 @@ def sample_inputs_upsample_2d_vec(op_info, device, dtype, requires_grad, **kwarg
         high=1,
     )
 
-    yield opinfo_core.SampleInput(make_arg(shape(D, rank)), shape(SS, rank, False), True)
+    yield opinfo_core.SampleInput(make_arg(shape(D, rank)), shape(SS, rank, False), True, None)
 
     for align_corners in align_corners_options:
         yield opinfo_core.SampleInput(
-            make_arg(shape(D, rank)), shape(S, rank, False), align_corners
+            make_arg(shape(D, rank)), shape(S, rank, False), align_corners, None
         )
         yield opinfo_core.SampleInput(
             make_arg(shape(D, rank)),
             shape(L, rank, False),
             align_corners,
+            None,
         )
         yield opinfo_core.SampleInput(
             make_arg(shape(D, rank)),
-            None,  # output_size
-            align_corners,
-            (1.7, 1.7),  # scaler
+            args=(
+                None,  # output_size
+                align_corners,
+            ),
+            kwargs=dict(scale_factors=(1.7, 1.7)),
         )
         yield opinfo_core.SampleInput(
             make_arg(shape(D, rank)),
-            None,  # if this is None, the scalar must be list
-            align_corners,
-            (0.6, 0.6),
+            args=(
+                None,  # if this is None, the scalar must be list
+                align_corners,
+            ),
+            kwargs=dict(scale_factors=(0.6, 0.6)),
         )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)),
+            args=(
+                None,  # if this is None, the scalar must be list
+                align_corners,
+            ),
+            kwargs=dict(scale_factors=(0.6, 4.2)),
+        )
+
 
 class _TestParamsMaxPoolEmptyStrideBase:
     # Adapted from https://github.com/pytorch/pytorch/blob/d6d55f8590eab05d2536756fb4efcfb2d07eb81a/torch/testing/_internal/common_methods_invocations.py#L3203
@@ -1998,7 +2010,7 @@ OP_DB: List[opinfo_core.OpInfo] = [
         supports_out=False,
     ),
     opinfo_core.OpInfo(
-        "ops.aten.upsample_bicubic2d",
+        "ops.aten.upsample_bicubic2d.default",
         aten_name="upsample_bicubic2d",
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
         sample_inputs_func=sample_inputs_upsample_2d,
@@ -2012,7 +2024,7 @@ OP_DB: List[opinfo_core.OpInfo] = [
         supports_out=False,
     ),
     opinfo_core.OpInfo(
-        "ops.aten.upsample_bilinear2d",
+        "ops.aten.upsample_bilinear2d.default",
         aten_name="upsample_bilinear2d",
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
         sample_inputs_func=sample_inputs_upsample_2d,

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -1431,7 +1431,58 @@ def sample_inputs_unfold(op_info, device, dtype, requires_grad, **kwargs):
         yield opinfo_core.SampleInput(t, args=(dimension, size, step))
 
 
-def sample_inputs_upsample_bicubic2d(op_info, device, dtype, requires_grad, **kwargs):
+def sample_inputs_upsample_2d(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+
+    N, C = 2, 3
+    D = 4
+    SS = 3
+    L = 5
+
+    align_corners_options = (True, False)
+    rank = 2
+
+    def shape(size, rank, with_batch_channel=True):
+        if with_batch_channel:
+            return tuple([N, C] + ([size] * rank))
+        return tuple([size] * rank)
+
+    make_arg = functools.partial(
+        torch_testing.make_tensor,
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+        low=-1,
+        high=1,
+    )
+
+    yield opinfo_core.SampleInput(make_arg(shape(D, rank)), shape(SS, rank, False), True)
+
+    for align_corners in align_corners_options:
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)), shape(S, rank, False), align_corners
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)),
+            shape(L, rank, False),
+            align_corners,
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)),
+            None,  # output_size
+            align_corners,
+            1.7, 1.7,  # scaler
+        )
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)),
+            None,  # if this is None, the scalar must be list
+            align_corners,
+            0.6, 0.6,
+        )
+
+
+def sample_inputs_upsample_2d_vec(op_info, device, dtype, requires_grad, **kwargs):
     del op_info
     del kwargs
 
@@ -1480,7 +1531,6 @@ def sample_inputs_upsample_bicubic2d(op_info, device, dtype, requires_grad, **kw
             align_corners,
             (0.6, 0.6),
         )
-
 
 class _TestParamsMaxPoolEmptyStrideBase:
     # Adapted from https://github.com/pytorch/pytorch/blob/d6d55f8590eab05d2536756fb4efcfb2d07eb81a/torch/testing/_internal/common_methods_invocations.py#L3203
@@ -1951,7 +2001,28 @@ OP_DB: List[opinfo_core.OpInfo] = [
         "ops.aten.upsample_bicubic2d",
         aten_name="upsample_bicubic2d",
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
-        sample_inputs_func=sample_inputs_upsample_bicubic2d,
+        sample_inputs_func=sample_inputs_upsample_2d,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.upsample_bicubic2d.vec",
+        aten_name="upsample_bicubic2d.vec",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_upsample_2d_vec,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.upsample_bilinear2d",
+        aten_name="upsample_bilinear2d",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_upsample_2d,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.upsample_bilinear2d.vec",
+        aten_name="upsample_bilinear2d.vec",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_upsample_2d_vec,
         supports_out=False,
     ),
     opinfo_core.OpInfo(

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -1461,22 +1461,22 @@ def sample_inputs_upsample_2d(op_info, device, dtype, requires_grad, **kwargs):
 
     for align_corners in align_corners_options:
         yield opinfo_core.SampleInput(
-            make_arg(shape(D, rank)), shape(S, rank, False), align_corners=align_corners
+            make_arg(shape(D, rank)), shape(S, rank, False), align_corners
         )
         yield opinfo_core.SampleInput(
             make_arg(shape(D, rank)),
             shape(L, rank, False),
-            align_corners=align_corners,
+            align_corners,
         )
         yield opinfo_core.SampleInput(
             make_arg(shape(D, rank)),
-            args=(shape(L, rank, False),),
-            kwargs=dict(align_corners=align_corners, scales_h=0.6, scales_w=4.2),
+            args=(shape(L, rank, False), align_corners),
+            kwargs=dict(scales_h=0.6, scales_w=4.2),
         )
         yield opinfo_core.SampleInput(
             make_arg(shape(D, rank)),
-            args=(shape(L, rank, False),),
-            kwargs=dict(align_corners=align_corners, scales_h=4.2, scales_w=0.6),
+            args=(shape(L, rank, False), align_corners),
+            kwargs=dict(scales_h=4.2, scales_w=0.6),
         )
 
 

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -2108,6 +2108,9 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "ops.aten.upsample_bilinear2d.default",
         nn_ops.aten_upsample_bilinear2d,
         trace_only=True,
+    ).skip(
+        matcher=lambda sample: sample.kwargs.get("align_corners") is False,
+        reason="fixme: align_corners=False output mismatch",
     ),
     TorchLibOpInfo(
         "ops.aten.upsample_bilinear2d.vec",
@@ -2118,6 +2121,9 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "ops.aten.upsample_bicubic2d.default",
         nn_ops.aten_upsample_bicubic2d,
         trace_only=True,
+    ).skip(
+        matcher=lambda sample: sample.kwargs.get("align_corners") is False,
+        reason="fixme: align_corners=False output mismatch",
     ),
     TorchLibOpInfo(
         "ops.aten.upsample_bicubic2d.vec",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -418,57 +418,6 @@ def _sum_input_wrangler(
 def _upsample_input_wrangler(
     args: list[Any], kwargs: dict[str, Any]
 ) -> tuple[list[Any], dict[str, Any]]:
-    # Wrangler for the signature difference between
-    #   'nn.functional.upsample_bilinear'
-    # and
-    #   'aten::upsample_bilinear2d'
-    # https://pytorch.org/docs/stable/generated/torch.nn.functional.upsample_bilinear.html
-    if "size" in kwargs:
-        args.append(np.array(kwargs["size"], dtype=np.int64))
-        del kwargs["size"]  # promote tensor type kwargs to args
-    else:
-        args.append(None)
-    if "align_corners" in kwargs:
-        args.append(kwargs["align_corners"])
-        del kwargs["align_corners"]
-    else:
-        args.append(True)  # Fill in the default value
-    if "scale_factor" in kwargs:
-        kwargs["scales_h"] = kwargs["scale_factor"]
-        kwargs["scales_w"] = kwargs["scale_factor"]
-        del kwargs["scale_factor"]  # adapt the function signature
-    return args, kwargs
-
-
-def _upsample_vec_input_wrangler(
-    args: list[Any], kwargs: dict[str, Any]
-) -> tuple[list[Any], dict[str, Any]]:
-    # Wrangler for the signature difference between
-    #   'nn.functional.upsample_bilinear'
-    # and
-    #   'aten::upsample_bilinear2d.vec'
-    # https://pytorch.org/docs/stable/generated/torch.nn.functional.upsample_bilinear.html
-    if "size" in kwargs:
-        args.append(np.array(kwargs["size"], dtype=np.int64))
-        del kwargs["size"]  # promote tensor type kwargs to args
-    else:
-        args.append(None)
-    if "align_corners" in kwargs:
-        args.append(kwargs["align_corners"])
-        del kwargs["align_corners"]
-    else:
-        args.append(True)  # Fill in the default value
-    if "scale_factor" in kwargs:
-        args.append([kwargs["scale_factor"]] * 2)
-        del kwargs["scale_factor"]  # promote tensor type kwargs to args
-    else:
-        args.append(None)
-    return args, kwargs
-
-
-def _upsample_input_wrangler(
-    args: list[Any], kwargs: dict[str, Any]
-) -> tuple[list[Any], dict[str, Any]]:
     if "scale_factor" in kwargs:
         kwargs["scales_h"] = kwargs["scale_factor"]
         kwargs["scales_w"] = kwargs["scale_factor"]
@@ -2156,27 +2105,23 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         test_class_name="TestOutputConsistencyEager",
     ),
     TorchLibOpInfo(
-        "ops.aten.upsample_bilinear2d",
+        "ops.aten.upsample_bilinear2d.default",
         nn_ops.aten_upsample_bilinear2d,
-        input_wrangler=_upsample_input_wrangler,
         trace_only=True,
     ),
     TorchLibOpInfo(
         "ops.aten.upsample_bilinear2d.vec",
         nn_ops.aten_upsample_bilinear2d_vec,
-        input_wrangler=_upsample_vec_input_wrangler,
         trace_only=True,
     ),
     TorchLibOpInfo(
-        "ops.aten.upsample_bicubic2d",
+        "ops.aten.upsample_bicubic2d.default",
         nn_ops.aten_upsample_bicubic2d,
-        input_wrangler=_upsample_input_wrangler,
         trace_only=True,
     ),
     TorchLibOpInfo(
         "ops.aten.upsample_bicubic2d.vec",
         nn_ops.aten_upsample_bicubic2d_vec,
-        input_wrangler=_upsample_input_wrangler,
         trace_only=True,
     ),
     TorchLibOpInfo(

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -2108,9 +2108,10 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "ops.aten.upsample_bilinear2d.default",
         nn_ops.aten_upsample_bilinear2d,
         trace_only=True,
-    ).skip(
-        matcher=lambda sample: sample.args[1] is False,
-        reason="fixme: align_corners=False output mismatch",
+    ).xfail(
+        matcher=lambda sample: sample.args[1] is False
+        and sample.kwargs.get("scales_h") is not None,
+        reason="fixme: align_corners=False output mismatch when scales are provided",
     ),
     TorchLibOpInfo(
         "ops.aten.upsample_bilinear2d.vec",
@@ -2121,9 +2122,10 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "ops.aten.upsample_bicubic2d.default",
         nn_ops.aten_upsample_bicubic2d,
         trace_only=True,
-    ).skip(
-        matcher=lambda sample: sample.args[1] is False,
-        reason="fixme: align_corners=False output mismatch",
+    ).xfail(
+        matcher=lambda sample: sample.args[1] is False
+        and sample.kwargs.get("scales_h") is not None,
+        reason="fixme: align_corners=False output mismatch when scales are provided",
     ),
     TorchLibOpInfo(
         "ops.aten.upsample_bicubic2d.vec",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -2109,7 +2109,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         nn_ops.aten_upsample_bilinear2d,
         trace_only=True,
     ).skip(
-        matcher=lambda sample: sample.kwargs.get("align_corners") is False,
+        matcher=lambda sample: sample.args[1] is False,
         reason="fixme: align_corners=False output mismatch",
     ),
     TorchLibOpInfo(
@@ -2122,7 +2122,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         nn_ops.aten_upsample_bicubic2d,
         trace_only=True,
     ).skip(
-        matcher=lambda sample: sample.kwargs.get("align_corners") is False,
+        matcher=lambda sample: sample.args[1] is False,
         reason="fixme: align_corners=False output mismatch",
     ),
     TorchLibOpInfo(

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -415,7 +415,7 @@ def _sum_input_wrangler(
     return args, kwargs
 
 
-def _upsample_bilinear2d_input_wrangler(
+def _upsample_input_wrangler(
     args: list[Any], kwargs: dict[str, Any]
 ) -> tuple[list[Any], dict[str, Any]]:
     # Wrangler for the signature difference between
@@ -440,7 +440,7 @@ def _upsample_bilinear2d_input_wrangler(
     return args, kwargs
 
 
-def _upsample_bilinear2d_vec_input_wrangler(
+def _upsample_vec_input_wrangler(
     args: list[Any], kwargs: dict[str, Any]
 ) -> tuple[list[Any], dict[str, Any]]:
     # Wrangler for the signature difference between
@@ -2156,20 +2156,27 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         test_class_name="TestOutputConsistencyEager",
     ),
     TorchLibOpInfo(
-        "nn.functional.upsample_bilinear2d",
+        "ops.aten.upsample_bilinear2d",
         nn_ops.aten_upsample_bilinear2d,
-        input_wrangler=_upsample_bilinear2d_input_wrangler,
+        input_wrangler=_upsample_input_wrangler,
         trace_only=True,
     ),
     TorchLibOpInfo(
-        "nn.functional.upsample_bilinear2d",
+        "ops.aten.upsample_bilinear2d.vec",
         nn_ops.aten_upsample_bilinear2d_vec,
-        input_wrangler=_upsample_bilinear2d_vec_input_wrangler,
+        input_wrangler=_upsample_vec_input_wrangler,
         trace_only=True,
     ),
     TorchLibOpInfo(
         "ops.aten.upsample_bicubic2d",
         nn_ops.aten_upsample_bicubic2d,
+        input_wrangler=_upsample_input_wrangler,
+        trace_only=True,
+    ),
+    TorchLibOpInfo(
+        "ops.aten.upsample_bicubic2d.vec",
+        nn_ops.aten_upsample_bicubic2d_vec,
+        input_wrangler=_upsample_input_wrangler,
         trace_only=True,
     ),
     TorchLibOpInfo(
@@ -2402,11 +2409,6 @@ ops_test_common.duplicate_opinfo(
     OPS_DB,
     "nn.functional.celu",
     ("nn.functional.celu_type_promoted",),
-)
-ops_test_common.duplicate_opinfo(
-    OPS_DB,
-    "nn.functional.upsample_bilinear",
-    ("nn.functional.upsample_bilinear2d",),
 )
 ops_test_common.duplicate_opinfo(
     OPS_DB,


### PR DESCRIPTION
- Refactor upsample 2d functions to use a common set of logics
- Add additional tests (`align_corners=False`; test the `aten::upsample_bicubic2d.vec` overload)
- Fix implementation for `aten::upsample_bicubic2d` by isolating the `aten::upsample_bicubic2d.vec` overload because it has a different signature.
- xfail `align_corners=False` and when scale_w and scale_h are specified