### PR TITLE
Fix implementation of index with boolean indices | fix(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -4047,10 +4047,7 @@ def aten_index(self: TensorType, indices: Sequence[Optional[INT64]]) -> TensorTy
 
 
 @torch_op(("aten::index.Tensor", "aten::_unsafe_index.Tensor"), trace_only=True)
-def aten_index_bool(
-    self: TensorType,
-    indices: Sequence[Optional[BOOL]]
-) -> TensorType:  # pylint: disable=inconsistent-return-statements
+def aten_index_bool(self: TensorType, indices: Sequence[Optional[BOOL]]) -> TensorType:  # pylint: disable=inconsistent-return-statements
     index_ranks = [len(index.shape) for index in indices if index is not None]
 
     if index_ranks[0] == 1:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -4109,7 +4109,6 @@ def aten_index_bool(self: TensorType, indices: Sequence[Optional[BOOL]]) -> Tens
         index_count = len([index for index in indices if index is not None])
         if index_count == 1:
             self_rank = len(self.shape)
-            count_of_none = 0
             # Prepare perm for transposing self tensor.
             # In indices, None meaning skip the corresponding dimension,
             # so we need to move this dimension to the end of the list.
@@ -4119,6 +4118,7 @@ def aten_index_bool(self: TensorType, indices: Sequence[Optional[BOOL]]) -> Tens
             # the final result's shape should be [5, 16, 5].
             trans_perm = [i for i in range(self_rank)]
             trans_perm.append(trans_perm.pop(0))
+            count_of_none = 0
             for index in indices:
                 if index is None:
                     self = op.Transpose(self, perm=trans_perm)

--- a/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/tests/function_libs/torch_lib/extra_opinfo.py
@@ -709,10 +709,8 @@ def sample_inputs_index_bool(op_info, device, dtype, requires_grad, **kwargs):
     )
     s = 5
     index_bool = _index_variable_bool(s, s, device=device)
-    # index_bool = torch.tensor([True, False, False, False, True])
-    # index_bool = torch.tensor([True, True, False])
     index_bool_2d = _index_variable_bool((s, s), s, device=device)
-    index_bool_2d_2 = _index_variable_bool((5, 5), s, device=device)
+    index_bool_3d = _index_variable_bool((s, s, s), s, device=device)
     test_args = [
         ([index_bool],),
         ([None, index_bool],),
@@ -723,23 +721,14 @@ def sample_inputs_index_bool(op_info, device, dtype, requires_grad, **kwargs):
         ([None, index_bool, None, index_bool],),
         ([index_bool, None, index_bool, None],),
         ([None, index_bool, index_bool, None],),
-
-        ([index_bool_2d],),                       # Torch OK, [16, 5, 5]
-        ([index_bool_2d, None],),                 # Torch OK, [16, 5, 5]
-        ([index_bool_2d, None, None],),           # Torch OK, [16, 5, 5]
-        # ([index_bool_2d, None, None, None],),     # Torch OK, [16, 16, 5, 5]
-        # ([None, index_bool_2d],),                 # Torch OK, [5, 16, 5]
-        # ([None, None, index_bool_2d],),           # Torch OK, [5, 5, 16]
-
-        # ([index_bool_2d, index_bool_2d],),        # Torch OK, [16]
-        # ([index_bool_2d, index_bool_2d, None],),  # Torch OK, [16, 16]
-        # ([index_bool_2d, index_bool_2d, None, None],),  # Torch OK, [16, 1, 16]
-
-        # ([None, index_bool_2d, index_bool_2d],),        # Torch Bad
-        # ([None, None, index_bool_2d, index_bool_2d],),  # Torch Bad,
-        # ([None, None, None, index_bool_2d],),           # Torch Bad
-        # ([index_bool_2d, None, index_bool_2d, None],),  # Torch Bad
-        # ([index_bool_2d, None, index_bool_2d],),        # Torch Bad
+        ([index_bool_2d],),
+        ([index_bool_2d, None],),
+        ([index_bool_2d, None, None],),
+        ([None, index_bool_2d],),
+        ([None, None, index_bool_2d],),
+        ([index_bool_3d],),
+        ([index_bool_3d, None],),
+        ([None, index_bool_3d],),
     ]
 
     for args in test_args:
