### PR TITLE
Simplify linked list design with a hash table

### DIFF
--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -549,19 +549,14 @@ class Node(_protocols.NodeProtocol, _display.PrettyPrintable):
         self._graph: Graph | None = graph
         self.doc_string = doc_string
 
-        # Attributes _link_box is used for the linked list
-        # and is modified by the DoublyLinkedList class. Do not modify them directly.
-        # This list of nodes is constructed as a doubly linked list
-        # pylint: disable=unused-private-member
-        self._link_box: _linked_list._LinkBox | None = None
-        # pylint: enable=unused-private-member
-        if self._graph is not None:
-            self._graph.append(self)
-
         # Add the node as a user of the inputs
         for i, input_value in enumerate(self._inputs):
             if input_value is not None:
                 input_value.add_user(self, i)
+
+        # Add the node to the graph if graph is specified
+        if self._graph is not None:
+            self._graph.append(self)
 
     def __str__(self) -> str:
         node_type_text = f"{self._domain}::{self._op_type}" + f":{self._overload}" * (
@@ -1098,7 +1093,7 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
             raise ValueError(
                 f"The node {node} belongs to another graph. Please remove it first with Graph.remove()."
             )
-        node._graph = self
+        node._graph = self  # pylint: disable=protected-access
         return node
 
     # Mutation methods
@@ -1137,7 +1132,7 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
         """
         if node.graph is not self:
             raise ValueError(f"The node {node} does not belong to this graph.")
-        node._graph = None
+        node._graph = None  # pylint: disable=protected-access
         self._nodes.remove(node)
 
     def insert_after(self, node: Node, new_nodes: Iterable[Node]) -> None:

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1041,8 +1041,8 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
         self._opset_imports = opset_imports or {}
         self._metadata: _metadata.MetadataStore | None = None
         self._metadata_props: dict[str, str] | None = None
-        self._nodes: _linked_list.DoublyLinkedHashList[Node] = (
-            _linked_list.DoublyLinkedHashList()
+        self._nodes: _linked_list.DoublyLinkedSet[Node] = (
+            _linked_list.DoublyLinkedSet()
         )
         # Call self.extend not self._nodes.extend so the graph reference is added to the nodes
         self.extend(nodes)

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1046,9 +1046,9 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
         self._opset_imports = opset_imports or {}
         self._metadata: _metadata.MetadataStore | None = None
         self._metadata_props: dict[str, str] | None = None
-        self._nodes: _linked_list.DoublyLinkedHashList[Node] = (
-            _linked_list.DoublyLinkedHashList(nodes)
-        )
+        self._nodes: _linked_list.DoublyLinkedHashList[Node] = _linked_list.DoublyLinkedHashList()
+        # Call self.extend not self._nodes.extend so the graph reference is added to the nodes
+        self.extend(nodes)
 
     @property
     def inputs(self) -> tuple[Value, ...]:

--- a/onnxscript/ir/_linked_list.py
+++ b/onnxscript/ir/_linked_list.py
@@ -9,8 +9,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, Generic, Iterable, Iterator, Protocol, Sequence, TypeVar
-
+from typing import Generic, Iterable, Iterator, Sequence, TypeVar
 
 T = TypeVar("T")
 

--- a/onnxscript/ir/_linked_list.py
+++ b/onnxscript/ir/_linked_list.py
@@ -25,19 +25,19 @@ class _LinkBox(Generic[T]):
     list without losing the links. This allows us to remove the object from the list during
     iteration and place the object into a different list without breaking any chains.
 
-    This is an internal class and should only be initialized by the :class:`DoublyLinkedHashList`.
+    This is an internal class and should only be initialized by the :class:`DoublyLinkedSet`.
 
     Attributes:
         prev: The previous box in the list.
         next: The next box in the list.
         erased: A flag to indicate if the box has been removed from the list.
-        owning_list: The :class:`DoublyLinkedHashList` to which the box belongs.
+        owning_list: The :class:`DoublyLinkedSet` to which the box belongs.
         value: The actual object in the list.
     """
 
     __slots__ = ("prev", "next", "value", "owning_list")
 
-    def __init__(self, owner: DoublyLinkedHashList[T], value: T | None) -> None:
+    def __init__(self, owner: DoublyLinkedSet[T], value: T | None) -> None:
         """Create a new link box.
 
         Args:
@@ -49,7 +49,7 @@ class _LinkBox(Generic[T]):
         self.prev: _LinkBox[T] = self
         self.next: _LinkBox[T] = self
         self.value: T | None = value
-        self.owning_list: DoublyLinkedHashList[T] = owner
+        self.owning_list: DoublyLinkedSet[T] = owner
 
     @property
     def erased(self) -> bool:
@@ -69,7 +69,7 @@ class _LinkBox(Generic[T]):
         return f"_LinkBox({self.value!r}, erased={self.erased}, prev={self.prev.value!r}, next={self.next.value!r})"
 
 
-class DoublyLinkedHashList(Generic[T], Sequence[T]):
+class DoublyLinkedSet(Generic[T], Sequence[T]):
     """A doubly linked list of nodes.
 
     Adding and removing elements from the list during iteration is safe. Moving elements
@@ -87,6 +87,8 @@ class DoublyLinkedHashList(Generic[T], Sequence[T]):
         Inserting and removing nodes from the list is O(1). Accessing nodes by index is O(n),
         although accessing nodes at either end of the list is O(1). I.e. `list[0]` and `list[-1]`
         are O(1).
+
+    Values need to be hashable. `None` is not a valid value in the list.
     """
 
     __slots__ = ("_root", "_length", "_values_to_boxes")
@@ -176,6 +178,8 @@ class DoublyLinkedHashList(Generic[T], Sequence[T]):
             box: The box which the new value is to be inserted.
             new_value: The new value to be inserted.
         """
+        if new_value is None:
+            raise TypeError("DoublyLinkedSet does not support None values")
         if box.value is new_value:
             # Do nothing if the new value is the same as the old value
             return box
@@ -269,4 +273,4 @@ class DoublyLinkedHashList(Generic[T], Sequence[T]):
         return self._insert_many_after(insertion_point, new_values)
 
     def __repr__(self) -> str:
-        return f"DoublyLinkedHashList({list(self)})"
+        return f"DoublyLinkedSet({list(self)})"

--- a/onnxscript/ir/_linked_list.py
+++ b/onnxscript/ir/_linked_list.py
@@ -175,7 +175,6 @@ class DoublyLinkedHashList(Generic[T], Sequence[T]):
         Args:
             box: The box which the new value is to be inserted.
             new_value: The new value to be inserted.
-            property_modifier: A function that modifies the properties of the new node.
         """
         if box.value is new_value:
             # Do nothing if the new value is the same as the old value
@@ -247,7 +246,6 @@ class DoublyLinkedHashList(Generic[T], Sequence[T]):
         Args:
             value: The value after which the new values are to be inserted.
             new_values: The new values to be inserted.
-            property_modifier: A function that modifies the properties of the new nodes.
         """
         if value not in self._values_to_boxes:
             raise ValueError(f"Value {value!r} is not in the list")
@@ -264,7 +262,6 @@ class DoublyLinkedHashList(Generic[T], Sequence[T]):
         Args:
             value: The value before which the new values are to be inserted.
             new_values: The new values to be inserted.
-            property_modifier: A function that modifies the properties of the new nodes.
         """
         if value not in self._values_to_boxes:
             raise ValueError(f"Value {value!r} is not in the list")

--- a/onnxscript/ir/_linked_list.py
+++ b/onnxscript/ir/_linked_list.py
@@ -129,6 +129,9 @@ class DoublyLinkedHashList(Generic[T], Sequence[T]):
             box = box.prev
 
     def __len__(self) -> int:
+        assert self._length == len(
+            self._values_to_boxes
+        ), "Bug in the implementation: length mismatch"
         return self._length
 
     def __getitem__(self, index: int) -> T:
@@ -267,3 +270,6 @@ class DoublyLinkedHashList(Generic[T], Sequence[T]):
             raise ValueError(f"Value {value!r} is not in the list")
         insertion_point = self._values_to_boxes[value].prev
         return self._insert_many_after(insertion_point, new_values)
+
+    def __repr__(self) -> str:
+        return f"DoublyLinkedHashList({list(self)})"

--- a/onnxscript/ir/_linked_list.py
+++ b/onnxscript/ir/_linked_list.py
@@ -179,7 +179,7 @@ class DoublyLinkedSet(Generic[T], Sequence[T]):
             new_value: The new value to be inserted.
         """
         if new_value is None:
-            raise TypeError("DoublyLinkedSet does not support None values")
+            raise TypeError(f"{self.__class__.__name__} does not support None values")
         if box.value is new_value:
             # Do nothing if the new value is the same as the old value
             return box

--- a/onnxscript/ir/_linked_list_test.py
+++ b/onnxscript/ir/_linked_list_test.py
@@ -13,18 +13,17 @@ import parameterized
 from onnxscript.ir import _linked_list
 
 
-class _TestElement(_linked_list.Linkable):
+class _TestElement:
     def __init__(self, value):
-        self._link_box = None
         self.value = value
 
     def __repr__(self) -> str:
-        return f"_TestElement({self.value}, _link_box={self._link_box!r})"
+        return f"_TestElement({self.value})"
 
 
-class DoublyLinkedListTest(unittest.TestCase):
+class DoublyLinkedHashListTest(unittest.TestCase):
     def test_empty_list(self):
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         self.assertEqual(len(linked_list), 0)
         self.assertEqual(list(linked_list), [])
         self.assertEqual(list(reversed(linked_list)), [])
@@ -34,7 +33,7 @@ class DoublyLinkedListTest(unittest.TestCase):
             _ = linked_list[-1]
 
     def test_append_single_element(self):
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elem = _TestElement(0)
         linked_list.append(elem)
 
@@ -49,7 +48,7 @@ class DoublyLinkedListTest(unittest.TestCase):
             _ = linked_list[-2]
 
     def test_append_multiple_elements(self):
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
         for elem in elems:
             linked_list.append(elem)
@@ -65,7 +64,7 @@ class DoublyLinkedListTest(unittest.TestCase):
         self.assertEqual(list(reversed(linked_list)), list(reversed(elems)))
 
     def test_extend(self):
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
         linked_list.extend(elems)
 
@@ -112,7 +111,7 @@ class DoublyLinkedListTest(unittest.TestCase):
         self, _: str, original: list[int], location: int, insertion: list[int], expected: list
     ) -> None:
         # Construct the original list
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in original]
         linked_list.extend(elems)
 
