### PR TITLE
[IR] Implement eq for Shape

### DIFF
--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -499,7 +499,18 @@ class Shape(_protocols.ShapeProtocol, _display.PrettyPrintable):
         return f"[{','.join([str(dim) for dim in self._dims])}]"
 
     def __eq__(self, other: object) -> bool:
-        raise NotImplementedError("Not implemented yet")
+        """Return True if the shapes are equal.
+
+        Two shapes are eqaul if all their dimensions are equal.
+        """
+        if isinstance(other, Shape):
+            return self._dims == other._dims
+        if not isinstance(other, Iterable):
+            return False
+        return self.dims == tuple(other)
+
+    def __ne__(self, other: object) -> bool:
+        return not self.__eq__(other)
 
 
 def _quoted(string: str) -> str:

--- a/onnxscript/ir/_core_test.py
+++ b/onnxscript/ir/_core_test.py
@@ -253,6 +253,10 @@ class ShapeTest(unittest.TestCase):
         shape_2 = _core.Shape(dims_2)
         self.assertNotEqual(shape_1, shape_2)
 
+    def test_ne_with_random_object(self):
+        shape = _core.Shape((42,))
+        self.assertNotEqual(shape, 42)
+
 
 class ValueTest(unittest.TestCase):
     def test_initialize(self):

--- a/onnxscript/ir/_core_test.py
+++ b/onnxscript/ir/_core_test.py
@@ -183,6 +183,77 @@ class DimensionTest(unittest.TestCase):
             op(dim, dim2)
 
 
+class ShapeTest(unittest.TestCase):
+    @parameterized.parameterized.expand(
+        [
+            ("empty", (), ()),
+            ("1d", (42,), (42,)),
+            ("int", (42, 42), (42, 42)),
+            ("str", ("any string", "any string"), ("any string", "any string")),
+            ("None", (None, None), (None, None)),
+        ]
+    )
+    def test_eq_with_other_shapes(
+        self, _: str, dims_1: tuple[Any, ...], dims_2: tuple[Any, ...]
+    ):
+        shape_1 = _core.Shape(dims_1)
+        shape_2 = _core.Shape(dims_2)
+        self.assertEqual(shape_1, shape_2)
+
+    @parameterized.parameterized.expand(
+        [
+            ("empty", ()),
+            ("1d", (42,)),
+            ("int", (42, 42)),
+            ("str", ("any string", "any string")),
+            ("None", (None, None)),
+        ]
+    )
+    def test_eq_with_tuple(self, _: str, dims: tuple[Any, ...]):
+        shape = _core.Shape(dims)
+        self.assertEqual(shape, dims)
+
+    @parameterized.parameterized.expand(
+        [
+            ("empty", []),
+            (
+                "1d",
+                [
+                    42,
+                ],
+            ),
+            ("int", [42, 42]),
+            ("str", ["any string", "any string"]),
+            ("None", [None, None]),
+        ]
+    )
+    def test_eq_with_list(self, _: str, dims: list[Any]):
+        shape = _core.Shape(dims)
+        self.assertEqual(shape, dims)
+
+    def test_eq_with_np_shape(self):
+        dims = (42,)
+        array = np.zeros(dims)
+        shape = _core.Shape(dims)
+        self.assertEqual(shape, array.shape)
+
+    @parameterized.parameterized.expand(
+        [
+            ("empty", (), (1,)),
+            ("d", (42,), (0,)),
+            ("rank", (42, 42), (42, 42, 42)),
+            ("str", ("any string",), (42,)),
+            ("None", (None, None), (None, 42)),
+        ]
+    )
+    def test_ne_with_other_shapes(
+        self, _: str, dims_1: tuple[Any, ...], dims_2: tuple[Any, ...]
+    ):
+        shape_1 = _core.Shape(dims_1)
+        shape_2 = _core.Shape(dims_2)
+        self.assertNotEqual(shape_1, shape_2)
+
+
 class ValueTest(unittest.TestCase):
     def test_initialize(self):
         _ = _core.Value(None, def_index=0)


### PR DESCRIPTION
Implement `__eq__` and `__ne__` for Shape. Supports comparing with other shapes or iterables.