@@ -757,38 +746,38 @@ def sample_inputs_index(op_info, device, dtype, requires_grad, **kwargs):
     index_2d = common_methods_invocations.index_variable((s + 1, 2), s, device=device)
     index_3d = common_methods_invocations.index_variable((s + 2, s + 1, 2), s, device=device)
     test_args = [
-        # ([index_1d],),
-        # ([None, index_1d],),
-        # ([None, None, None, index_1d],),
-        # ([index_1d, None],),
-        # ([index_1d, None, None],),
+        ([index_1d],),
+        ([None, index_1d],),
+        ([None, None, None, index_1d],),
+        ([index_1d, None],),
+        ([index_1d, None, None],),
         # Extra index
-        # ([None, index_1d, None, index_1d],),
-        # ([index_1d, None, index_1d, None],),
-        # ([None, index_1d, index_1d, None],),
+        ([None, index_1d, None, index_1d],),
+        ([index_1d, None, index_1d, None],),
+        ([None, index_1d, index_1d, None],),
         ([index_2d],),
-        # ([None, index_2d],),
-        # ([None, None, None, index_2d],),
-        # ([index_2d, None],),
-        # ([index_2d, None, None],),
-        # # Extra index
-        # ([None, index_2d, None, index_2d],),
-        # ([index_2d, None, index_2d, None],),
-        # ([None, index_2d, index_2d, None],),
-        # ([index_3d],),
-        # ([None, index_3d],),
-        # ([None, None, None, index_3d],),
-        # ([index_3d, None],),
-        # ([index_3d, None, None],),
-        # # Extra index
-        # ([None, index_3d, None, index_3d],),
-        # ([index_3d, None, index_3d, None],),
-        # ([None, index_3d, index_3d, None],),
-        # # Mixed indices
-        # ([None, index_3d, index_1d, index_2d],),
-        # # All indices are not None
-        # ([index_2d, index_3d, index_1d],),
-        # ([index_2d, index_3d, index_1d, index_2d],),
+        ([None, index_2d],),
+        ([None, None, None, index_2d],),
+        ([index_2d, None],),
+        ([index_2d, None, None],),
+        # Extra index
+        ([None, index_2d, None, index_2d],),
+        ([index_2d, None, index_2d, None],),
+        ([None, index_2d, index_2d, None],),
+        ([index_3d],),
+        ([None, index_3d],),
+        ([None, None, None, index_3d],),
+        ([index_3d, None],),
+        ([index_3d, None, None],),
+        # Extra index
+        ([None, index_3d, None, index_3d],),
+        ([index_3d, None, index_3d, None],),
+        ([None, index_3d, index_3d, None],),
+        # Mixed indices
+        ([None, index_3d, index_1d, index_2d],),
+        # All indices are not None
+        ([index_2d, index_3d, index_1d],),
+        ([index_2d, index_3d, index_1d, index_2d],),
     ]
 
     for args in test_args:

--- a/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/tests/function_libs/torch_lib/extra_opinfo.py
@@ -692,6 +692,60 @@ def sample_inputs__fft_c2r(self, device, dtype, requires_grad=False, **_):
             )
 
 