@@ -157,7 +156,7 @@ class DoublyLinkedListTest(unittest.TestCase):
         self, _: str, original: list[int], location: int, insertion: list[int], expected: list
     ) -> None:
         # Construct the original list
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in original]
         linked_list.extend(elems)
 
@@ -181,7 +180,7 @@ class DoublyLinkedListTest(unittest.TestCase):
         ]
     )
     def test_remove(self, _: str, index: int, expected: list[int]) -> None:
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
         linked_list.extend(elems)
 
@@ -192,7 +191,7 @@ class DoublyLinkedListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in reversed(linked_list)], expected[::-1])
 
     def test_remove_raises_when_element_not_found(self) -> None:
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
         linked_list.extend(elems)
 
@@ -200,7 +199,7 @@ class DoublyLinkedListTest(unittest.TestCase):
             linked_list.remove(_TestElement(3))
 
     def test_remove_raises_when_element_is_already_removed(self) -> None:
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elem = _TestElement(0)
         linked_list.append(elem)
         linked_list.remove(elem)
@@ -209,7 +208,7 @@ class DoublyLinkedListTest(unittest.TestCase):
             linked_list.remove(elem)
 
     def test_append_self_does_nothing(self) -> None:
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elem = _TestElement(0)
         linked_list.append(elem)
 
