### PR TITLE
Bump required ONNX to 1.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,13 +92,13 @@ dmypy.json
 !.vscode/extensions.json
 
 # Generated files
-onnxscript/tests/models/testoutputs/*
-onnxscript/tests/export/*
-docs/auto_examples/*
-onnxscript/tests/mylib.onnxlib
-**/onnx_backend_test_code/**
-*.onnxlib
 *.onnx
 !testdata/**/*.onnx
-tools/ort_rewriter_profiling/onnx_models/*
+*.onnxlib
+**/onnx_backend_test_code/**
+docs/auto_examples/*
+tests/export/*
+tests/models/testoutputs/*
+tests/mylib.onnxlib
 tools/ort_rewriter_profiling/.logs/*
+tools/ort_rewriter_profiling/onnx_models/*

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,7 +26,7 @@ COMMON_TEST_DEPENDENCIES = (
     "pytest!=7.1.0",
     "pyyaml",
 )
-ONNX = "onnx==1.15"
+ONNX = "onnx==1.16"
 ONNX_RUNTIME = "onnxruntime==1.17.1"
 PYTORCH = "torch==2.2.2"
 TORCHVISON = "torchvision==0.17.2"

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -7920,14 +7920,6 @@ def aten_sym_size(self: TReal, dim: int = 0) -> TReal:
     """sym_size(Tensor self, int dim) -> Tensor"""
     # NOTE: onnxscript doesn't support attribute process,
     # so op.Shape(self, start=dim, end=dim + 1) is not supported.
-
-    # TODO(titaiwang): ORT==1.15 fixes SegFault
-    # https://github.com/microsoft/onnxscript/pull/484#discussion_r1136105039
-    # Change the op to:
-    # shape = op.Shape(self)
-    # idx= op.Reshape(dim, [1])
-    # return op.Gather(shape, idx)
-
     shape = op.Shape(self)
     # Reshape helps dim from int to tensor, and
     # input arguments support attribute processing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "License :: OSI Approved :: MIT License",
 ]
-dependencies = ["numpy", "onnx>=1.15", "typing_extensions"]
+dependencies = ["numpy", "onnx>=1.16", "typing_extensions"]
 
 [tool.setuptools.packages.find]
 include = ["onnxscript*"]


### PR DESCRIPTION
Bump required ONNX to 1.16 to always target the latest ONNX version.

Compatibility: The IR should be able to process any IR versions in ONNX. The latest version of ONNX provides this backward compatibility as well as an understanding of the latest IR version.

When ONNX updates, we can bump onnxscript version to be in sync so that we always target the latest ONNX version.