### PR TITLE
[IR] Improve api usability

### DIFF
--- a/onnxscript/ir/__init__.py
+++ b/onnxscript/ir/__init__.py
@@ -56,6 +56,8 @@ __all__ = [
     # Enums
     "AttributeType",
     "DataType",
+    # Types
+    "OperatorIdentifier",
 ]
 
 from onnxscript.ir import serde
@@ -104,6 +106,7 @@ from onnxscript.ir._protocols import (
     MapTypeProtocol,
     ModelProtocol,
     NodeProtocol,
+    OperatorIdentifier,
     ReferenceAttributeProtocol,
     ShapeProtocol,
     SparseTensorProtocol,

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -375,12 +375,48 @@ class Dimension(_protocols.DimensionProtocol, _display.PrettyPrintable):
         self._value = value
         self._denotation = denotation
 
-    def __index__(self) -> int:
+    def __int__(self) -> int:
         if not isinstance(self.value, int):
             raise TypeError(
-                f"The value of this dim is not int, but {type(self.value)} ({self.value})"
+                f"The value of this Dimension is not int, but {type(self.value)} ({self.value})"
             )
         return self.value
+
+    def __index__(self) -> int:
+        return int(self)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, (int, str)) or other is None:
+            return self.value == other
+        if not isinstance(other, Dimension):
+            return False
+        return self.value == other.value
+
+    def __ne__(self, value: object) -> bool:
+        return not self.__eq__(value)
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, (int, Dimension)):
+            raise TypeError(f"Expected other to be Dimension or int, got {type(other)}")
+        return int(self) < int(other)
+
+    def __le__(self, other: object) -> bool:
+        if not isinstance(other, (int, Dimension)):
+            raise TypeError(f"Expected other to be Dimension or int, got {type(other)}")
+        return int(self) <= int(other)
+
+    def __gt__(self, other: object) -> bool:
+        if not isinstance(other, (int, Dimension)):
+            raise TypeError(f"Expected other to be Dimension or int, got {type(other)}")
+        return int(self) > int(other)
+
+    def __ge__(self, other: object) -> bool:
+        if not isinstance(other, (int, Dimension)):
+            raise TypeError(f"Expected other to be Dimension or int, got {type(other)}")
+        return int(self) >= int(other)
+
+    def __hash__(self) -> int:
+        return hash(self.value)
 
     @property
     def value(self) -> int | str | None:

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -873,12 +873,13 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
 
     def __repr__(self) -> str:
         value_name = self.name if self.name else "anonymous:" + str(id(self))
+        def_node = self.def_node()
         def_node_text = (
-            self.def_node.name or "anonymous_node:" + str(id(self.def_node))
-            if self.def_node is not None
+            def_node.name or "anonymous_node:" + str(id(def_node))
+            if def_node is not None
             else None
         )
-        return f"{self.__class__.__name__}({value_name!r}, type={self.type!r}, shape={self.shape}, def_node={def_node_text}, def_index={self.def_index})"
+        return f"{self.__class__.__name__}({value_name!r}, type={self.type!r}, shape={self.shape}, def_node={def_node_text}, def_index={self.def_index()})"
 
     def __str__(self) -> str:
         value_name = self.name if self.name else "anonymous:" + str(id(self))
@@ -889,21 +890,13 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
         # that make them hard to read
         return f"%{_quoted(value_name)}<{type_text},{shape_text}>"
 
-    @property
     def def_node(self) -> Node | None:
+        """The node that produces this value."""
         return self._def_node
 
-    @def_node.setter
-    def def_node(self, _: Any) -> None:
-        raise AttributeError("def_node is immutable. Please create a new value instead.")
-
-    @property
     def def_index(self) -> int | None:
+        """The index of the output of the defining node."""
         return self._def_index
-
-    @def_index.setter
-    def def_index(self, _: Any) -> None:
-        raise AttributeError("def_index is immutable. Please create a new value instead.")
 
     def users(self) -> frozenset[tuple[Node, int]]:
         return frozenset(self._users)
@@ -1008,11 +1001,12 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
 
     def is_graph_output(self) -> bool:
         """Whether the value is an output of a graph."""
-        if self.def_node is None:
+        def_node = self.def_node()
+        if def_node is None:
             return False
-        if self.def_node.graph is None:
+        if def_node.graph is None:
             return False
-        return self in self.def_node.graph.outputs
+        return self in def_node.graph.outputs
 
 
 class Input(Value):

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1158,7 +1158,7 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
             raise ValueError(
                 f"The node {node} belongs to another graph. Please remove it first with Graph.remove()."
             )
-        node._graph = self  # pylint: disable=protected-access
+        node.graph = self
         return node
 
     # Mutation methods