@@ -221,7 +220,7 @@ class DoublyLinkedListTest(unittest.TestCase):
         self.assertEqual(list(reversed(linked_list)), [elem])
 
     def test_append_supports_appending_element_from_the_same_list(self) -> None:
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
         linked_list.extend(elems)
 
@@ -232,7 +231,7 @@ class DoublyLinkedListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in reversed(linked_list)], [1, 2, 0])
 
     def test_extend_supports_extending_elements_from_the_same_list(self) -> None:
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
         linked_list.extend(elems)
 
@@ -243,7 +242,7 @@ class DoublyLinkedListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in reversed(linked_list)], [0, 1, 2])
 
     def test_insert_after_supports_inserting_element_from_the_same_list(self) -> None:
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
         linked_list.extend(elems)
 
@@ -253,7 +252,7 @@ class DoublyLinkedListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in linked_list], [0, 2, 1])
 
     def test_insert_before_supports_inserting_element_from_the_same_list(self) -> None:
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
         linked_list.extend(elems)
 
@@ -263,7 +262,7 @@ class DoublyLinkedListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in linked_list], [2, 0, 1])
 
     def test_iterator_supports_mutation_during_iteration_current_element(self) -> None:
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
         linked_list.extend(elems)
 
@@ -276,7 +275,7 @@ class DoublyLinkedListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in reversed(linked_list)], [2, 0])
 
     def test_iterator_supports_mutation_during_iteration_previous_element(self) -> None:
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
         linked_list.extend(elems)
 
