### PR TITLE
Fix and simplify native_batch_norm | fix(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5817,7 +5817,6 @@ def aten__native_batch_norm_legit_functional(
                 bias,
                 running_mean,
                 running_var,
-                axes,
                 momentum=1.0 - momentum,
                 eps=eps,
             )

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5648,8 +5648,8 @@ def aten_native_batch_norm(
         sqr_input_sub_mean = op.Mul(input_sub_mean, input_sub_mean)
         running_var = op.Squeeze(op.ReduceMean(sqr_input_sub_mean, axes))
 
-    # Have to split to 2 private functions, because training_function return 3 outputs
-    # While inference_function return 1 output
+    # We have to split to two private functions, because BatchNormalization returns
+    # three outputs when training_mode=True and one when it is False.
     if training is True:
         norm, mean, var = _aten_native_batch_norm_training_onnx(
             input, weight, bias, running_mean, running_var, axes, training, momentum, eps
@@ -5764,8 +5764,8 @@ def aten__native_batch_norm_legit_functional(
         sqr_input_sub_mean = op.Mul(input_sub_mean, input_sub_mean)
         running_var = op.Squeeze(op.ReduceMean(sqr_input_sub_mean, axes))
 
-    # Have to split to 2 private functions, because training_function return 3 outputs
-    # While inference_function return 1 output
+    # We have to split to two private functions, because BatchNormalization returns
+    # three outputs when training_mode=True and one when it is False.
     if training:
         norm, new_mean, new_var = _aten_native_batch_norm_training_onnx(
             input, weight, bias, running_mean, running_var, axes, momentum=momentum, eps=eps

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -4237,7 +4237,7 @@ def aten_instance_norm(
         running_mean,
         running_var,
         epsilon=eps,
-        momentum=1.0 - momemtum,
+        momentum=1.0 - momentum,
         training_mode=False,
     )
     return op.Reshape(norm, op.Shape(input))
@@ -5689,8 +5689,8 @@ def _aten_native_batch_norm_training_onnx(
 ) -> Tuple[TFloat, TFloat, TFloat, TFloat, TFloat]:
     """Batch normalization training mode.
 
-    NOTE: momentum in PyTorch is 1.0-momemtum in ONNX.
-    When calling this function be sure to pass 1.0-momemtum when momentum is obtained from PyTorch.
+    NOTE: momentum in PyTorch is 1.0-momentum in ONNX.
+    When calling this function be sure to pass 1.0-momentum when momentum is obtained from PyTorch.
     """
     norm, running_mean, _ = op.BatchNormalization(
         input,
@@ -5720,7 +5720,7 @@ def _aten_native_batch_norm_training_onnx(
     n = op.Cast(op.Size(input) / op.Shape(input)[1], to=FLOAT.dtype)
     unbiased_var = var * (n / (n - 1.0))
 
-    # NOTE: momentum in ONNX is 1.0-momemtum in PyTorch
+    # NOTE: momentum in ONNX is 1.0-momentum in PyTorch
     new_running_var = (
         op.CastLike((1.0 - momentum) * unbiased_var, running_var) + momentum * running_var
     )
@@ -5741,8 +5741,8 @@ def _aten_native_batch_norm_inference_onnx(
 ) -> Tuple[TFloat, TFloat, TFloat, TFloat, TFloat]:
     """Batch normalization inference mode.
 
-    NOTE: momentum in PyTorch is 1.0-momemtum in ONNX.
-    When calling this function be sure to pass 1.0-momemtum when momentum is obtained from PyTorch.
+    NOTE: momentum in PyTorch is 1.0-momentum in ONNX.
+    When calling this function be sure to pass 1.0-momentum when momentum is obtained from PyTorch.
     """
     norm = op.BatchNormalization(
         input,

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5772,7 +5772,7 @@ def aten__native_batch_norm_legit_functional(
         )
     else:
         norm, new_mean, new_var = _aten_native_batch_norm_inference_onnx(
-            input, weight, bias, new_mean, new_var, axes, momentum=momentum, eps=eps
+            input, weight, bias, running_mean, running_var, axes, momentum=momentum, eps=eps
         )
     # NOTE: Fixed to be FLOAT dtype
     running_mean = op.Cast(running_mean, to=FLOAT.dtype)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5772,7 +5772,7 @@ def aten__native_batch_norm_legit_functional(
         )
     else:
         norm, new_mean, new_var = _aten_native_batch_norm_inference_onnx(
-            input, weight, bias, running_mean, running_var, axes, momentum=momentum, eps=eps
+            input, weight, bias, new_mean, new_var, axes, momentum=momentum, eps=eps
         )
     # NOTE: Fixed to be FLOAT dtype
     running_mean = op.Cast(running_mean, to=FLOAT.dtype)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5668,7 +5668,6 @@ def aten_native_batch_norm(
             bias,
             running_mean,
             running_var,
-            axes,
             momentum=1.0 - momentum,
             eps=eps,
         )

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -4237,7 +4237,7 @@ def aten_instance_norm(
         running_mean,
         running_var,
         epsilon=eps,
-        momentum=1.0-momemtum,
+        momentum=1.0 - momemtum,
         training_mode=False,
     )
     return op.Reshape(norm, op.Shape(input))
@@ -5652,11 +5652,25 @@ def aten_native_batch_norm(
     # three outputs when training_mode=True and one when it is False.
     if training:
         norm, input_mean, input_rstd, _, _ = _aten_native_batch_norm_training_onnx(
-            input, weight, bias, running_mean, running_var, axes, momentum=1.0-momentum, eps=eps
+            input,
+            weight,
+            bias,
+            running_mean,
+            running_var,
+            axes,
+            momentum=1.0 - momentum,
+            eps=eps,
         )
     else:
         norm, input_mean, input_rstd, _, _ = _aten_native_batch_norm_inference_onnx(
-            input, weight, bias, running_mean, running_var, axes, momentum=1.0-momentum, eps=eps
+            input,
+            weight,
+            bias,
+            running_mean,
+            running_var,
+            axes,
+            momentum=1.0 - momentum,
+            eps=eps,
         )
 
     return norm, input_mean, input_rstd
@@ -5793,7 +5807,7 @@ def aten__native_batch_norm_legit_functional(
                 running_mean,
                 running_var,
                 axes,
-                momentum=1.0-momentum,
+                momentum=1.0 - momentum,
                 eps=eps,
             )
         )
@@ -5806,7 +5820,7 @@ def aten__native_batch_norm_legit_functional(
                 running_mean,
                 running_var,
                 axes,
-                momentum=1.0-momentum,
+                momentum=1.0 - momentum,
                 eps=eps,
             )
         )

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5652,11 +5652,11 @@ def aten_native_batch_norm(
     # three outputs when training_mode=True and one when it is False.
     if training is True:
         norm, mean, var = _aten_native_batch_norm_training_onnx(
-            input, weight, bias, running_mean, running_var, axes, training, momentum, eps
+            input, weight, bias, running_mean, running_var, axes, momentum=momentum, eps=eps
         )
     else:
         norm, mean, var = _aten_native_batch_norm_inference_onnx(
-            input, weight, bias, running_mean, running_var, axes, training, momentum, eps
+            input, weight, bias, running_mean, running_var, axes, momentum=momentum, eps=eps
         )
     return norm, mean, var
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5708,18 +5708,9 @@ def _aten_native_batch_norm_inference_onnx(
         momentum=momentum,
         training_mode=False,
     )
-    # Compute var and rstd
-    # Mean, var, and rstd computation and results are expected to be
-    # in higher precision when inputs are float16.
-    # upcast_input = op.Cast(input, to=FLOAT.dtype)
-    mean = op.ReduceMean(input, axes)
-    input_sub_mean = op.Sub(input, mean)
-    sqr = op.Mul(input_sub_mean, input_sub_mean)
-    var = op.ReduceMean(sqr, axes, keepdims=False)
-    rstd = op.Div(1.0, op.Sqrt(var + eps))
-    # Get mean again with size = [1, C]
-    mean = op.ReduceMean(input, axes, keepdims=False)
-    return norm, mean, rstd
+    empty_mean = op.CastLike(op.Shape(input, start=0, end=0), norm)
+    empty_var = op.CastLike(op.Shape(input, start=0, end=0), norm)
+    return norm, empty_mean, empty_var
 
 
 # TODO: This op is using duplicated code from aten_native_batch_norm,

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5735,7 +5735,6 @@ def _aten_native_batch_norm_inference_onnx(
     bias: TFloat,
     running_mean: TFloat,
     running_var: TFloat,
-    axes: INT64,
     momentum: float,
     eps: float,
 ) -> Tuple[TFloat, TFloat, TFloat, TFloat, TFloat]:
@@ -5825,7 +5824,6 @@ def aten__native_batch_norm_legit_functional(
             )
         )
 
-    # FIXME: Fix running_mean, running_var
     return norm, input_mean, input_rstd, running_mean, running_var
 
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5774,6 +5774,9 @@ def aten__native_batch_norm_legit_functional(
         norm, new_mean, new_var = _aten_native_batch_norm_inference_onnx(
             input, weight, bias, running_mean, running_var, axes, momentum=momentum, eps=eps
         )
+    # NOTE: Fixed to be FLOAT dtype
+    running_mean = op.Cast(running_mean, to=FLOAT.dtype)
+    running_var = op.Cast(running_var, to=FLOAT.dtype)
     return norm, running_mean, running_var, new_mean, new_var
 
 

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -998,7 +998,8 @@ def sample_inputs__native_batch_norm_legit(op_info, device, dtype, requires_grad
         if args[0] is not None and args[1] is not None:
             yield opinfo_core.SampleInput(
                 sample.input,
-                args=(args[2], args[3], args[0], args[1], training, momentum, eps),
+                args=(args[2], args[3], args[0], args[1]),
+                kwargs={"training": training, "momentum": momentum, "eps": eps},
             )
 
 
@@ -1019,7 +1020,8 @@ def sample_inputs__native_batch_norm_legit_no_stats(
         eps = sample.kwargs.get("eps", 1e-5)
         if args[0] is not None and args[1] is None:
             yield opinfo_core.SampleInput(
-                sample.input, args=(args[2], args[3], training, momentum, eps)
+                sample.input, args=(args[2], args[3]),
+                kwargs={"training": training, "momentum": momentum, "eps": eps},
             )
 
 

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -1020,7 +1020,8 @@ def sample_inputs__native_batch_norm_legit_no_stats(
         eps = sample.kwargs.get("eps", 1e-5)
         if args[0] is not None and args[1] is None:
             yield opinfo_core.SampleInput(
-                sample.input, args=(args[2], args[3]),
+                sample.input,
+                args=(args[2], args[3]),
                 kwargs={"training": training, "momentum": momentum, "eps": eps},
             )
 

--- a/onnxscript/tests/function_libs/torch_lib/ops_test.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test.py
@@ -69,7 +69,7 @@ def dtypes_except(*dtypes: torch.dtype) -> Sequence[torch.dtype]:
 
 
 def _should_skip_xfail_test_sample(
-    op_name: str, sample, dtype: torch.dtype
+    op_name: str, sample, dtype: torch.dtype, device_type: str
 ) -> Tuple[Optional[str], Optional[str]]:
     """Returns a reason if a test sample should be skipped."""
     if op_name not in ops_test_data.OP_WITH_SKIPPED_XFAIL_SUBTESTS:
@@ -83,6 +83,12 @@ def _should_skip_xfail_test_sample(
                 continue
             if decorator_meta.dtypes is not None and dtype not in decorator_meta.dtypes:
                 # Not applicable for this dtype
+                continue
+            if (
+                decorator_meta.device_type is not None
+                and decorator_meta.device_type != device_type
+            ):
+                # Not applicable for this device_type
                 continue
             if decorator_meta.matcher(sample):
                 return decorator_meta.test_behavior, decorator_meta.reason
@@ -200,7 +206,13 @@ def run_test_output_match(
             ),
             kwargs=repr(cpu_sample.kwargs),
         ):
-            test_behavior, reason = _should_skip_xfail_test_sample(op.name, cpu_sample, dtype)
+            try:
+                device_type = cpu_sample.args[0].device.type
+            except (AttributeError, IndexError):
+                device_type = "cpu"
+            test_behavior, reason = _should_skip_xfail_test_sample(
+                op.name, cpu_sample, dtype, device_type
+            )
 
             with ops_test_common.normal_xfail_skip_test_behaviors(test_behavior, reason):
                 input_onnx = [ops_test_common.convert_tensor_to_numpy(x) for x in inputs]

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_common.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_common.py
@@ -70,6 +70,7 @@ class DecorateMeta:
     variant_name: str
     decorator: Callable[..., Any]
     dtypes: Optional[Collection[torch.dtype]]
+    device_type: Optional[str]
     reason: str
     test_behavior: str
     matcher: Optional[Callable[[Any], bool]] = None
@@ -85,6 +86,7 @@ def xfail(
     *,
     reason: str,
     dtypes: Optional[Collection[torch.dtype]] = None,
+    device_type: Optional[str] = None,
     matcher: Optional[Callable[[Any], Any]] = None,
     enabled_if: bool = True,
     test_class_name: Optional[str] = None,
@@ -96,6 +98,7 @@ def xfail(
         variant_name: Optional OpInfo variant_test_name.
         reason: The reason for the failure.
         dtypes: The dtypes to expect the failure.
+        device_type: Device type. E.g. "cpu", "cuda".
         matcher: A function that matches the test sample input. It is used only when
             the xfail is in the SKIP_XFAIL_SUBTESTS list.
         enabled_if: Whether the xfail is enabled.
@@ -107,6 +110,7 @@ def xfail(
         variant_name=variant_name,
         decorator=unittest.expectedFailure,
         dtypes=dtypes,
+        device_type=device_type,
         matcher=matcher,
         reason=reason,
         enabled_if=enabled_if,
@@ -121,6 +125,7 @@ def skip(
     *,
     reason: str,
     dtypes: Optional[Collection[torch.dtype]] = None,
+    device_type: Optional[str] = None,
     matcher: Optional[Callable[[Any], Any]] = None,
     enabled_if: bool = True,
     test_class_name: Optional[str] = None,
@@ -132,6 +137,7 @@ def skip(
         variant_name: Optional OpInfo variant_test_name.
         reason: The reason for skipping.
         dtypes: The dtypes to skip.
+        device_type: Device type. E.g. "cpu", "cuda".
         matcher: A function that matches the test sample input. It is used only when
             the skip is in the SKIP_XFAIL_SUBTESTS list.
         enabled_if: Whether the skip is enabled.
@@ -143,6 +149,7 @@ def skip(
         variant_name=variant_name,
         decorator=unittest.skip(f"Skip: {reason}"),
         dtypes=dtypes,
+        device_type=device_type,
         reason=reason,
         matcher=matcher,
         enabled_if=enabled_if,
@@ -174,6 +181,7 @@ def add_decorate_info(
             decorate_meta.test_class_name or test_class_name,
             base_test_name,
             dtypes=decorate_meta.dtypes,
+            device_type=decorate_meta.device_type,
             active_if=decorate_meta.enabled_if,
         )
         decorators.append(new_decorator)

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1865,6 +1865,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         core_ops.aten__native_batch_norm_legit_functional,
         trace_only=True,
     ).skip(
+        device_type="cpu",
         matcher=lambda sample: sample.kwargs.get("training") is False,
         reason="native_batch_norm outputs different results on CPU and CUDA when training is False. Our implematation is based on that for CUDA",
     ),

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1839,16 +1839,19 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         tolerance={torch.float16: (1e-2, 7e-3)},
     )
     .skip(
+        device_type="cpu",
         matcher=lambda sample: sample.args[-3] is False,
         reason="native_batch_norm outputs different shapes on CPU and CUDA when training is False. Our implematation is based on that for CUDA",
     )
     .skip(
+        device_type="cpu",
         dtypes=(torch.float16,),
         reason="native_batch_norm outputs different dtypes on CPU and CUDA. Our implematation is based on that for CUDA",
     ),
     TorchLibOpInfo(
         "ops.aten._native_batch_norm_legit", core_ops.aten_native_batch_norm, trace_only=True
     ).skip(
+        device_type="cpu",
         matcher=lambda sample: sample.kwargs.get("training") is False,
         reason="native_batch_norm outputs different shapes on CPU and CUDA when training is False. Our implematation is based on that for CUDA",
     ),

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1838,11 +1838,14 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         trace_only=True,
         tolerance={torch.float16: (1e-2, 7e-3)},
     ).skip(
-        device_type="cpu",
-        reason="native_batch_norm outputs different results on CPU and CUDA. Our implematation is based on that for CUDA",
+        matcher=lambda sample: sample.kwargs.get("training") is False,
+        reason="native_batch_norm outputs different results on CPU and CUDA when training is False. Our implematation is based on that for CUDA",
     ),
     TorchLibOpInfo(
         "ops.aten._native_batch_norm_legit", core_ops.aten_native_batch_norm, trace_only=True
+    ).skip(
+        matcher=lambda sample: sample.kwargs.get("training") is False,
+        reason="native_batch_norm outputs different results on CPU and CUDA when training is False. Our implematation is based on that for CUDA",
     ),
     TorchLibOpInfo(
         "ops.aten._native_batch_norm_legit.no_stats",
@@ -1853,6 +1856,9 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "ops.aten._native_batch_norm_legit_functional",
         core_ops.aten__native_batch_norm_legit_functional,
         trace_only=True,
+    ).skip(
+        matcher=lambda sample: sample.kwargs.get("training") is False,
+        reason="native_batch_norm outputs different results on CPU and CUDA when training is False. Our implematation is based on that for CUDA",
     ),
     TorchLibOpInfo(
         "ops.aten.native_group_norm",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1843,7 +1843,6 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "ops.aten._native_batch_norm_legit_functional",
         core_ops.aten__native_batch_norm_legit_functional,
         trace_only=True,
-        compare_shape_only_for_output=(3, 4),
     ),
     TorchLibOpInfo(
         "ops.aten.native_group_norm",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -110,6 +110,7 @@ class TorchLibOpInfo:
         *,
         reason: str,
         dtypes: Optional[Collection[torch.dtype]] = None,
+        device_type: Optional[str] = None,
         matcher: Optional[Callable[[Any], Any]] = None,
         enabled_if: bool = True,
         test_class_name: Optional[str] = None,
@@ -120,6 +121,7 @@ class TorchLibOpInfo:
             variant_name: Optional OpInfo variant_test_name.
             reason: The reason for skipping.
             dtypes: The dtypes to skip.
+            device_type: Device type. E.g. "cpu", "cuda".
             matcher: A function that matches the test sample input. It is used only when
                 the skip is in the SKIP_XFAIL_SUBTESTS list.
             enabled_if: Whether the skip is enabled.
@@ -132,6 +134,7 @@ class TorchLibOpInfo:
                 variant_name,
                 reason=reason,
                 dtypes=dtypes,
+                device_type=device_type,
                 matcher=matcher,
                 enabled_if=enabled_if,
                 test_class_name=test_class_name,
@@ -145,6 +148,7 @@ class TorchLibOpInfo:
         *,
         reason: str,
         dtypes: Optional[Collection[torch.dtype]] = None,
+        device_type: Optional[str] = None,
         matcher: Optional[Callable[[Any], Any]] = None,
         enabled_if: bool = True,
         test_class_name: Optional[str] = None,
@@ -154,7 +158,8 @@ class TorchLibOpInfo:
         Args:
             variant_name: Optional OpInfo variant_test_name.
             reason: The reason for the failure.
-            dtypes: The dtypes to expect the failure.
+            dtypes: The dtypes to expect the failure
+            device_type: Device type. E.g. "cpu", "cuda"..
             matcher: A function that matches the test sample input. It is used only when
                 the xfail is in the SKIP_XFAIL_SUBTESTS list.
             enabled_if: Whether the xfail is enabled.
@@ -167,6 +172,7 @@ class TorchLibOpInfo:
                 variant_name,
                 reason=reason,
                 dtypes=dtypes,
+                device_type=device_type,
                 matcher=matcher,
                 enabled_if=enabled_if,
                 test_class_name=test_class_name,
@@ -1831,6 +1837,9 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         core_ops.aten_native_batch_norm,
         trace_only=True,
         tolerance={torch.float16: (1e-2, 7e-3)},
+    ).skip(
+        device_type="cpu",
+        reason="native_batch_norm outputs different results on CPU and CUDA. Our implematation is based on that for CUDA",
     ),
     TorchLibOpInfo(
         "ops.aten._native_batch_norm_legit", core_ops.aten_native_batch_norm, trace_only=True

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1837,15 +1837,20 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         core_ops.aten_native_batch_norm,
         trace_only=True,
         tolerance={torch.float16: (1e-2, 7e-3)},
-    ).skip(
-        matcher=lambda sample: sample.kwargs.get("training") is False,
-        reason="native_batch_norm outputs different results on CPU and CUDA when training is False. Our implematation is based on that for CUDA",
+    )
+    .skip(
+        matcher=lambda sample: sample.args[-3] is False,
+        reason="native_batch_norm outputs different shapes on CPU and CUDA when training is False. Our implematation is based on that for CUDA",
+    )
+    .skip(
+        dtypes=(torch.float16,),
+        reason="native_batch_norm outputs different dtypes on CPU and CUDA. Our implematation is based on that for CUDA",
     ),
     TorchLibOpInfo(
         "ops.aten._native_batch_norm_legit", core_ops.aten_native_batch_norm, trace_only=True
     ).skip(
         matcher=lambda sample: sample.kwargs.get("training") is False,
-        reason="native_batch_norm outputs different results on CPU and CUDA when training is False. Our implematation is based on that for CUDA",
+        reason="native_batch_norm outputs different shapes on CPU and CUDA when training is False. Our implematation is based on that for CUDA",
     ),
     TorchLibOpInfo(
         "ops.aten._native_batch_norm_legit.no_stats",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -1830,6 +1830,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "native_batch_norm",
         core_ops.aten_native_batch_norm,
         trace_only=True,
+        tolerance={torch.float16: (1e-2, 7e-3)},
     ),
     TorchLibOpInfo(
         "ops.aten._native_batch_norm_legit", core_ops.aten_native_batch_norm, trace_only=True


### PR DESCRIPTION
- Merged implementations for `_native_batch_norm_legit_functional`
- Fix the implementation where `momentum` was not replaced with `1-momentum` to handle the ONNX spec difference.
- Update the test decorator to support skipping by device type. Skip the tests only on cpu.

Fixes https://github.com/microsoft/onnxscript/issues/1256