### PR TITLE
[IR] Assign default names to nodes and values

### DIFF
--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -39,6 +39,7 @@ from onnxscript.ir import (
     _enums,
     _linked_list,
     _metadata,
+    _name_authority,
     _protocols,
 )
 
@@ -1140,6 +1141,8 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
         # Call self.extend not self._nodes.extend so the graph reference is added to the nodes
         self.extend(nodes)
 
+        self._name_authority = _name_authority.NameAuthority()
+
     @property
     def inputs(self) -> list[Input]:
         return self._inputs
@@ -1180,12 +1183,18 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
     def __reversed__(self) -> Iterator[Node]:
         return reversed(self._nodes)
 
-    def _set_node_graph_to_self(self, node: Node) -> Node:
-        """Set the graph reference for the node."""
+    def _set_node_graph_to_self_and_assign_names(self, node: Node) -> Node:
+        """Set the graph reference for the node and assign names to it and its outputs if they don't have one."""
         if node.graph is not None and node.graph is not self:
             raise ValueError(
                 f"The node {node} belongs to another graph. Please remove it first with Graph.remove()."
             )
+        # Give the node and its output values names if they don't not have one
+        if node.name is None:
+            self._name_authority.name_node(node)
+        for value in node._outputs:  # pylint: disable=protected-access
+            if value.name is None:
+                self._name_authority.name_value(value)
         node.graph = self
         return node
 
@@ -1199,7 +1208,7 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
         Raises:
             ValueError: If the node belongs to another graph.
         """
-        self._set_node_graph_to_self(node)
+        self._set_node_graph_to_self_and_assign_names(node)
         self._nodes.append(node)
 
     def extend(self, nodes: Iterable[Node], /) -> None:
@@ -1211,7 +1220,7 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
         Raises:
             ValueError: If any node belongs to another graph.
         """
-        nodes = [self._set_node_graph_to_self(node) for node in nodes]
+        nodes = [self._set_node_graph_to_self_and_assign_names(node) for node in nodes]
         self._nodes.extend(nodes)
 
     def remove(self, node: Node, /) -> None:
@@ -1240,7 +1249,7 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
         """
         if isinstance(new_nodes, Node):
             new_nodes = (new_nodes,)
-        new_nodes = [self._set_node_graph_to_self(node) for node in new_nodes]
+        new_nodes = [self._set_node_graph_to_self_and_assign_names(node) for node in new_nodes]
         self._nodes.insert_after(node, new_nodes)
 
     def insert_before(self, node: Node, new_nodes: Iterable[Node] | Node, /) -> None:
@@ -1255,7 +1264,7 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
         """
         if isinstance(new_nodes, Node):
             new_nodes = (new_nodes,)
-        new_nodes = [self._set_node_graph_to_self(node) for node in new_nodes]
+        new_nodes = [self._set_node_graph_to_self_and_assign_names(node) for node in new_nodes]
         self._nodes.insert_before(node, new_nodes)
 
     def sort(self) -> None:

--- a/onnxscript/ir/_name_authority.py
+++ b/onnxscript/ir/_name_authority.py
@@ -1,0 +1,30 @@
+"""Auxiliary class for managing names in the IR."""
+
+from __future__ import annotations
+
+from onnxscript.ir import _core
+
+
+class NameAuthority:
+    """Class for giving names to values and nodes in the IR.
+
+    The names are generated in the format ``val_{value_counter}`` for values and
+    ``node_{op_type}_{node_counter}`` for nodes. The counter is incremented each time
+    a new value or node is named.
+
+    The class does not keep track of the names it has given, so it is possible to
+    generate names that conflicts with existing names. It is the responsibility of the
+    user to ensure that the names are unique (typically by running a name-fixing pass
+    on the graph).
+    """
+    def __init__(self):
+        self._value_counter = 0
+        self._node_counter = 0
+
+    def name_value(self, value: _core.Value) -> None:
+        value.name = f"val_{self._value_counter}"
+        self._value_counter += 1
+
+    def name_node(self, node: _core.Node):
+        node.name = f"node_{node.op_type}_{self._node_counter}"
+        self._node_counter += 1

--- a/onnxscript/ir/_naming_authority.py
+++ b/onnxscript/ir/_naming_authority.py
@@ -1,5 +1,0 @@
-"""Auxiliary class for managing names in the IR."""
-
-from __future__ import annotations
-
-class

--- a/onnxscript/ir/_naming_authority.py
+++ b/onnxscript/ir/_naming_authority.py
@@ -1,0 +1,5 @@
+"""Auxiliary class for managing names in the IR."""
+
+from __future__ import annotations
+
+class


### PR DESCRIPTION
Assign default names to nodes and values if they do not have one. 

The class does not keep track of the names it has given, so it is possible to
generate names that conflicts with existing names. It is the responsibility of the
user to ensure that the names are unique (typically by running a name-fixing pass
on the graph).