+def _index_variable_bool(shape, max_indices, device):
+    if not isinstance(shape, tuple):
+        shape = (shape,)
+    index = (
+        torch.rand(*shape, dtype=torch.double, device=device).mul_(max_indices).floor_().bool()
+    )
+    return index
+
+
+def sample_inputs_index_bool(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info  # Unused
+    del kwargs  # Unused
+    make_arg = functools.partial(
+        torch_testing.make_tensor, dtype=dtype, device=device, requires_grad=requires_grad
+    )
+    s = 5
+    index_bool = _index_variable_bool(s, s, device=device)
+    # index_bool = torch.tensor([True, False, False, False, True])
+    # index_bool = torch.tensor([True, True, False])
+    index_bool_2d = _index_variable_bool((s, s), s, device=device)
+    index_bool_2d_2 = _index_variable_bool((5, 5), s, device=device)
+    test_args = [
+        ([index_bool],),
+        ([None, index_bool],),
+        ([None, None, None, index_bool],),
+        ([index_bool, None],),
+        ([index_bool, None, None],),
+        # Extra index
+        ([None, index_bool, None, index_bool],),
+        ([index_bool, None, index_bool, None],),
+        ([None, index_bool, index_bool, None],),
+
+        ([index_bool_2d],),                       # Torch OK, [16, 5, 5]
+        ([index_bool_2d, None],),                 # Torch OK, [16, 5, 5]
+        ([index_bool_2d, None, None],),           # Torch OK, [16, 5, 5]
+        # ([index_bool_2d, None, None, None],),     # Torch OK, [16, 16, 5, 5]
+        # ([None, index_bool_2d],),                 # Torch OK, [5, 16, 5]
+        # ([None, None, index_bool_2d],),           # Torch OK, [5, 5, 16]
+
+        # ([index_bool_2d, index_bool_2d],),        # Torch OK, [16]
+        # ([index_bool_2d, index_bool_2d, None],),  # Torch OK, [16, 16]
+        # ([index_bool_2d, index_bool_2d, None, None],),  # Torch OK, [16, 1, 16]
+
+        # ([None, index_bool_2d, index_bool_2d],),        # Torch Bad
+        # ([None, None, index_bool_2d, index_bool_2d],),  # Torch Bad,
+        # ([None, None, None, index_bool_2d],),           # Torch Bad
+        # ([index_bool_2d, None, index_bool_2d, None],),  # Torch Bad
+        # ([index_bool_2d, None, index_bool_2d],),        # Torch Bad
+    ]
+
+    for args in test_args:
+        yield opinfo_core.SampleInput(make_arg((s, s, s, s)), args=args)
+
+
 def sample_inputs_index(op_info, device, dtype, requires_grad, **kwargs):
     del op_info  # Unused
     del kwargs  # Unused
@@ -703,38 +757,38 @@ def sample_inputs_index(op_info, device, dtype, requires_grad, **kwargs):
     index_2d = common_methods_invocations.index_variable((s + 1, 2), s, device=device)
     index_3d = common_methods_invocations.index_variable((s + 2, s + 1, 2), s, device=device)
     test_args = [
-        ([index_1d],),
-        ([None, index_1d],),
-        ([None, None, None, index_1d],),
-        ([index_1d, None],),
-        ([index_1d, None, None],),
+        # ([index_1d],),
+        # ([None, index_1d],),
+        # ([None, None, None, index_1d],),
+        # ([index_1d, None],),
+        # ([index_1d, None, None],),
         # Extra index
-        ([None, index_1d, None, index_1d],),
-        ([index_1d, None, index_1d, None],),
-        ([None, index_1d, index_1d, None],),
+        # ([None, index_1d, None, index_1d],),
+        # ([index_1d, None, index_1d, None],),
+        # ([None, index_1d, index_1d, None],),
         ([index_2d],),
-        ([None, index_2d],),
-        ([None, None, None, index_2d],),
-        ([index_2d, None],),
-        ([index_2d, None, None],),
-        # Extra index
-        ([None, index_2d, None, index_2d],),
-        ([index_2d, None, index_2d, None],),
-        ([None, index_2d, index_2d, None],),
-        ([index_3d],),
-        ([None, index_3d],),
-        ([None, None, None, index_3d],),
-        ([index_3d, None],),
-        ([index_3d, None, None],),
-        # Extra index
-        ([None, index_3d, None, index_3d],),
-        ([index_3d, None, index_3d, None],),
-        ([None, index_3d, index_3d, None],),
-        # Mixed indices
-        ([None, index_3d, index_1d, index_2d],),
-        # All indices are not None
-        ([index_2d, index_3d, index_1d],),
-        ([index_2d, index_3d, index_1d, index_2d],),
+        # ([None, index_2d],),
+        # ([None, None, None, index_2d],),
+        # ([index_2d, None],),
+        # ([index_2d, None, None],),
+        # # Extra index
+        # ([None, index_2d, None, index_2d],),
+        # ([index_2d, None, index_2d, None],),
+        # ([None, index_2d, index_2d, None],),
+        # ([index_3d],),
+        # ([None, index_3d],),
+        # ([None, None, None, index_3d],),
+        # ([index_3d, None],),
+        # ([index_3d, None, None],),
+        # # Extra index
+        # ([None, index_3d, None, index_3d],),
+        # ([index_3d, None, index_3d, None],),
+        # ([None, index_3d, index_3d, None],),
+        # # Mixed indices
+        # ([None, index_3d, index_1d, index_2d],),
+        # # All indices are not None
+        # ([index_2d, index_3d, index_1d],),
+        # ([index_2d, index_3d, index_1d, index_2d],),
     ]
 
     for args in test_args:
@@ -1955,6 +2009,15 @@ OP_DB: List[opinfo_core.OpInfo] = [
             torch.bool, torch.float16, torch.bfloat16, torch.chalf
         ),
         sample_inputs_func=sample_inputs_index,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.index.Tensor.bool",
+        aten_name="index.Tensor",
+        dtypes=common_dtype.all_types_and_complex_and(
+            torch.bool, torch.float16, torch.bfloat16, torch.chalf
+        ),
+        sample_inputs_func=sample_inputs_index_bool,
+        op=torch.ops.aten.index.Tensor,
     ),
     opinfo_core.OpInfo(
         "ops.aten.index_put",

--- a/tests/function_libs/torch_lib/ops_test_data.py
+++ b/tests/function_libs/torch_lib/ops_test_data.py
@@ -848,6 +848,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     # TorchLibOpInfo("is_same_size", core_ops.aten_is_same_size),  # no test case in OPS_DB
     # TorchLibOpInfo("is_nonzero", core_ops.aten_is_nonzero),  # no test case in OPS_DB
     TorchLibOpInfo("ops.aten.index.Tensor", core_ops.aten_index, trace_only=True),
+    TorchLibOpInfo("ops.aten.index.Tensor.bool", core_ops.aten_index_bool, trace_only=True),
     TorchLibOpInfo(
         "index_put_bool",
         core_ops.aten_index_put_bool,


### PR DESCRIPTION
1. Add fix to make the aten_index op function could handle more scenarios while the type of indices is Boolean.
2. Add more tests to cover those new scenarios.