@@ -290,7 +289,7 @@ class DoublyLinkedListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in reversed(linked_list)], [2])
 
     def test_iterator_supports_mutation_during_iteration_next_element(self) -> None:
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
         linked_list.extend(elems)
 
@@ -304,7 +303,7 @@ class DoublyLinkedListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in reversed(linked_list)], [0])
 
     def test_iterator_supports_mutation_in_nested_iteration_right_of_iterator(self) -> None:
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
         linked_list.extend(elems)
 
@@ -324,7 +323,7 @@ class DoublyLinkedListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in reversed(linked_list)], [2, 0])
 
     def test_iterator_supports_mutation_in_nested_iteration_when_iter_is_self(self) -> None:
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
         linked_list.extend(elems)
 
@@ -344,7 +343,7 @@ class DoublyLinkedListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in reversed(linked_list)], [2, 1])
 
     def test_iterator_supports_mutation_in_nested_iteration_left_of_iterator(self) -> None:
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
         linked_list.extend(elems)
 
@@ -366,11 +365,11 @@ class DoublyLinkedListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in reversed(linked_list)], [2, 1])
 
     def test_insert_after_supports_element_from_different_list_during_iteration(self) -> None:
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
         linked_list.extend(elems)
 
-        other_linked_list = _linked_list.DoublyLinkedList()
+        other_linked_list = _linked_list.DoublyLinkedHashList()
         other_elem = _TestElement(42)
         other_linked_list.append(other_elem)
 
@@ -381,17 +380,18 @@ class DoublyLinkedListTest(unittest.TestCase):
         self.assertEqual(len(linked_list), 4)
         self.assertEqual([elem.value for elem in linked_list], [0, 1, 42, 2])
         self.assertEqual([elem.value for elem in reversed(linked_list)], [2, 42, 1, 0])
-        self.assertEqual(len(other_linked_list), 0)
-        self.assertEqual([elem.value for elem in other_linked_list], [])
+        # Other list remains unchanged
+        self.assertEqual(len(other_linked_list), 1)
+        self.assertEqual([elem.value for elem in other_linked_list], [42])
 
     def test_insert_after_supports_taking_elements_from_another_doubly_linked_list(
         self,
     ) -> None:
-        linked_list = _linked_list.DoublyLinkedList()
+        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
         linked_list.extend(elems)
 
-        other_linked_list = _linked_list.DoublyLinkedList()
+        other_linked_list = _linked_list.DoublyLinkedHashList()
         other_elem = _TestElement(42)
         other_linked_list.append(other_elem)
 
@@ -400,8 +400,9 @@ class DoublyLinkedListTest(unittest.TestCase):
         self.assertEqual(len(linked_list), 4)
         self.assertEqual([elem.value for elem in linked_list], [0, 1, 42, 2])
         self.assertEqual([elem.value for elem in reversed(linked_list)], [2, 42, 1, 0])
-        self.assertEqual(len(other_linked_list), 0)
-        self.assertEqual([elem.value for elem in other_linked_list], [])
+        # Other list remains unchanged
+        self.assertEqual(len(other_linked_list), 1)
+        self.assertEqual([elem.value for elem in other_linked_list], [42])
 
 
 if __name__ == "__main__":

--- a/onnxscript/ir/_linked_list_test.py
+++ b/onnxscript/ir/_linked_list_test.py
@@ -64,10 +64,8 @@ class DoublyLinkedHashListTest(unittest.TestCase):
         self.assertEqual(list(reversed(linked_list)), list(reversed(elems)))
 
     def test_extend(self):
-        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
-        linked_list.extend(elems)
-
+        linked_list = _linked_list.DoublyLinkedHashList(elems)
         self.assertEqual(len(linked_list), 3)
         self.assertEqual(linked_list[0], elems[0])
         self.assertEqual(linked_list[1], elems[1])
@@ -111,9 +109,8 @@ class DoublyLinkedHashListTest(unittest.TestCase):
         self, _: str, original: list[int], location: int, insertion: list[int], expected: list
     ) -> None:
         # Construct the original list
