### PR TITLE
[CI] Fix test path to run tests/ in CI

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -59,8 +59,7 @@ def test(session):
     )
     session.install(".", "--no-deps")
     session.run("pip", "list")
-    session.run("pytest", "onnxscript", *session.posargs)
-    session.run("pytest", "docs/test", *session.posargs)
+    session.run("pytest", "onnxscript", "tests", "docs/test", *session.posargs)
 
 
 @nox.session(tags=["test-torch-nightly"])
@@ -74,7 +73,7 @@ def test_torch_nightly(session):
     session.install("-r", "requirements/ci/requirements-pytorch-nightly.txt")
     session.install(".", "--no-deps")
     session.run("pip", "list")
-    session.run("pytest", "onnxscript", *session.posargs)
+    session.run("pytest", "onnxscript", "tests", *session.posargs)
 
 
 @nox.session(tags=["test-onnx-weekly"])
@@ -84,7 +83,7 @@ def test_onnx_weekly(session):
     session.install("-r", "requirements/ci/requirements-onnx-weekly.txt")
     session.install(".", "--no-deps")
     session.run("pip", "list")
-    session.run("pytest", "onnxscript", *session.posargs)
+    session.run("pytest", "onnxscript", "tests", *session.posargs)
 
 
 @nox.session(tags=["test-ort-nightly"])
@@ -100,7 +99,7 @@ def test_ort_nightly(session):
     session.install("-r", "requirements/ci/requirements-ort-nightly.txt")
     session.install(".", "--no-deps")
     session.run("pip", "list")
-    session.run("pytest", "onnxscript", *session.posargs)
+    session.run("pytest", "onnxscript", "tests", *session.posargs)
 
 
 @nox.session(tags=["test-experimental-torchlib-tracing"])

--- a/tests/models/eg1.py
+++ b/tests/models/eg1.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-from onnxscript.onnx import opset15 as op
+from onnxscript import opset15 as op
 from onnxscript.onnx_types import FLOAT
 
 # tensor inputs can have ONNX-like type annotations


### PR DESCRIPTION
Run tests under the `tests/` directory. Previously we migrated `tests/` from `onnxscript/tests` but I did not realize nox was not properly configured to discover them. cc @BowenBao 

1. Fix a serialization / deserialization issue with shape/type in the IR
2. Fix an import error in test