@@ -1197,7 +1197,7 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
         """
         if node.graph is not self:
             raise ValueError(f"The node {node} does not belong to this graph.")
-        node._graph = None  # pylint: disable=protected-access
+        node.graph = None
         self._nodes.remove(node)
 
     def insert_after(self, node: Node, new_nodes: Iterable[Node] | Node, /) -> None:

--- a/onnxscript/ir/_core_test.py
+++ b/onnxscript/ir/_core_test.py
@@ -211,8 +211,8 @@ class GraphTest(unittest.TestCase):
             nodes=(node,),
             opset_imports={"": 1},
         )
-        self.assertEqual(graph.inputs, (v0, v1))
-        self.assertEqual(graph.outputs, node.outputs)
+        self.assertEqual(graph.inputs, [v0, v1])
+        self.assertEqual(graph.outputs, [*node.outputs])
         self.assertEqual(graph.opset_imports, {"": 1})
         self.assertEqual(graph.initializers, {})
         self.assertIsNone(graph.doc_string)

--- a/onnxscript/ir/_protocols.py
+++ b/onnxscript/ir/_protocols.py
@@ -54,7 +54,7 @@ class ArrayCompatible(Protocol):
 
 @typing.runtime_checkable
 class DLPackCompatible(Protocol):
-    """Protocol objects that can support dlpack.
+    """Protocol for objects that can support dlpack.
 
     Computation backends can call __dlpack__ to obtain the underlying data in a
     tensor without copying the data. This allows use to use tensorflow tensors etc.
@@ -118,20 +118,20 @@ class TensorProtocol(ArrayCompatible, Protocol):
 
 @typing.runtime_checkable
 class ValueProtocol(Protocol):
-    """Values.
+    """Protocol for values.
 
     A value is a named entity that can be used to represent an input or output of a graph,
-    a function, or a node. The information it stores corresponds to ValueInfoProto
+    a function, or a node. The information it stores corresponds to ``ValueInfoProto``
     in the ONNX specification.
 
     A :class:`Value` is always not owned or owned by exactly one node. When the value is not
-    owned, it must be an input of a graph or a function. The def_node and def_index
-    attributes are None.
+    owned, it must be an input of a graph or a function. ``def_node`` and ``def_index``
+    are ``None``.
 
     When the value is owned by a node, it is an output of the node.
-    The node that produces the value is stored in the :attr:`def_node` attribute.
-    The index of the output of the node that produces the value is stored in the
-    :attr:`def_index` attribute.
+    The node that produces the value can be accessed with :method:`def_node`.
+    The index of the output of the node that produces the value can be accessed with
+    :method:`def_index`.
 
     To find all the nodes that use this value as an input, call :meth:`users`.
 
@@ -139,20 +139,24 @@ class ValueProtocol(Protocol):
 
     Attributes:
         name: The name of the value. A value is always named when it is part of a graph.
-        def_node: The node that produces this value.
-        def_index: The index of the output of the node that produces this value.
         shape: The shape of the value.
         type: The type of the value.
         metadata_props: Metadata.
     """
 
     name: str
-    def_node: NodeProtocol | None
-    def_index: int | None
     shape: ShapeProtocol | None
     type: TypeProtocol | None
     metadata_props: Mapping[str, str]
     meta: Mapping[str, Any]
+
+    def def_node(self) -> NodeProtocol | None:
+        """The node that produces this value."""
+        ...
+
+    def def_index(self) -> int | None:
+        """The index of the output of the node that produces this value."""
+        ...
 
     def users(self) -> AbstractSet[tuple[NodeProtocol, int]]:
         """The set of (node, input_index) with node being those that use this value as an input."""
@@ -165,7 +169,7 @@ class ValueProtocol(Protocol):
 
 @typing.runtime_checkable
 class NodeProtocol(Protocol):
-    """Nodes.
+    """Protocol for nodes.
 
     A node represents an invocation of an operation on the :class:`Value` s in
     the computational graph.
@@ -222,7 +226,7 @@ class NodeProtocol(Protocol):
 
 @typing.runtime_checkable
 class GraphProtocol(Protocol):
-    """Graphs.
+    """Protocol for graphs.
 
     Graph represents a computation graph. In addition to the ONNX specification
     specified fields, it also contains a mapping of :attr:`opset_imports`. This
@@ -288,7 +292,7 @@ class GraphProtocol(Protocol):
 
 @typing.runtime_checkable
 class ModelProtocol(Protocol):
-    """Models.
+    """Protocol for models.
 
     A model is a container for a graph and metadata. It is the top-level object
     that represents an ONNX model.

--- a/onnxscript/ir/_protocols.py
+++ b/onnxscript/ir/_protocols.py
@@ -416,12 +416,12 @@ class TypeProtocol(Protocol):
             Refer to https://github.com/onnx/onnx/blob/main/docs/TypeDenotation.md#type-denotation-definition
             for pre-defined type denotations.
         elem_type: The type of its elements for nested types like Sequence[Optional] tensors.
-            Or None if the type is not nested.
+            Or the DataType if the type is not nested.
         dtype: The data type of the tensor or the nested tensor.
     """
 
     denotation: str | None
-    elem_type: TypeProtocol | None
+    elem_type: TypeProtocol | _enums.DataType
     dtype: _enums.DataType
 
     def __eq__(self, __value: object) -> bool: ...


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1358

1. Expose OperatorIdentifier type
2. Improve methods in the TensorType class
3. Change `def_node` and `def_index` from attributes to functions to reflect their read-only properties in `Value`
4. Add `dtype` for `Value`
5. Make `Dimension` Comparable with `int` and hashable.
6. Make inputs and outputs in Graph mutable