### PR TITLE
Add Op (_upsample_bilinear2d_aa, _upsample_bicubic2d_aa) | feat(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -2205,8 +2205,8 @@ def _get_upsample_align_corners_mode(align_corners: bool) -> str:
     (
         "aten::upsample_bicubic2d",
         "aten::upsample_bicubic2d_aa",
-        "aten::upsample_bilinear2d_aa",
         "aten::upsample_bilinear2d",
+        "aten::upsample_bilinear2d_aa",
         "aten::upsample_nearest1d",
         "aten::upsample_nearest2d",
         "aten::upsample_nearest3d",

--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -2208,7 +2208,7 @@ def _get_upsample_align_corners_mode(align_corners: bool) -> str:
         "aten::upsample_bilinear2d",
         "aten::upsample_bilinear2d_aa",
     ),
-    private=True
+    private=True,
 )
 def _aten_upsample_output_size(
     self: TReal,
@@ -2230,7 +2230,7 @@ def _aten_upsample_output_size(
         mode=mode,
         coordinate_transformation_mode=coordinate_transformation_mode,
         nearest_mode="floor",
-        antialias = antialias,
+        antialias=antialias,
     )
 
 

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -2052,10 +2052,24 @@ OP_DB: List[opinfo_core.OpInfo] = [
         supports_out=False,
     ),
     opinfo_core.OpInfo(
+        "ops.aten._upsample_bicubic2d_aa",
+        aten_name="_upsample_bicubic2d_aa",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_upsample_2d,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
         "ops.aten.upsample_bicubic2d.vec",
         aten_name="upsample_bicubic2d.vec",
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
         sample_inputs_func=sample_inputs_upsample_2d_vec,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten._upsample_bilinear2d_aa",
+        aten_name="_upsample_bilinear2d_aa",
+        dtypes=common_dtype.floating_types_and(torch.bfloat16),
+        sample_inputs_func=sample_inputs_upsample_2d,
         supports_out=False,
     ),
     opinfo_core.OpInfo(

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -2113,6 +2113,13 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         reason="fixme: align_corners=False output mismatch when scales are provided",
     ),
     TorchLibOpInfo(
+        "ops.aten._upsample_bilinear2d_aa",
+        nn_ops.aten__upsample_bilinear2d_aa,
+        trace_only=True,
+        # ONNX use different antialias method than PyTorch, so the result is different
+        compare_shape_only_for_output=(0,),
+    ),
+    TorchLibOpInfo(
         "ops.aten.upsample_bilinear2d.vec",
         nn_ops.aten_upsample_bilinear2d_vec,
         trace_only=True,
@@ -2130,6 +2137,13 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "ops.aten.upsample_bicubic2d.vec",
         nn_ops.aten_upsample_bicubic2d_vec,
         trace_only=True,
+    ),
+    TorchLibOpInfo(
+        "ops.aten._upsample_bicubic2d_aa",
+        nn_ops.aten__upsample_bicubic2d_aa,
+        trace_only=True,
+        # ONNX use different antialias method than PyTorch, so the result is different
+        compare_shape_only_for_output=(0,),
     ),
     TorchLibOpInfo(
         "ops.aten.upsample_linear1d",


### PR DESCRIPTION
It seems that the antialias method is different between ONNX and PyTorch, so we can just compare the shape, instead of the value.

Below is the difference between ONXN and PyTorch:

```python
# ONNX
import numpy as np
self = np.array([[[[2,1,1,1],
                   [1,1,1,1],
                   [1,1,1,1],
                   [1,1,1,1]]]]).astype(np.float32)
print(self.shape)
output_size = np.array([1,1]).astype(np.int64)
align_corners = True
r = aten__upsample_bicubic2d_aa(self, output_size, align_corners)
print(r)
```
ONXN output = [[[[1.390625]]]]
```python
# PyTorch
import torch as t
r = t.ops.aten._upsample_bicubic2d_aa(t.tensor(self), t.tensor(output_size), align_corners)
print(r)
```
Torch output = tensor([[[[2.2656]]]])

I also tried some other parameters combination but none of them can match with torch.