-        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in original]
-        linked_list.extend(elems)
+        linked_list = _linked_list.DoublyLinkedHashList(elems)
 
         # Create the new elements
         new_elements = [_TestElement(i) for i in insertion]
@@ -156,9 +153,8 @@ class DoublyLinkedHashListTest(unittest.TestCase):
         self, _: str, original: list[int], location: int, insertion: list[int], expected: list
     ) -> None:
         # Construct the original list
-        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in original]
-        linked_list.extend(elems)
+        linked_list = _linked_list.DoublyLinkedHashList(elems)
 
         # Create the new elements
         new_elements = [_TestElement(i) for i in insertion]
@@ -180,9 +176,8 @@ class DoublyLinkedHashListTest(unittest.TestCase):
         ]
     )
     def test_remove(self, _: str, index: int, expected: list[int]) -> None:
-        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
-        linked_list.extend(elems)
+        linked_list = _linked_list.DoublyLinkedHashList(elems)
 
         linked_list.remove(elems[index])
 
@@ -191,9 +186,8 @@ class DoublyLinkedHashListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in reversed(linked_list)], expected[::-1])
 
     def test_remove_raises_when_element_not_found(self) -> None:
-        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
-        linked_list.extend(elems)
+        linked_list = _linked_list.DoublyLinkedHashList(elems)
 
         with self.assertRaises(ValueError):
             linked_list.remove(_TestElement(3))
@@ -220,9 +214,8 @@ class DoublyLinkedHashListTest(unittest.TestCase):
         self.assertEqual(list(reversed(linked_list)), [elem])
 
     def test_append_supports_appending_element_from_the_same_list(self) -> None:
-        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
-        linked_list.extend(elems)
+        linked_list = _linked_list.DoublyLinkedHashList(elems)
 
         linked_list.append(elems[1])
 
@@ -231,10 +224,8 @@ class DoublyLinkedHashListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in reversed(linked_list)], [1, 2, 0])
 
     def test_extend_supports_extending_elements_from_the_same_list(self) -> None:
-        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
-        linked_list.extend(elems)
-
+        linked_list = _linked_list.DoublyLinkedHashList(elems)
         linked_list.extend(elems[::-1])
 
         self.assertEqual(len(linked_list), 3)
@@ -242,30 +233,24 @@ class DoublyLinkedHashListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in reversed(linked_list)], [0, 1, 2])
 
     def test_insert_after_supports_inserting_element_from_the_same_list(self) -> None:
-        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
-        linked_list.extend(elems)
-
+        linked_list = _linked_list.DoublyLinkedHashList(elems)
         linked_list.insert_after(elems[0], [elems[2]])
 
         self.assertEqual(len(linked_list), 3)
         self.assertEqual([elem.value for elem in linked_list], [0, 2, 1])
 
     def test_insert_before_supports_inserting_element_from_the_same_list(self) -> None:
-        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
-        linked_list.extend(elems)
-
+        linked_list = _linked_list.DoublyLinkedHashList(elems)
         linked_list.insert_before(elems[0], [elems[2]])
 
         self.assertEqual(len(linked_list), 3)
         self.assertEqual([elem.value for elem in linked_list], [2, 0, 1])
 
     def test_iterator_supports_mutation_during_iteration_current_element(self) -> None:
-        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
-        linked_list.extend(elems)
-
+        linked_list = _linked_list.DoublyLinkedHashList(elems)
         for elem in linked_list:
             if elem.value == 1:
                 linked_list.remove(elem)
@@ -275,10 +260,8 @@ class DoublyLinkedHashListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in reversed(linked_list)], [2, 0])
 
     def test_iterator_supports_mutation_during_iteration_previous_element(self) -> None:
-        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
-        linked_list.extend(elems)
-
+        linked_list = _linked_list.DoublyLinkedHashList(elems)
         for elem in linked_list:
             if elem.value == 1:
                 linked_list.remove(elem)
@@ -289,10 +272,8 @@ class DoublyLinkedHashListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in reversed(linked_list)], [2])
 
     def test_iterator_supports_mutation_during_iteration_next_element(self) -> None:
-        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
-        linked_list.extend(elems)
-
+        linked_list = _linked_list.DoublyLinkedHashList(elems)
         for elem in linked_list:
             if elem.value == 1:
                 linked_list.remove(elems[2])
@@ -303,10 +284,8 @@ class DoublyLinkedHashListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in reversed(linked_list)], [0])
 
     def test_iterator_supports_mutation_in_nested_iteration_right_of_iterator(self) -> None:
-        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
-        linked_list.extend(elems)
-
+        linked_list = _linked_list.DoublyLinkedHashList(elems)
         iter1_visited = []
         iter2_visited = []
         for elem in linked_list:
@@ -323,10 +302,8 @@ class DoublyLinkedHashListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in reversed(linked_list)], [2, 0])
 
     def test_iterator_supports_mutation_in_nested_iteration_when_iter_is_self(self) -> None:
-        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
-        linked_list.extend(elems)
-
+        linked_list = _linked_list.DoublyLinkedHashList(elems)
         iter1_visited = []
         iter2_visited = []
         for elem in linked_list:
@@ -343,10 +320,8 @@ class DoublyLinkedHashListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in reversed(linked_list)], [2, 1])
 
     def test_iterator_supports_mutation_in_nested_iteration_left_of_iterator(self) -> None:
-        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
-        linked_list.extend(elems)
-
+        linked_list = _linked_list.DoublyLinkedHashList(elems)
         iter1_visited = []
         iter2_visited = []
         for elem in linked_list:
@@ -365,10 +340,8 @@ class DoublyLinkedHashListTest(unittest.TestCase):
         self.assertEqual([elem.value for elem in reversed(linked_list)], [2, 1])
 
     def test_insert_after_supports_element_from_different_list_during_iteration(self) -> None:
-        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
-        linked_list.extend(elems)
-
+        linked_list = _linked_list.DoublyLinkedHashList(elems)
         other_linked_list = _linked_list.DoublyLinkedHashList()
         other_elem = _TestElement(42)
         other_linked_list.append(other_elem)
@@ -387,10 +360,8 @@ class DoublyLinkedHashListTest(unittest.TestCase):
     def test_insert_after_supports_taking_elements_from_another_doubly_linked_list(
         self,
     ) -> None:
-        linked_list = _linked_list.DoublyLinkedHashList()
         elems = [_TestElement(i) for i in range(3)]
-        linked_list.extend(elems)
-
+        linked_list = _linked_list.DoublyLinkedHashList(elems)
         other_linked_list = _linked_list.DoublyLinkedHashList()
         other_elem = _TestElement(42)
         other_linked_list.append(other_elem)

--- a/onnxscript/ir/_linked_list_test.py
+++ b/onnxscript/ir/_linked_list_test.py
@@ -21,9 +21,9 @@ class _TestElement:
         return f"_TestElement({self.value})"
 
 
-class DoublyLinkedHashListTest(unittest.TestCase):
+class DoublyLinkedSetTest(unittest.TestCase):
     def test_empty_list(self):
-        linked_list = _linked_list.DoublyLinkedHashList()
+        linked_list = _linked_list.DoublyLinkedSet()
         self.assertEqual(len(linked_list), 0)
         self.assertEqual(list(linked_list), [])
         self.assertEqual(list(reversed(linked_list)), [])
@@ -33,7 +33,7 @@ class DoublyLinkedHashListTest(unittest.TestCase):
             _ = linked_list[-1]
 
     def test_append_single_element(self):
-        linked_list = _linked_list.DoublyLinkedHashList()
+        linked_list = _linked_list.DoublyLinkedSet()
         elem = _TestElement(0)
         linked_list.append(elem)
 
@@ -48,7 +48,7 @@ class DoublyLinkedHashListTest(unittest.TestCase):
             _ = linked_list[-2]
 
     def test_append_multiple_elements(self):
-        linked_list = _linked_list.DoublyLinkedHashList()
+        linked_list = _linked_list.DoublyLinkedSet()
         elems = [_TestElement(i) for i in range(3)]
         for elem in elems:
             linked_list.append(elem)
@@ -65,7 +65,7 @@ class DoublyLinkedHashListTest(unittest.TestCase):
 
     def test_extend(self):
         elems = [_TestElement(i) for i in range(3)]
-        linked_list = _linked_list.DoublyLinkedHashList(elems)
+        linked_list = _linked_list.DoublyLinkedSet(elems)
         self.assertEqual(len(linked_list), 3)
         self.assertEqual(linked_list[0], elems[0])
         self.assertEqual(linked_list[1], elems[1])
@@ -110,7 +110,7 @@ class DoublyLinkedHashListTest(unittest.TestCase):
     ) -> None:
         # Construct the original list
         elems = [_TestElement(i) for i in original]
