### PR TITLE
Llama experiment

### DIFF
--- a/docs/examples/llama/llama_model.py
+++ b/docs/examples/llama/llama_model.py
@@ -1,0 +1,269 @@
+"""
+Code modified from different sources:
+
+* https://github.com/huggingface/transformers/blob/main/tests/models/llama/test_modeling_llama.py
+* https://github.com/pytorch/pytorch/pull/117009
+* https://github.com/sdpython/experimental-experiment/blob/main/experimental_experiment/torch_helper/llama_helper.py
+"""
+
+import random
+from typing import Sequence, Tuple
+import torch
+import torch.export
+import onnx
+import collections
+import onnx.inliner
+import onnxscript
+import onnxscript.function_libs.torch_lib._flags
+from onnxrewriter import optimizer
+from onnxrewriter.rewriter import onnxruntime as ort_rewriter
+
+
+def get_llama_decoder(
+    input_dims: Sequence[Tuple[int, int]] = ((2, 8), (4, 7), (9, 15)),
+    hidden_size=16,
+    num_hidden_layers=1,
+    vocab_size=1024,
+    intermediate_size=16,
+    max_position_embeddings=1024,
+    num_attention_heads=2,
+    _attn_implementation="eager",
+):
+    """
+    Returns the decoder part.
+    See :func:`experimental_experiment.torch_helper.llama_helper.get_llama_model`.
+    """
+    from transformers import LlamaConfig
+    from transformers.models.llama.modeling_llama import LlamaDecoderLayer
+
+    config = LlamaConfig(
+        num_hidden_layers=num_hidden_layers,
+        vocab_size=vocab_size,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        max_position_embeddings=max_position_embeddings,
+        num_attention_heads=num_attention_heads,
+    )
+    if _attn_implementation:
+        config._attn_implementation = _attn_implementation
+
+    class LlamaDecoderWrapper(torch.nn.Module):
+        def __init__(self, config):
+            super().__init__()
+            self.decoder = LlamaDecoderLayer(config, layer_idx=0)
+
+        def forward(self, hidden_states, attention_mask, position_ids):
+            (decoder_output,) = self.decoder(hidden_states, attention_mask, position_ids)
+            return decoder_output
+
+    def generate_example_inputs(batch: int, seq: int, hidden_size: int):
+        # shape: batch x seq x hidden_size
+        hidden_state = torch.randn(batch, seq, hidden_size)
+        attention_mask = torch.zeros(batch, 1, seq, seq, dtype=torch.float)
+        position_ids = torch.arange(0, seq, dtype=torch.int64)
+        position_ids = position_ids.unsqueeze(0).view(-1, seq)
+        return hidden_state, attention_mask, position_ids
+
+    example_args_collection = []
+    for b, s in input_dims:
+        example_args_collection.append(generate_example_inputs(b, s, hidden_size))
+
+    return LlamaDecoderWrapper(config), example_args_collection
+
+
+def get_llama_attention(
+    input_dims: Sequence[Tuple[int, int]] = ((2, 8), (4, 7), (9, 15)),
+    hidden_size=16,
+    num_hidden_layers=1,
+    vocab_size=1024,
+    intermediate_size=16,
+    max_position_embeddings=1024,
+    num_attention_heads=2,
+    _attn_implementation="eager",
+):
+    """
+    Returns the attention part.
+    See :func:`experimental_experiment.torch_helper.llama_helper.get_llama_model`.
+    """
+    from transformers import LlamaConfig
+    from transformers.models.llama.modeling_llama import LlamaAttention
+
+    config = LlamaConfig(
+        num_hidden_layers=num_hidden_layers,
+        vocab_size=vocab_size,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        max_position_embeddings=max_position_embeddings,
+        num_attention_heads=num_attention_heads,
+    )
+    if _attn_implementation:
+        config._attn_implementation = _attn_implementation
+
+    class LlamaAttentionWrapper(torch.nn.Module):
+        def __init__(self, config):
+            super().__init__()
+            self.attention = LlamaAttention(config, layer_idx=0)
+
+        def forward(self, hidden_states, attention_mask, position_ids):
+            attn_output, _, _ = self.attention(hidden_states, attention_mask, position_ids)
+            return attn_output
+
+    def generate_example_inputs(batch: int, seq: int, hidden_size: int):
+        hidden_state = torch.randn(batch, seq, hidden_size)
+        attention_mask = torch.zeros(batch, 1, seq, seq, dtype=torch.float)
+        position_ids = torch.arange(0, seq, dtype=torch.int64)
+        position_ids = position_ids.unsqueeze(0).view(-1, seq)
+
+        return hidden_state, attention_mask, position_ids
+
+    example_args_collection = []
+    for b, s in input_dims:
+        example_args_collection.append(generate_example_inputs(b, s, hidden_size))
+
+    return LlamaAttentionWrapper(config), example_args_collection
+
+
+def ids_tensor(shape, vocab_size, rng=None, name=None):
+    #  Creates a random int32 tensor of the shape within the vocab size
+
+    if rng is None:
+        rng = random.Random()
+
+    total_dims = 1
+    for dim in shape:
+        total_dims *= dim
+
+    values = []
+    for _ in range(total_dims):
+        values.append(rng.randint(0, vocab_size - 1))
+
+    return torch.tensor(data=values, dtype=torch.long).view(shape).contiguous()
+
+
+def get_llama_model(
+    input_dims: Sequence[Tuple[int, int]] = ((2, 8), (4, 7), (9, 15)),
+    hidden_size=16,
+    num_hidden_layers=1,
+    vocab_size=1024,
+    intermediate_size=16,
+    max_position_embeddings=1024,
+    num_attention_heads=2,
+    _attn_implementation="eager",  # needed value to remove graph breaks
+):
+    """
+    Returns a model.
+    See `LlamaConfig
+    <https://huggingface.co/docs/transformers/v4.37.2/en/model_doc/llama2#transformers.LlamaConfig>`_.
+    The parameters are chosen for a unit test configuration.
+    For benchmark, a bigger one should be used.
+    Commented out, the default value from :epkg:`transformers`.
+
+    ::
+
+        kwargs = dict(
+            input_dims=[(2, 1024)] * 2,
+            num_hidden_layers=1,  # 32
+            hidden_size=512,  # 4096
+            vocab_size=4000,  # 32000
+            intermediate_size=2000,  # 11008
+            max_position_embeddings=2048,
+            num_attention_heads=8,  # 32
+        )
+    """
+    from transformers import LlamaConfig
+    from transformers.models.llama.modeling_llama import LlamaModel
+
+    config = LlamaConfig(
+        num_hidden_layers=num_hidden_layers,
+        vocab_size=vocab_size,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        max_position_embeddings=max_position_embeddings,
+        num_attention_heads=num_attention_heads,
+    )
+    if _attn_implementation:
+        config._attn_implementation = _attn_implementation
+
+    class LlamaModelWrapper(torch.nn.Module):
+        def __init__(self, config):
+            super().__init__()
+            self.model = LlamaModel(config)
+
+        def forward(self, input_ids, attention_mask):
+            model_output = self.model(input_ids, attention_mask=attention_mask)
+            return model_output[0]
+
+    def generate_example_inputs(batch: int, seq: int, vocab_size: int):
+        input_ids = ids_tensor([batch, seq], vocab_size)
+        input_mask = torch.tril(torch.ones(batch, seq, dtype=torch.float32))
+        assert input_mask.dtype == torch.float32
+        return input_ids, input_mask
+
+    example_args_collection = []
+    for b, s in input_dims:
+        example_args_collection.append(generate_example_inputs(b, s, vocab_size))
+
+    return LlamaModelWrapper(config), example_args_collection
+
+
+def display_model_stats(model: onnx.ModelProto):
+    """Displays the number of nodes, number of inputs, number of outputs and number of initializers."""
+    print(f"number of nodes: {len(model.graph.node)}")
+    unique_nodes = collections.Counter([node.op_type for node in model.graph.node])
+    for k, v in unique_nodes.items():
+        print(f"  {k}: {v}")
+    print(f"number of inputs: {len(model.graph.input)}")
+    print(f"number of outputs: {len(model.graph.output)}")
+    print(f"number of initializers: {len(model.graph.initializer)}")
+    print(f"number of functions: {len(model.functions)}")
+
+
+def export():
+    model, example_args_collection = get_llama_model()
+    exported = torch.export.export(model, example_args_collection[0])
+    print(exported)
+    exported_onnx = torch.onnx.dynamo_export(exported, *example_args_collection[0]).model_proto
+    print("===exported_onnx===")
+    display_model_stats(exported_onnx)
+    inlined_exported_onnx = onnx.inliner.inline_local_functions(exported_onnx)
+    print("===inlined_exported_onnx===")
+    display_model_stats(inlined_exported_onnx)
+
+    onnxscript.function_libs.torch_lib._flags.EXPERIMENTAL_PREFER_TRACING = True
+
+    exported_eager_onnx = torch.onnx.dynamo_export(
+        exported, *example_args_collection[0]
+    ).model_proto
+    print("===exported_eager_onnx===")
+    display_model_stats(exported_eager_onnx)
+    inlined_eager_exported_onnx = onnx.inliner.inline_local_functions(exported_eager_onnx)
+    print("===inlined_eager_exported_onnx===")
+    display_model_stats(inlined_eager_exported_onnx)
+    print(onnx.printer.to_text(inlined_eager_exported_onnx))
+
+    rewritten_model = ort_rewriter.rewrite(exported_onnx)
+    rewritten_model = onnx.inliner.inline_local_functions(rewritten_model)
+    print("===rewritten_model===")
+    display_model_stats(rewritten_model)
+
+    rewritten_inlined_eager_exported_onnx = optimizer.optimize(
+        exported_onnx, num_iterations=2, onnx_shape_inference=False
+    )
+    rewritten_inlined_eager_exported_onnx = onnx.inliner.inline_local_functions(
+        rewritten_inlined_eager_exported_onnx
+    )
+    print("===rewritten_inlined_eager_exported_onnx===")
+    display_model_stats(rewritten_inlined_eager_exported_onnx)
+    rewritten_inlined_eager_exported_onnx2 = ort_rewriter.rewrite(
+        rewritten_inlined_eager_exported_onnx
+    )
+    rewritten_inlined_eager_exported_onnx2 = onnx.inliner.inline_local_functions(
+        rewritten_inlined_eager_exported_onnx2
+    )
+    print("===rewritten_inlined_eager_exported_onnx2===")
+    display_model_stats(rewritten_inlined_eager_exported_onnx2)
+    print(onnx.printer.to_text(rewritten_inlined_eager_exported_onnx2))
+
+
+if __name__ == "__main__":
+    export()

