### PR TITLE
Fix implementation of index_put | fix(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -4066,6 +4066,7 @@ def aten_index_put(
     accumulate: bool = False,
 ) -> TReal:
     """index_put(Tensor self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor
+
     See implementation of `torch.onnx.symbolic_opset11.index_put
     <https://github.com/pytorch/pytorch/blob/main/torch/onnx/symbolic_opset11.py#L212>`_.
     """

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -4070,8 +4070,7 @@ def aten_index_put(
     shape_self = op.Shape(self)
 
     if op.Cast(accumulate, to=BOOL.dtype):
-        zeros = op.CastLike(op.ConstantOfShape(shape_self), values)
-        result = op.ScatterND(zeros, new_index, values, reduction="add")
+        result = op.ScatterND(result, new_index, values, reduction="add")
         result = op.Add(result, self)
     else:
         result = op.ScatterND(self, new_index, values)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -4065,27 +4065,23 @@ def aten_index_put(
     values: TReal,
     accumulate: bool = False,
 ) -> TReal:
-    """index_put(Tensor self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor"""
+    """index_put(Tensor self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor
+    See implementation of `torch.onnx.symbolic_opset11.index_put
+    <https://github.com/pytorch/pytorch/blob/main/torch/onnx/symbolic_opset11.py#L212>`_.
+    """
 
-    index = op.SequenceAt(indices, 0)  # assume indices only have 1 element
-    # change array([1,3]) to array([[1,1,1,1,1],[3,3,3,3,3]])
-    self_dim_1 = op.Gather(op.Shape(self), 1)
-    index_dim_0 = op.Gather(op.Shape(index), 0)
-    neg_1 = op.Constant(value_ints=[-1])
-    shape = op.Concat(op.Reshape(self_dim_1, neg_1), op.Reshape(index_dim_0, neg_1), axis=0)
-    new_ind = op.Expand(index, shape)
-    new_ind_t = op.Transpose(new_ind)
+    # TODO(justinchuby): Handle when indicies has more than one element
+    index = op.SequenceAt(indices, 0)
+    new_index = op.Unsqueeze(index, [-1])
+    shape_self = op.Shape(self)
 
     if op.Cast(accumulate, to=BOOL.dtype):
-        # put values into zeros array first, then add to input
-        zeros = op.Expand(op.Constant(value_float=0.0), op.Shape(self))
-        zeros = op.CastLike(zeros, values)
-        result = op.ScatterElements(zeros, new_ind_t, values)
-        # FIXME: type promotion
-        result = op.CastLike(result, self)
+        zeros = op.CastLike(op.ConstantOfShape(shape_self), values)
+        result = op.ScatterND(zeros, new_index, values, reduction="add")
         result = op.Add(result, self)
     else:
-        result = op.ScatterElements(self, new_ind_t, values)
+        result = op.ScatterND(self, new_index, values)
+
     return result
 
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -4067,10 +4067,9 @@ def aten_index_put(
     # TODO(justinchuby): Handle when indicies has more than one element
     index = op.SequenceAt(indices, 0)
     new_index = op.Unsqueeze(index, [-1])
-    shape_self = op.Shape(self)
 
     if op.Cast(accumulate, to=BOOL.dtype):
-        result = op.ScatterND(result, new_index, values, reduction="add")
+        result = op.ScatterND(self, new_index, values, reduction="add")
     else:
         result = op.ScatterND(self, new_index, values)
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -4071,7 +4071,6 @@ def aten_index_put(
 
     if op.Cast(accumulate, to=BOOL.dtype):
         result = op.ScatterND(result, new_index, values, reduction="add")
-        result = op.Add(result, self)
     else:
         result = op.ScatterND(self, new_index, values)
 

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -766,6 +766,26 @@ def sample_inputs_index(op_info, device, dtype, requires_grad, **kwargs):
         yield opinfo_core.SampleInput(make_arg((s, s, s, s)), args=args)
 
 
+def sample_inputs_index_put(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info
+    del kwargs
+
+    data = torch_testing.make_tensor(
+        (10, 3),
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+    indices = torch.arange(8, dtype=torch.int64, device=device).reshape((-1, 4))
+    values = torch_testing.make_tensor(
+        (2, 3, 4),
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+    )
+    yield opinfo_core.SampleInput(data, indices, values)
+
+
 def sample_inputs_layer_norm(op_info, device, dtype, requires_grad, **kwargs):
     del op_info  # unused
     del kwargs
@@ -1969,6 +1989,13 @@ OP_DB: List[opinfo_core.OpInfo] = [
         ),
         sample_inputs_func=sample_inputs_index_bool,
         op=torch.ops.aten.index.Tensor,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.index_put",
+        aten_name="index_put",
+        dtypes=common_dtype.floating_types(),
+        sample_inputs_func=sample_inputs_index_put,
+        supports_out=False,
     ),
     opinfo_core.OpInfo(
         "ops.aten.layer_norm",

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -753,7 +753,7 @@ def sample_inputs_index_put(op_info, device, dtype, requires_grad, **kwargs):
     )
     indices = torch.arange(8, dtype=torch.int64, device=device).reshape((-1, 4))
     values = torch_testing.make_tensor(
-        (-1, 4, 3),
+        (2, 4, 3),
         device=device,
         dtype=dtype,
         requires_grad=requires_grad,

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -778,7 +778,7 @@ def sample_inputs_index_put(op_info, device, dtype, requires_grad, **kwargs):
     )
     indices = torch.arange(8, dtype=torch.int64, device=device).reshape((-1, 4))
     values = torch_testing.make_tensor(
-        (2, 3, 4),
+        (-1, 4, 3),
         device=device,
         dtype=dtype,
         requires_grad=requires_grad,

--- a/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/onnxscript/tests/function_libs/torch_lib/extra_opinfo.py
@@ -751,7 +751,7 @@ def sample_inputs_index_put(op_info, device, dtype, requires_grad, **kwargs):
         dtype=dtype,
         requires_grad=requires_grad,
     )
-    indices = torch.arange(8, dtype=torch.int64, device=device).reshape((-1, 4))
+    indices = (torch.arange(8, dtype=torch.int64, device=device).reshape((-1, 4)),)
     values = torch_testing.make_tensor(
         (2, 4, 3),
         device=device,

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -845,7 +845,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         core_ops.aten_index_put_bool,
     ).skip(
         matcher=lambda sample: not (sample.args[0][0].dtype == torch.bool),
-        reason="this Aten overload only support tensor(bool) as indices",
+        reason="this Aten overload only supports tensor(bool) as indices",
     ),
     TorchLibOpInfo(
         "index_put",

--- a/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
+++ b/onnxscript/tests/function_libs/torch_lib/ops_test_data.py
@@ -850,17 +850,16 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo(
         "index_put",
         core_ops.aten_index_put,
-    ).skip(
-        enabled_if=version_utils.onnxruntime_older_than("1.17"), 
-        matcher=lambda sample: not (
-            (sample.args[0][0].dtype == torch.int64)
-            # onnxruntime: MLFloat16 data type is not supported with ScatterND when reduction is 'add'
-            and (
-                sample.args[1].dtype != torch.float16
-                or not sample.kwargs.get("accumulate", False)
-            )
-        ),
-        reason="this Aten overload only support tensor(int) as indices and float32 when accumulate is True",
+    )
+    .skip(
+        matcher=lambda sample: not (sample.args[0][0].dtype == torch.int64),
+        reason="this Aten overload only supports tensor(int) as indices",
+    )
+    .xfail(
+        enabled_if=version_utils.onnxruntime_older_than("1.18"),
+        dtypes=(torch.float16,),
+        matcher=lambda sample: sample.kwargs.get("accumulate") is True,
+        reason="fixme: ORT only supports float32 when accumulate is True:  MLFloat16 data type is not supported with ScatterND when reduction is 'add'",
     ),
     TorchLibOpInfo("ops.aten.index_put", core_ops.aten_index_put),
     TorchLibOpInfo("index_select", core_ops.aten_index_select),


### PR DESCRIPTION
Continuation of #1277 by @xadupre 

The onnx implementation of index_put is different in torch script exporter
(https://github.com/pytorch/pytorch/blob/main/torch/onnx/symbolic_opset11.py#L212). The PR replaces the current implementation failing on one corner case by the one from torch script.