-        linked_list = _linked_list.DoublyLinkedHashList(elems)
+        linked_list = _linked_list.DoublyLinkedSet(elems)
 
         # Create the new elements
         new_elements = [_TestElement(i) for i in insertion]
@@ -154,7 +154,7 @@ class DoublyLinkedHashListTest(unittest.TestCase):
     ) -> None:
         # Construct the original list
         elems = [_TestElement(i) for i in original]
-        linked_list = _linked_list.DoublyLinkedHashList(elems)
+        linked_list = _linked_list.DoublyLinkedSet(elems)
 
         # Create the new elements
         new_elements = [_TestElement(i) for i in insertion]
@@ -177,7 +177,7 @@ class DoublyLinkedHashListTest(unittest.TestCase):
     )
     def test_remove(self, _: str, index: int, expected: list[int]) -> None:
         elems = [_TestElement(i) for i in range(3)]
-        linked_list = _linked_list.DoublyLinkedHashList(elems)
+        linked_list = _linked_list.DoublyLinkedSet(elems)
 
         linked_list.remove(elems[index])
 
@@ -187,13 +187,13 @@ class DoublyLinkedHashListTest(unittest.TestCase):
 
     def test_remove_raises_when_element_not_found(self) -> None:
         elems = [_TestElement(i) for i in range(3)]
-        linked_list = _linked_list.DoublyLinkedHashList(elems)
+        linked_list = _linked_list.DoublyLinkedSet(elems)
 
         with self.assertRaises(ValueError):
             linked_list.remove(_TestElement(3))
 
     def test_remove_raises_when_element_is_already_removed(self) -> None:
-        linked_list = _linked_list.DoublyLinkedHashList()
+        linked_list = _linked_list.DoublyLinkedSet()
         elem = _TestElement(0)
         linked_list.append(elem)
         linked_list.remove(elem)
@@ -202,7 +202,7 @@ class DoublyLinkedHashListTest(unittest.TestCase):
             linked_list.remove(elem)
 
     def test_append_self_does_nothing(self) -> None:
-        linked_list = _linked_list.DoublyLinkedHashList()
+        linked_list = _linked_list.DoublyLinkedSet()
         elem = _TestElement(0)
         linked_list.append(elem)
 
@@ -215,7 +215,7 @@ class DoublyLinkedHashListTest(unittest.TestCase):
 
     def test_append_supports_appending_element_from_the_same_list(self) -> None:
         elems = [_TestElement(i) for i in range(3)]
-        linked_list = _linked_list.DoublyLinkedHashList(elems)
+        linked_list = _linked_list.DoublyLinkedSet(elems)
 
         linked_list.append(elems[1])
 
@@ -225,7 +225,7 @@ class DoublyLinkedHashListTest(unittest.TestCase):
 
     def test_extend_supports_extending_elements_from_the_same_list(self) -> None:
         elems = [_TestElement(i) for i in range(3)]
-        linked_list = _linked_list.DoublyLinkedHashList(elems)
+        linked_list = _linked_list.DoublyLinkedSet(elems)
         linked_list.extend(elems[::-1])
 
         self.assertEqual(len(linked_list), 3)
@@ -234,7 +234,7 @@ class DoublyLinkedHashListTest(unittest.TestCase):
 
     def test_insert_after_supports_inserting_element_from_the_same_list(self) -> None:
         elems = [_TestElement(i) for i in range(3)]
-        linked_list = _linked_list.DoublyLinkedHashList(elems)
+        linked_list = _linked_list.DoublyLinkedSet(elems)
         linked_list.insert_after(elems[0], [elems[2]])
 
         self.assertEqual(len(linked_list), 3)
@@ -242,7 +242,7 @@ class DoublyLinkedHashListTest(unittest.TestCase):
 
     def test_insert_before_supports_inserting_element_from_the_same_list(self) -> None:
         elems = [_TestElement(i) for i in range(3)]
-        linked_list = _linked_list.DoublyLinkedHashList(elems)
+        linked_list = _linked_list.DoublyLinkedSet(elems)
         linked_list.insert_before(elems[0], [elems[2]])
 
         self.assertEqual(len(linked_list), 3)
@@ -250,7 +250,7 @@ class DoublyLinkedHashListTest(unittest.TestCase):
 
     def test_iterator_supports_mutation_during_iteration_current_element(self) -> None:
         elems = [_TestElement(i) for i in range(3)]