--- a/docs/examples/llama/llama_model.py
+++ b/docs/examples/llama/llama_model.py
@@ -6,17 +6,19 @@ Code modified from different sources:
 * https://github.com/sdpython/experimental-experiment/blob/main/experimental_experiment/torch_helper/llama_helper.py
 """
 
+import collections
 import random
 from typing import Sequence, Tuple
+
+import onnx
+import onnx.inliner
 import torch
 import torch.export
-import onnx
-import collections
-import onnx.inliner
-import onnxscript
-import onnxscript.function_libs.torch_lib._flags
 from onnxrewriter import optimizer
 from onnxrewriter.rewriter import onnxruntime as ort_rewriter
+
+import onnxscript
+import onnxscript.function_libs.torch_lib._flags
 
 
 def get_llama_decoder(
@@ -221,6 +223,7 @@ def display_model_stats(model: onnx.ModelProto):
 
 def export():
     model, example_args_collection = get_llama_model()
+
     exported = torch.export.export(model, example_args_collection[0])
     print("===exported fx graph===")
     print(exported)
@@ -243,6 +246,7 @@ def export():
     print("===inlined_eager_exported_onnx===")
     display_model_stats(inlined_eager_exported_onnx)
     # print(onnx.printer.to_text(inlined_eager_exported_onnx))
+    onnx.save(inlined_eager_exported_onnx, "inlined_eager_exported_onnx.onnx")
 
     rewritten_model = ort_rewriter.rewrite(exported_onnx)
     rewritten_model = onnx.inliner.inline_local_functions(rewritten_model)

--- a/docs/examples/llama/llama_model.py
+++ b/docs/examples/llama/llama_model.py
@@ -239,10 +239,11 @@ def export():
     inlined_eager_exported_onnx = onnx.inliner.inline_local_functions(exported_eager_onnx)
     print("===inlined_eager_exported_onnx===")
     display_model_stats(inlined_eager_exported_onnx)
-    print(onnx.printer.to_text(inlined_eager_exported_onnx))
+    # print(onnx.printer.to_text(inlined_eager_exported_onnx))
 
     rewritten_model = ort_rewriter.rewrite(exported_onnx)
     rewritten_model = onnx.inliner.inline_local_functions(rewritten_model)
+    onnx.save(rewritten_model, "rewritten_model.onnx")
     print("===rewritten_model===")
     display_model_stats(rewritten_model)
 
@@ -262,7 +263,13 @@ def export():
     )
     print("===rewritten_inlined_eager_exported_onnx2===")
     display_model_stats(rewritten_inlined_eager_exported_onnx2)
-    print(onnx.printer.to_text(rewritten_inlined_eager_exported_onnx2))
+    # print(onnx.printer.to_text(rewritten_inlined_eager_exported_onnx2))
+    rewritten_inlined_eager_exported_onnx2 = onnx.shape_inference.infer_shapes(
+        rewritten_inlined_eager_exported_onnx2, data_prop=True
+    )
+    onnx.save(
+        rewritten_inlined_eager_exported_onnx2, "rewritten_inlined_eager_exported_onnx2.onnx"
+    )
 
 
 if __name__ == "__main__":

--- a/docs/examples/llama/llama_model.py
+++ b/docs/examples/llama/llama_model.py
@@ -233,7 +233,7 @@ def time_ort_model(model, name: str, example_args, run_count=100):
     for _ in range(run_count):
         session.run(None, ort_input)
     end = time.time()
-    print(f"ORT Time {name}:", (end - start) / run_count, "average over", run_count, "runs")
+    print(f"ORT Time {name}:", (end - start) / run_count, "averaged over", run_count, "runs")
 
 
 def export():
@@ -300,6 +300,11 @@ def export():
     torchscript_model = onnx.load("torchscript_model.onnx")
     print("===torchscript_model===")
     display_model_stats(torchscript_model)
+    optimized_torchscript_model = optimizer.optimize(
+        torchscript_model, num_iterations=2, onnx_shape_inference=False
+    )
+    print("===optimized_torchscript_model===")
+    display_model_stats(optimized_torchscript_model)
 
     # Time the model
     time_ort_model(inlined_exported_onnx, "inlined_exported_onnx", example_args_collection[0])
@@ -313,6 +318,9 @@ def export():
         example_args_collection[0],
     )
     time_ort_model(torchscript_model, "torchscript_model", example_args_collection[0])
+    time_ort_model(
+        optimized_torchscript_model, "optimized_torchscript_model", example_args_collection[0]
+    )
 
     # Time the model
     start = time.time()
@@ -320,7 +328,7 @@ def export():
         for _ in range(100):
             model(*example_args_collection[0])
     end = time.time()
-    print("Eager Time:", (end - start) / 100)
+    print("Eager Time:", (end - start) / 100, "averaged over 100 runs")
 
 
 if __name__ == "__main__":

--- a/docs/examples/llama/llama_model.py
+++ b/docs/examples/llama/llama_model.py
@@ -191,7 +191,8 @@ def get_llama_model(
 
         def forward(self, input_ids, attention_mask):
             model_output = self.model(input_ids, attention_mask=attention_mask)
-            return model_output[0]
+            # Output 2, 3 are None
+            return model_output[0], model_output[1]
 
     def generate_example_inputs(batch: int, seq: int, vocab_size: int):
         input_ids = ids_tensor([batch, seq], vocab_size)
@@ -221,7 +222,9 @@ def display_model_stats(model: onnx.ModelProto):
 def export():
     model, example_args_collection = get_llama_model()
     exported = torch.export.export(model, example_args_collection[0])
+    print("===exported fx graph===")
     print(exported)
+    print("FX Node count:", len(exported.graph.nodes))
     exported_onnx = torch.onnx.dynamo_export(exported, *example_args_collection[0]).model_proto
     print("===exported_onnx===")
     display_model_stats(exported_onnx)

--- a/docs/examples/llama/llama_model.py
+++ b/docs/examples/llama/llama_model.py
@@ -266,12 +266,13 @@ def export():
     rewritten_model = optimizer.optimize(exported_onnx, num_iterations=2)
     # rewritten_model = ort_rewriter.rewrite(rewritten_model)
     rewritten_model = onnx.inliner.inline_local_functions(rewritten_model)
+    rewritten_model = onnx.shape_inference.infer_shapes(rewritten_model, data_prop=True)
     onnx.save(rewritten_model, "rewritten_model.onnx")
     print("===rewritten_model===")
     display_model_stats(rewritten_model)
 
     rewritten_inlined_eager_exported_onnx = optimizer.optimize(
-        exported_onnx, num_iterations=2, onnx_shape_inference=False
+        exported_onnx, num_iterations=2, onnx_shape_inference=True
     )
     rewritten_inlined_eager_exported_onnx = onnx.inliner.inline_local_functions(
         rewritten_inlined_eager_exported_onnx
@@ -301,10 +302,11 @@ def export():
     print("===torchscript_model===")
     display_model_stats(torchscript_model)
     optimized_torchscript_model = optimizer.optimize(
-        torchscript_model, num_iterations=2, onnx_shape_inference=False
+        torchscript_model, num_iterations=2, onnx_shape_inference=True
     )
     print("===optimized_torchscript_model===")
     display_model_stats(optimized_torchscript_model)
+    onnx.save(optimized_torchscript_model, "optimized_torchscript_model.onnx")
 
     # Time the model
     time_ort_model(inlined_exported_onnx, "inlined_exported_onnx", example_args_collection[0])

--- a/docs/examples/llama/llama_model.py
+++ b/docs/examples/llama/llama_model.py
@@ -305,8 +305,9 @@ def export():
 
     # Time the model
     start = time.time()
-    for _ in range(100):
-        model(*example_args_collection[0])
+    with torch.no_grad():
+        for _ in range(100):
+            model(*example_args_collection[0])
     end = time.time()
     print("Eager Time:", (end - start) / 100)
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -4906,7 +4906,10 @@ def aten_margin_ranking_loss(
     raise NotImplementedError()
 
 
-@torch_op(("aten::masked_fill", "aten::masked_fill.Scalar", "aten::masked_fill.Tensor"), traceable=True)
+@torch_op(
+    ("aten::masked_fill", "aten::masked_fill.Scalar", "aten::masked_fill.Tensor"),
+    traceable=True,
+)
 def aten_masked_fill(self: TTensor, mask: BOOL, value: TTensor) -> TTensor:
     """masked_fill.Tensor(Tensor self, Tensor mask, Tensor value) -> Tensor"""
     # NOTE: Do not attempt to cast `mask` to BOOL because mask should not take any other types.

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -4906,7 +4906,7 @@ def aten_margin_ranking_loss(
     raise NotImplementedError()
 
 
-@torch_op(("aten::masked_fill", "aten::masked_fill.Scalar", "aten::masked_fill.Tensor"))
+@torch_op(("aten::masked_fill", "aten::masked_fill.Scalar", "aten::masked_fill.Tensor"), traceable=True)
 def aten_masked_fill(self: TTensor, mask: BOOL, value: TTensor) -> TTensor:
     """masked_fill.Tensor(Tensor self, Tensor mask, Tensor value) -> Tensor"""
     # NOTE: Do not attempt to cast `mask` to BOOL because mask should not take any other types.
@@ -7482,7 +7482,7 @@ def aten_softmax(self: TFloatOrBFloat16, dim: int, dtype: int = -1) -> TFloatOrB
     return result
 
 
-@torch_op(("aten::softmax", "aten::softmax.int", "aten::special_softmax"))
+@torch_op(("aten::softmax", "aten::softmax.int", "aten::special_softmax"), traceable=True)
 def aten_softmax_no_dtype(self: TFloatOrBFloat16, dim: int) -> TFloatOrBFloat16:
     """softmax(Tensor self, int dim, ScalarType? dtype=None) -> Tensor"""
 
@@ -7887,7 +7887,7 @@ def aten_symeig(
     raise NotImplementedError()
 
 
-@torch_op("aten::t")
+@torch_op("aten::t", traceable=True)
 def aten_t(self: TTensor) -> TTensor:
     """t(Tensor(a) self) -> Tensor(a)"""
 
@@ -8063,7 +8063,7 @@ def aten_to_sparse_csr(self: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
-@torch_op("aten::topk")
+@torch_op("aten::topk", traceable=True)
 def aten_topk(
     self: TReal, k: INT64, dim: int = -1, largest: bool = True, sorted: bool = True
 ) -> Tuple[TReal, INT64]:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -721,7 +721,7 @@ def aten_argmax_dim(self: Union[RealType, UINT8], dim: int, keepdim: bool = Fals
     return result
 
 
-@torch_op("aten::argmin")
+@torch_op("aten::argmin", traceable=True)
 def aten_argmin(self: Union[RealType, UINT8], keepdim: bool = False) -> INT64:
     """argmin(Tensor self, int? dim=None, bool keepdim=False) -> Tensor"""
 
@@ -734,7 +734,7 @@ def aten_argmin(self: Union[RealType, UINT8], keepdim: bool = False) -> INT64:
     return result
 
 
-@torch_op("aten::argmin")
+@torch_op("aten::argmin", traceable=True)
 def aten_argmin_dim(self: Union[RealType, UINT8], dim: int, keepdim: bool = False) -> INT64:
     """argmin(Tensor self, int? dim=None, bool keepdim=False) -> Tensor"""
 
@@ -3238,7 +3238,7 @@ def aten_exp(self: TFloat) -> TFloat:
     return op.Exp(self)
 
 
-@torch_op("aten::exp2")
+@torch_op("aten::exp2", traceable=True)
 def aten_exp2(self: TFloat) -> TFloat:
     """exp2(Tensor self) -> Tensor"""
 
@@ -3257,7 +3257,7 @@ def aten_expand(self: TTensor, size: TInt) -> TTensor:
     return op.Expand(self, size)
 
 
-@torch_op("aten::expand_as")
+@torch_op("aten::expand_as", traceable=True)
 def aten_expand_as(self: TTensor, other: TTensor) -> TTensor:
     """expand_as(Tensor(a) self, Tensor other) -> Tensor(a)"""
 


### PR DESCRIPTION
llama model based on: https://github.com/sdpython/experimental-experiment/blob/main/experimental_experiment/torch_helper/llama_helper.py

```
===exported fx graph===
ExportedProgram:
    class GraphModule(torch.nn.Module):
        def forward(self, arg0_1: "f32[16]", arg1_1: "f32[16]", arg2_1: "f32[16]", arg3_1: "f32[1024, 16]"
, arg4_1: "f32[16, 16]", arg5_1: "f32[16, 16]", arg6_1: "f32[16, 16]", arg7_1: "f32[16, 16]", arg8_1: "f32[16, 16]", arg9_1: "f32[16, 16]", arg10_1: "f32[16, 16]", arg11_1: "f32[1024, 8]", arg12_1: "f32[1024, 8]", arg13_1: "i64[2, 8]", arg14_1: "f32[2, 8]"):                                                                        # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:1021 in forward, code: position_ids = torch.arange(                                            arange: "i64[8]" = torch.ops.aten.arange.start(0, 8, dtype = torch.int64, device = device(type
='cpu'), pin_memory = False)                                                                                          
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:1024 in forward, code: position_ids = position_ids.unsqueeze(0)                                unsqueeze: "i64[1, 8]" = torch.ops.aten.unsqueeze.default(arange, 0);  arange = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:1027 in forward, code: inputs_embeds = self.embed_tokens(input_ids)                            embedding: "f32[2, 8, 16]" = torch.ops.aten.embedding.default(arg3_1, arg13_1);  arg3_1 = arg1
3_1 = None                                                                                                            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/modeling
_attn_mask_utils.py:156 in _make_causal_mask, code: mask = torch.full((tgt_len, tgt_len), torch.finfo(dtype).min, device=device)                                                                                                full: "f32[8, 8]" = torch.ops.aten.full.default([8, 8], -3.4028234663852886e+38, device = devi
ce(type='cpu'), pin_memory = False)                                                                                   
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/modeling
_attn_mask_utils.py:157 in _make_causal_mask, code: mask_cond = torch.arange(mask.size(-1), device=device)            arange_1: "i64[8]" = torch.ops.aten.arange.default(8, device = device(type='cpu'), pin_memory 
= False)                                                                                                              
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/modeling
_attn_mask_utils.py:158 in _make_causal_mask, code: mask.masked_fill_(mask_cond < (mask_cond + 1).view(mask.size(-1), 1), 0)                                                                                                    add: "i64[8]" = torch.ops.aten.add.Tensor(arange_1, 1)
            view: "i64[8, 1]" = torch.ops.aten.view.default(add, [8, 1]);  add = None
            lt: "b8[8, 8]" = torch.ops.aten.lt.Tensor(arange_1, view);  arange_1 = view = None
            masked_fill: "f32[8, 8]" = torch.ops.aten.masked_fill.Scalar(full, lt, 0);  full = lt = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/modeling
_attn_mask_utils.py:182 in _expand_mask, code: expanded_mask = mask[:, None, None, :].expand(bsz, 1, tgt_len, src_len).to(dtype)                                                                                                slice_3: "f32[2, 8]" = torch.ops.aten.slice.Tensor(arg14_1, 0, 0, 9223372036854775807);  arg14
_1 = None                                                                                                             unsqueeze_3: "f32[2, 1, 8]" = torch.ops.aten.unsqueeze.default(slice_3, 1);  slice_3 = None
            unsqueeze_4: "f32[2, 1, 1, 8]" = torch.ops.aten.unsqueeze.default(unsqueeze_3, 2);  unsqueeze_
3 = None                                                                                                              slice_4: "f32[2, 1, 1, 8]" = torch.ops.aten.slice.Tensor(unsqueeze_4, 3, 0, 922337203685477580
7);  unsqueeze_4 = None                                                                                               expand_1: "f32[2, 1, 8, 8]" = torch.ops.aten.expand.default(slice_4, [2, 1, 8, 8]);  slice_4 =
 None                                                                                                                 
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/modeling
_attn_mask_utils.py:184 in _expand_mask, code: inverted_mask = 1.0 - expanded_mask                                    rsub: "f32[2, 1, 8, 8]" = torch.ops.aten.rsub.Scalar(expand_1, 1.0);  expand_1 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/modeling
_attn_mask_utils.py:186 in _expand_mask, code: return inverted_mask.masked_fill(inverted_mask.to(torch.bool), torch.finfo(dtype).min)                                                                                           _to_copy: "b8[2, 1, 8, 8]" = torch.ops.aten._to_copy.default(rsub, dtype = torch.bool)
            masked_fill_1: "f32[2, 1, 8, 8]" = torch.ops.aten.masked_fill.Scalar(rsub, _to_copy, -3.402823
4663852886e+38);  rsub = _to_copy = None                                                                              
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/modeling
_attn_mask_utils.py:137 in to_4d, code: expanded_attn_mask = causal_4d_mask.masked_fill(expanded_attn_mask.bool(), torch.finfo(dtype).min)                                                                                      _to_copy_1: "b8[2, 1, 8, 8]" = torch.ops.aten._to_copy.default(masked_fill_1, dtype = torch.bo
ol);  masked_fill_1 = None                                                                                            unsqueeze_5: "f32[1, 8, 8]" = torch.ops.aten.unsqueeze.default(masked_fill, 0);  masked_fill =
 None                                                                                                                 unsqueeze_6: "f32[1, 1, 8, 8]" = torch.ops.aten.unsqueeze.default(unsqueeze_5, 1);  unsqueeze_
5 = None                                                                                                              slice_5: "f32[1, 1, 8, 8]" = torch.ops.aten.slice.Tensor(unsqueeze_6, 2, 0, 922337203685477580
7);  unsqueeze_6 = None                                                                                               slice_6: "f32[1, 1, 8, 8]" = torch.ops.aten.slice.Tensor(slice_5, 3, 0, 9223372036854775807); 
 slice_5 = None                                                                                                       expand_2: "f32[2, 1, 8, 8]" = torch.ops.aten.expand.default(slice_6, [2, 1, 8, 8]);  slice_6 =
 None                                                                                                                 masked_fill_2: "f32[2, 1, 8, 8]" = torch.ops.aten.masked_fill.Scalar(expand_2, _to_copy_1, -3.
4028234663852886e+38);  expand_2 = _to_copy_1 = None                                                                  
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:115 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)                   pow_1: "f32[2, 8, 16]" = torch.ops.aten.pow.Tensor_Scalar(embedding, 2)
            mean: "f32[2, 8, 1]" = torch.ops.aten.mean.dim(pow_1, [-1], True);  pow_1 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:116 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)                                                                                                      add_1: "f32[2, 8, 1]" = torch.ops.aten.add.Tensor(mean, 1e-06);  mean = None
            rsqrt: "f32[2, 8, 1]" = torch.ops.aten.rsqrt.default(add_1);  add_1 = None
            mul: "f32[2, 8, 16]" = torch.ops.aten.mul.Tensor(embedding, rsqrt);  rsqrt = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:117 in forward, code: return self.weight * hidden_states.to(input_dtype)                       mul_1: "f32[2, 8, 16]" = torch.ops.aten.mul.Tensor(arg0_1, mul);  arg0_1 = mul = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:386 in forward, code: query_states = self.q_proj(hidden_states)                                t: "f32[16, 16]" = torch.ops.aten.t.default(arg4_1);  arg4_1 = None
            view_1: "f32[16, 16]" = torch.ops.aten.view.default(mul_1, [16, 16])
            mm: "f32[16, 16]" = torch.ops.aten.mm.default(view_1, t);  view_1 = t = None
            view_2: "f32[2, 8, 16]" = torch.ops.aten.view.default(mm, [2, 8, 16]);  mm = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:387 in forward, code: key_states = self.k_proj(hidden_states)                                  t_1: "f32[16, 16]" = torch.ops.aten.t.default(arg5_1);  arg5_1 = None
            view_3: "f32[16, 16]" = torch.ops.aten.view.default(mul_1, [16, 16])
            mm_1: "f32[16, 16]" = torch.ops.aten.mm.default(view_3, t_1);  view_3 = t_1 = None
            view_4: "f32[2, 8, 16]" = torch.ops.aten.view.default(mm_1, [2, 8, 16]);  mm_1 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:388 in forward, code: value_states = self.v_proj(hidden_states)                                t_2: "f32[16, 16]" = torch.ops.aten.t.default(arg6_1);  arg6_1 = None
            view_5: "f32[16, 16]" = torch.ops.aten.view.default(mul_1, [16, 16]);  mul_1 = None
            mm_2: "f32[16, 16]" = torch.ops.aten.mm.default(view_5, t_2);  view_5 = t_2 = None
            view_6: "f32[2, 8, 16]" = torch.ops.aten.view.default(mm_2, [2, 8, 16]);  mm_2 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:390 in forward, code: query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)                                                                                        view_7: "f32[2, 8, 2, 8]" = torch.ops.aten.view.default(view_2, [2, 8, 2, 8]);  view_2 = None
            transpose: "f32[2, 2, 8, 8]" = torch.ops.aten.transpose.int(view_7, 1, 2);  view_7 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:391 in forward, code: key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)                                                                                  view_8: "f32[2, 8, 2, 8]" = torch.ops.aten.view.default(view_4, [2, 8, 2, 8]);  view_4 = None
            transpose_1: "f32[2, 2, 8, 8]" = torch.ops.aten.transpose.int(view_8, 1, 2);  view_8 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:392 in forward, code: value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)                                                                              view_9: "f32[2, 8, 2, 8]" = torch.ops.aten.view.default(view_6, [2, 8, 2, 8]);  view_6 = None
            transpose_2: "f32[2, 2, 8, 8]" = torch.ops.aten.transpose.int(view_9, 1, 2);  view_9 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:154 in forward, code: self.cos_cached[:seq_len].to(dtype=x.dtype),                             slice_7: "f32[8, 8]" = torch.ops.aten.slice.Tensor(arg11_1, 0, 0, 8);  arg11_1 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:155 in forward, code: self.sin_cached[:seq_len].to(dtype=x.dtype),                             slice_8: "f32[8, 8]" = torch.ops.aten.slice.Tensor(arg12_1, 0, 0, 8);  arg12_1 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:232 in apply_rotary_pos_emb, code: cos = cos[position_ids].unsqueeze(unsqueeze_dim)            index: "f32[1, 8, 8]" = torch.ops.aten.index.Tensor(slice_7, [unsqueeze]);  slice_7 = None
            unsqueeze_7: "f32[1, 1, 8, 8]" = torch.ops.aten.unsqueeze.default(index, 1);  index = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:233 in apply_rotary_pos_emb, code: sin = sin[position_ids].unsqueeze(unsqueeze_dim)            index_1: "f32[1, 8, 8]" = torch.ops.aten.index.Tensor(slice_8, [unsqueeze]);  slice_8 = unsque
eze = None                                                                                                            unsqueeze_8: "f32[1, 1, 8, 8]" = torch.ops.aten.unsqueeze.default(index_1, 1);  index_1 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:234 in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q) * sin)                mul_2: "f32[2, 2, 8, 8]" = torch.ops.aten.mul.Tensor(transpose, unsqueeze_7)
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:206 in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]                                      slice_9: "f32[2, 2, 8, 4]" = torch.ops.aten.slice.Tensor(transpose, 3, 0, 4)
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:207 in rotate_half, code: x2 = x[..., x.shape[-1] // 2 :]                                      slice_10: "f32[2, 2, 8, 4]" = torch.ops.aten.slice.Tensor(transpose, 3, 4, 9223372036854775807
);  transpose = None                                                                                                  
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:208 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)                                  neg: "f32[2, 2, 8, 4]" = torch.ops.aten.neg.default(slice_10);  slice_10 = None
            cat: "f32[2, 2, 8, 8]" = torch.ops.aten.cat.default([neg, slice_9], -1);  neg = slice_9 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:234 in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q) * sin)                mul_3: "f32[2, 2, 8, 8]" = torch.ops.aten.mul.Tensor(cat, unsqueeze_8);  cat = None
            add_2: "f32[2, 2, 8, 8]" = torch.ops.aten.add.Tensor(mul_2, mul_3);  mul_2 = mul_3 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:235 in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k) * sin)                mul_4: "f32[2, 2, 8, 8]" = torch.ops.aten.mul.Tensor(transpose_1, unsqueeze_7);  unsqueeze_7 =
 None                                                                                                                 
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:206 in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]                                      slice_11: "f32[2, 2, 8, 4]" = torch.ops.aten.slice.Tensor(transpose_1, 3, 0, 4)
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:207 in rotate_half, code: x2 = x[..., x.shape[-1] // 2 :]                                      slice_12: "f32[2, 2, 8, 4]" = torch.ops.aten.slice.Tensor(transpose_1, 3, 4, 92233720368547758
07);  transpose_1 = None                                                                                              
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:208 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)                                  neg_1: "f32[2, 2, 8, 4]" = torch.ops.aten.neg.default(slice_12);  slice_12 = None
            cat_1: "f32[2, 2, 8, 8]" = torch.ops.aten.cat.default([neg_1, slice_11], -1);  neg_1 = slice_1
1 = None                                                                                                              
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:235 in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k) * sin)                mul_5: "f32[2, 2, 8, 8]" = torch.ops.aten.mul.Tensor(cat_1, unsqueeze_8);  cat_1 = unsqueeze_8
 = None                                                                                                               add_3: "f32[2, 2, 8, 8]" = torch.ops.aten.add.Tensor(mul_4, mul_5);  mul_4 = mul_5 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:413 in forward, code: attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(self.head_dim)                                                                                   transpose_3: "f32[2, 2, 8, 8]" = torch.ops.aten.transpose.int(add_3, 2, 3)
            expand_3: "f32[2, 2, 8, 8]" = torch.ops.aten.expand.default(add_2, [2, 2, 8, 8]);  add_2 = Non
e                                                                                                                     clone: "f32[2, 2, 8, 8]" = torch.ops.aten.clone.default(expand_3, memory_format = torch.contig
uous_format);  expand_3 = None                                                                                        _unsafe_view: "f32[4, 8, 8]" = torch.ops.aten._unsafe_view.default(clone, [4, 8, 8]);  clone =
 None                                                                                                                 expand_4: "f32[2, 2, 8, 8]" = torch.ops.aten.expand.default(transpose_3, [2, 2, 8, 8]);  trans
pose_3 = None                                                                                                         clone_1: "f32[2, 2, 8, 8]" = torch.ops.aten.clone.default(expand_4, memory_format = torch.cont
iguous_format);  expand_4 = None                                                                                      _unsafe_view_1: "f32[4, 8, 8]" = torch.ops.aten._unsafe_view.default(clone_1, [4, 8, 8]);  clo
ne_1 = None                                                                                                           bmm: "f32[4, 8, 8]" = torch.ops.aten.bmm.default(_unsafe_view, _unsafe_view_1);  _unsafe_view 
= _unsafe_view_1 = None                                                                                               view_10: "f32[2, 2, 8, 8]" = torch.ops.aten.view.default(bmm, [2, 2, 8, 8]);  bmm = None
            div: "f32[2, 2, 8, 8]" = torch.ops.aten.div.Tensor(view_10, 2.8284271247461903);  view_10 = No
ne                                                                                                                    
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:426 in forward, code: attn_weights = attn_weights + attention_mask                             add_4: "f32[2, 2, 8, 8]" = torch.ops.aten.add.Tensor(div, masked_fill_2);  div = masked_fill_2
 = None                                                                                                               
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:429 in forward, code: attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)                                                                             _softmax: "f32[2, 2, 8, 8]" = torch.ops.aten._softmax.default(add_4, -1, False);  add_4 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:430 in forward, code: attn_weights = nn.functional.dropout(attn_weights, p=self.attention_dropout, training=self.training)                                                                               clone_2: "f32[2, 2, 8, 8]" = torch.ops.aten.clone.default(_softmax);  _softmax = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:431 in forward, code: attn_output = torch.matmul(attn_weights, value_states)                   expand_5: "f32[2, 2, 8, 8]" = torch.ops.aten.expand.default(clone_2, [2, 2, 8, 8]);  clone_2 =
 None                                                                                                                 view_11: "f32[4, 8, 8]" = torch.ops.aten.view.default(expand_5, [4, 8, 8]);  expand_5 = None
            expand_6: "f32[2, 2, 8, 8]" = torch.ops.aten.expand.default(transpose_2, [2, 2, 8, 8])
            clone_3: "f32[2, 2, 8, 8]" = torch.ops.aten.clone.default(expand_6, memory_format = torch.cont
iguous_format);  expand_6 = None                                                                                      _unsafe_view_2: "f32[4, 8, 8]" = torch.ops.aten._unsafe_view.default(clone_3, [4, 8, 8]);  clo
ne_3 = None                                                                                                           bmm_1: "f32[4, 8, 8]" = torch.ops.aten.bmm.default(view_11, _unsafe_view_2);  view_11 = _unsaf
e_view_2 = None                                                                                                       view_12: "f32[2, 2, 8, 8]" = torch.ops.aten.view.default(bmm_1, [2, 2, 8, 8]);  bmm_1 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:439 in forward, code: attn_output = attn_output.transpose(1, 2).contiguous()                   transpose_4: "f32[2, 8, 2, 8]" = torch.ops.aten.transpose.int(view_12, 1, 2);  view_12 = None
            clone_4: "f32[2, 8, 2, 8]" = torch.ops.aten.clone.default(transpose_4, memory_format = torch.c
ontiguous_format);  transpose_4 = None                                                                                
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:441 in forward, code: attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)                                                                                                                    view_13: "f32[2, 8, 16]" = torch.ops.aten.view.default(clone_4, [2, 8, 16]);  clone_4 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:448 in forward, code: attn_output = self.o_proj(attn_output)                                   t_3: "f32[16, 16]" = torch.ops.aten.t.default(arg7_1);  arg7_1 = None
            view_14: "f32[16, 16]" = torch.ops.aten.view.default(view_13, [16, 16]);  view_13 = None
            mm_3: "f32[16, 16]" = torch.ops.aten.mm.default(view_14, t_3);  view_14 = t_3 = None
            view_15: "f32[2, 8, 16]" = torch.ops.aten.view.default(mm_3, [2, 8, 16]);  mm_3 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:807 in forward, code: hidden_states = residual + hidden_states                                 add_5: "f32[2, 8, 16]" = torch.ops.aten.add.Tensor(embedding, view_15);  embedding = view_15 =
 None                                                                                                                 
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:115 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)                   pow_2: "f32[2, 8, 16]" = torch.ops.aten.pow.Tensor_Scalar(add_5, 2)
            mean_1: "f32[2, 8, 1]" = torch.ops.aten.mean.dim(pow_2, [-1], True);  pow_2 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:116 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)                                                                                                      add_6: "f32[2, 8, 1]" = torch.ops.aten.add.Tensor(mean_1, 1e-06);  mean_1 = None
            rsqrt_1: "f32[2, 8, 1]" = torch.ops.aten.rsqrt.default(add_6);  add_6 = None
            mul_6: "f32[2, 8, 16]" = torch.ops.aten.mul.Tensor(add_5, rsqrt_1);  rsqrt_1 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:117 in forward, code: return self.weight * hidden_states.to(input_dtype)                       mul_7: "f32[2, 8, 16]" = torch.ops.aten.mul.Tensor(arg1_1, mul_6);  arg1_1 = mul_6 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:268 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))                                                                                                       t_4: "f32[16, 16]" = torch.ops.aten.t.default(arg8_1);  arg8_1 = None
            view_16: "f32[16, 16]" = torch.ops.aten.view.default(mul_7, [16, 16])
            mm_4: "f32[16, 16]" = torch.ops.aten.mm.default(view_16, t_4);  view_16 = t_4 = None
            view_17: "f32[2, 8, 16]" = torch.ops.aten.view.default(mm_4, [2, 8, 16]);  mm_4 = None
            silu: "f32[2, 8, 16]" = torch.ops.aten.silu.default(view_17);  view_17 = None
            t_5: "f32[16, 16]" = torch.ops.aten.t.default(arg9_1);  arg9_1 = None
            view_18: "f32[16, 16]" = torch.ops.aten.view.default(mul_7, [16, 16]);  mul_7 = None
            mm_5: "f32[16, 16]" = torch.ops.aten.mm.default(view_18, t_5);  view_18 = t_5 = None
            view_19: "f32[2, 8, 16]" = torch.ops.aten.view.default(mm_5, [2, 8, 16]);  mm_5 = None
            mul_8: "f32[2, 8, 16]" = torch.ops.aten.mul.Tensor(silu, view_19);  silu = view_19 = None
            t_6: "f32[16, 16]" = torch.ops.aten.t.default(arg10_1);  arg10_1 = None
            view_20: "f32[16, 16]" = torch.ops.aten.view.default(mul_8, [16, 16]);  mul_8 = None
            mm_6: "f32[16, 16]" = torch.ops.aten.mm.default(view_20, t_6);  view_20 = t_6 = None
            view_21: "f32[2, 8, 16]" = torch.ops.aten.view.default(mm_6, [2, 8, 16]);  mm_6 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:813 in forward, code: hidden_states = residual + hidden_states                                 add_7: "f32[2, 8, 16]" = torch.ops.aten.add.Tensor(add_5, view_21);  add_5 = view_21 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:115 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)                   pow_3: "f32[2, 8, 16]" = torch.ops.aten.pow.Tensor_Scalar(add_7, 2)
            mean_2: "f32[2, 8, 1]" = torch.ops.aten.mean.dim(pow_3, [-1], True);  pow_3 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:116 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)                                                                                                      add_8: "f32[2, 8, 1]" = torch.ops.aten.add.Tensor(mean_2, 1e-06);  mean_2 = None
            rsqrt_2: "f32[2, 8, 1]" = torch.ops.aten.rsqrt.default(add_8);  add_8 = None
            mul_9: "f32[2, 8, 16]" = torch.ops.aten.mul.Tensor(add_7, rsqrt_2);  add_7 = rsqrt_2 = None
            
            # File: /home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/transformers/models/l
lama/modeling_llama.py:117 in forward, code: return self.weight * hidden_states.to(input_dtype)                       mul_10: "f32[2, 8, 16]" = torch.ops.aten.mul.Tensor(arg2_1, mul_9);  arg2_1 = mul_9 = None
            return (mul_10, add_3, transpose_2)
            
Graph signature: ExportGraphSignature(input_specs=[InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgu
ment(name='arg0_1'), target='model.layers.0.input_layernorm.weight', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='arg1_1'), target='model.layers.0.post_attention_layernorm.weight', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='arg2_1'), target='model.norm.weight', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='arg3_1'), target='model.embed_tokens.weight', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='arg4_1'), target='model.layers.0.self_attn.q_proj.weight', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='arg5_1'), target='model.layers.0.self_attn.k_proj.weight', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='arg6_1'), target='model.layers.0.self_attn.v_proj.weight', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='arg7_1'), target='model.layers.0.self_attn.o_proj.weight', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='arg8_1'), target='model.layers.0.mlp.gate_proj.weight', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='arg9_1'), target='model.layers.0.mlp.up_proj.weight', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='arg10_1'), target='model.layers.0.mlp.down_proj.weight', persistent=None), InputSpec(kind=<InputKind.BUFFER: 3>, arg=TensorArgument(name='arg11_1'), target='model.layers.0.self_attn.rotary_emb.cos_cached', persistent=False), InputSpec(kind=<InputKind.BUFFER: 3>, arg=TensorArgument(name='arg12_1'), target='model.layers.0.self_attn.rotary_emb.sin_cached', persistent=False), InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=TensorArgument(name='arg13_1'), target=None, persistent=None), InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=TensorArgument(name='arg14_1'), target=None, persistent=None)], output_specs=[OutputSpec(kind=<OutputKind.USER_OUTPUT: 1>, arg=TensorArgument(name='mul_10'), target=None), OutputSpec(kind=<OutputKind.USER_OUTPUT: 1>, arg=TensorArgument(name='add_3'), target=None), OutputSpec(kind=<OutputKind.USER_OUTPUT: 1>, arg=TensorArgument(name='transpose_2'), target=None)])                                Range constraints: {}

FX Node count: 139
/home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/torch/onnx/_internal/exporter.py:136: Use
rWarning: torch.onnx.dynamo_export only implements opset version 18 for now. If you need to use a different opset version, please register them with register_custom_op.                                              warnings.warn(
===exported_onnx===
number of nodes: 1
  transformers_models_llama_modeling_llama_LlamaModel_model_1: 1
number of inputs: 15
number of outputs: 3
number of initializers: 0
number of functions: 41
===inlined_exported_onnx===
number of nodes: 508
  Constant: 166
  Cast: 88
  Range: 2
  Unsqueeze: 9
  Gather: 1
  Expand: 9
  CastLike: 22
  Mul: 22
  Add: 9
  Reshape: 65
  Less: 1
  Where: 3
  Slice: 10
  Abs: 6
  Sub: 1
  Pow: 3
  Shape: 13
  Size: 11
  Equal: 11
  If: 12
  Sqrt: 3
  Reciprocal: 3
  MatMul: 9
  Transpose: 9
  Max: 2
  Concat: 2
  GatherND: 2
  Neg: 2
  SequenceConstruct: 2
  ConcatFromSequence: 2
  Identity: 5
  Div: 1
  Softmax: 1
  Sigmoid: 1
number of inputs: 15
number of outputs: 3
number of initializers: 0
number of functions: 0
/home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/torch/onnx/_internal/exporter.py:136: Use
rWarning: torch.onnx.dynamo_export only implements opset version 18 for now. If you need to use a different opset version, please register them with register_custom_op.                                              warnings.warn(
===exported_eager_onnx===
number of nodes: 1
  transformers_models_llama_modeling_llama_LlamaModel_model_1: 1
number of inputs: 15
number of outputs: 3
number of initializers: 0
number of functions: 37
===inlined_eager_exported_onnx===
number of nodes: 461
  Constant: 158
  Cast: 88
  Range: 2
  Unsqueeze: 12
  Gather: 1
  Expand: 9
  CastLike: 15
  Mul: 22
  Add: 9
  Reshape: 65
  Less: 1
  Where: 3
  Slice: 10
  Abs: 6
  Sub: 1
  Pow: 3
  ReduceMean: 3
  Sqrt: 3
  Reciprocal: 3
  Transpose: 16
  MatMul: 9
  Max: 2
  Shape: 2
  Concat: 2
  GatherND: 2
  Neg: 2
  SequenceConstruct: 2
  ConcatFromSequence: 2
  Identity: 5
  Div: 1
  Softmax: 1
  Sigmoid: 1
number of inputs: 15
number of outputs: 3
number of initializers: 0
number of functions: 0
'GroupQueryAttention' is not a known op in 'com.microsoft'
Could not rewrite function: Could not find Add node
Could not rewrite function: Could not find Add node
/home/justinchu/anaconda3/envs/onnx/lib/python3.10/site-packages/onnxrewriter/ir/irbuilder.py:135: UserWar
ning: Use of undefined variable ''.                                                                         warnings.warn(f"Use of undefined variable '{input}'.", stacklevel=1)
Applied 0 pattern rewrite rules.
===rewritten_model===
number of nodes: 270
  Constant: 95
  Cast: 41
  Range: 2
  Unsqueeze: 5
  Gather: 1
  Expand: 3
  CastLike: 15
  Mul: 15
  Add: 6
  Reshape: 23
  Less: 1
  Where: 3
  Slice: 8
  Abs: 2
  Sub: 1
  Pow: 3
  Shape: 8
  Size: 6
  Equal: 6
  If: 6
  Sqrt: 3
  Reciprocal: 3
  Transpose: 4
  MatMul: 7
  ConstantOfShape: 1
  GroupQueryAttention: 1
  Sigmoid: 1
number of inputs: 15
number of outputs: 3
number of initializers: 0
number of functions: 0
Applied 3 pattern rewrite rules.
Applied 0 pattern rewrite rules.
===rewritten_inlined_eager_exported_onnx===
number of nodes: 91
  Constant: 34
  Gather: 1
  Slice: 3
  Unsqueeze: 2
  Expand: 1
  Mul: 11
  Sub: 1
  Cast: 2
  Where: 2
  Pow: 3
  ReduceMean: 3
  Add: 5
  Sqrt: 3
  Reciprocal: 3
  Transpose: 7
  MatMul: 7
  ConstantOfShape: 1
  GroupQueryAttention: 1
  Sigmoid: 1
number of inputs: 15
number of outputs: 3
number of initializers: 0
number of functions: 0
Applied 0 pattern rewrite rules.
===rewritten_inlined_eager_exported_onnx2===
number of nodes: 91
  Constant: 34
  Gather: 1
  Slice: 3
  Unsqueeze: 2
  Expand: 1
  Mul: 11
  Sub: 1
  Cast: 2
  Where: 2
  Pow: 3
  ReduceMean: 3
  Add: 5
  Sqrt: 3
  Reciprocal: 3
  Transpose: 7
  MatMul: 7
  ConstantOfShape: 1
  GroupQueryAttention: 1
  Sigmoid: 1
number of inputs: 15
number of outputs: 3
number of initializers: 0
number of functions: 0
```