### PR TITLE
Update CODECOV_TOKEN to upload coverage information

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -75,6 +75,8 @@ jobs:
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Codecov actions v4 requires CODECOV_TOKEN to be provided https://github.com/codecov/codecov-action/issues/1293