-        linked_list = _linked_list.DoublyLinkedHashList(elems)
+        linked_list = _linked_list.DoublyLinkedSet(elems)
         for elem in linked_list:
             if elem.value == 1:
                 linked_list.remove(elem)
@@ -261,7 +261,7 @@ class DoublyLinkedHashListTest(unittest.TestCase):
 
     def test_iterator_supports_mutation_during_iteration_previous_element(self) -> None:
         elems = [_TestElement(i) for i in range(3)]
-        linked_list = _linked_list.DoublyLinkedHashList(elems)
+        linked_list = _linked_list.DoublyLinkedSet(elems)
         for elem in linked_list:
             if elem.value == 1:
                 linked_list.remove(elem)
@@ -273,7 +273,7 @@ class DoublyLinkedHashListTest(unittest.TestCase):
 
     def test_iterator_supports_mutation_during_iteration_next_element(self) -> None:
         elems = [_TestElement(i) for i in range(3)]
-        linked_list = _linked_list.DoublyLinkedHashList(elems)
+        linked_list = _linked_list.DoublyLinkedSet(elems)
         for elem in linked_list:
             if elem.value == 1:
                 linked_list.remove(elems[2])
@@ -285,7 +285,7 @@ class DoublyLinkedHashListTest(unittest.TestCase):
 
     def test_iterator_supports_mutation_in_nested_iteration_right_of_iterator(self) -> None:
         elems = [_TestElement(i) for i in range(3)]
-        linked_list = _linked_list.DoublyLinkedHashList(elems)
+        linked_list = _linked_list.DoublyLinkedSet(elems)
         iter1_visited = []
         iter2_visited = []
         for elem in linked_list:
@@ -303,7 +303,7 @@ class DoublyLinkedHashListTest(unittest.TestCase):
 
     def test_iterator_supports_mutation_in_nested_iteration_when_iter_is_self(self) -> None:
         elems = [_TestElement(i) for i in range(3)]
-        linked_list = _linked_list.DoublyLinkedHashList(elems)
+        linked_list = _linked_list.DoublyLinkedSet(elems)
         iter1_visited = []
         iter2_visited = []
         for elem in linked_list:
@@ -321,7 +321,7 @@ class DoublyLinkedHashListTest(unittest.TestCase):
 
     def test_iterator_supports_mutation_in_nested_iteration_left_of_iterator(self) -> None:
         elems = [_TestElement(i) for i in range(3)]
-        linked_list = _linked_list.DoublyLinkedHashList(elems)
+        linked_list = _linked_list.DoublyLinkedSet(elems)
         iter1_visited = []
         iter2_visited = []
         for elem in linked_list:
@@ -341,8 +341,8 @@ class DoublyLinkedHashListTest(unittest.TestCase):
 
     def test_insert_after_supports_element_from_different_list_during_iteration(self) -> None:
         elems = [_TestElement(i) for i in range(3)]
-        linked_list = _linked_list.DoublyLinkedHashList(elems)
-        other_linked_list = _linked_list.DoublyLinkedHashList()
+        linked_list = _linked_list.DoublyLinkedSet(elems)
+        other_linked_list = _linked_list.DoublyLinkedSet()
         other_elem = _TestElement(42)
         other_linked_list.append(other_elem)
 
@@ -361,8 +361,8 @@ class DoublyLinkedHashListTest(unittest.TestCase):
         self,
     ) -> None:
         elems = [_TestElement(i) for i in range(3)]
-        linked_list = _linked_list.DoublyLinkedHashList(elems)
-        other_linked_list = _linked_list.DoublyLinkedHashList()
+        linked_list = _linked_list.DoublyLinkedSet(elems)
+        other_linked_list = _linked_list.DoublyLinkedSet()
         other_elem = _TestElement(42)
         other_linked_list.append(other_elem)
 


### PR DESCRIPTION
Use a dictionary to map the values to the boxes in the doubly linked list implementation to

1. Remove the private pointer from Node to LinkedBox
2. Simplify membership checks
3. Ensure elements in the list are unique

Also changed:
1. The node <-> graph relationships are now managed by Graph directly and not by a property_modifier function. Meaning the user is responsible to remove nodes from other graphs before adding the same node to a new graph. This helps separate the concern of the graph from the linked list, allowing us to treat the linked list as a normal list. The list also doesn't need to handle exclusivity, meaning the same value will not be removed from the original list when being added to a new list and can appear in multiple lists, which is what we expect how lists behave. 