### PR TITLE
[IR] Avoid creating empty dictionaries during deserialization

### DIFF
--- a/onnxscript/ir/serde.py
+++ b/onnxscript/ir/serde.py
@@ -483,7 +483,9 @@ def deserialize_value_info_proto(
         value.name = proto.name
     value.shape = deserialize_type_proto_for_shape(proto.type)
     value.type = deserialize_type_proto_for_type(proto.type)
-    value.metadata_props.update(deserialize_metadata_props(proto.metadata_props))
+    metadata_props = deserialize_metadata_props(proto.metadata_props)
+    if metadata_props is not None:
+        value.metadata_props.update(metadata_props)
     return value
 
 

--- a/onnxscript/ir/serde.py
+++ b/onnxscript/ir/serde.py
@@ -87,7 +87,9 @@ class TensorProtoTensor(_core.TensorBase):
 
     def __init__(self, proto: onnx.TensorProto) -> None:
         self._proto = proto
-        self._metadata_props: dict[str, str] = deserialize_metadata_props(proto.metadata_props)
+        self._metadata_props: dict[str, str] | None = deserialize_metadata_props(
+            proto.metadata_props
+        )
         self._metadata: _metadata.MetadataStore | None = None
 
     @property
@@ -142,6 +144,8 @@ class TensorProtoTensor(_core.TensorBase):
 
     @property
     def metadata_props(self) -> dict[str, str]:
+        if self._metadata_props is None:
+            self._metadata_props = {}
         return self._metadata_props
 
 
@@ -619,7 +623,9 @@ def deserialize_tensor(
     )
 
 
-def deserialize_metadata_props(proto: Sequence[onnx.StringStringEntryProto]) -> dict[str, str] | None:
+def deserialize_metadata_props(
+    proto: Sequence[onnx.StringStringEntryProto],
+) -> dict[str, str] | None:
     if len(proto) == 0:
         # Avoid creating an empty dictionary to save memory
         return None

--- a/onnxscript/ir/serde.py
+++ b/onnxscript/ir/serde.py
@@ -617,7 +617,9 @@ def deserialize_tensor(
     )
 
 
-def deserialize_metadata_props(proto: Sequence[onnx.StringStringEntryProto]) -> dict[str, str]:
+def deserialize_metadata_props(proto: Sequence[onnx.StringStringEntryProto]) -> dict[str, str] | None:
+    if len(proto) == 0:
+        return None
     return {entry.key: entry.value for entry in proto}
 
 

--- a/onnxscript/ir/serde.py
+++ b/onnxscript/ir/serde.py
@@ -621,6 +621,7 @@ def deserialize_tensor(
 
 def deserialize_metadata_props(proto: Sequence[onnx.StringStringEntryProto]) -> dict[str, str] | None:
     if len(proto) == 0:
+        # Avoid creating an empty dictionary to save memory
         return None
     return {entry.key: entry.value for entry in proto}
 


### PR DESCRIPTION
Avoid creating empty dictionaries for metadata_props during deserialization.

When deserializing a 350k-node model, not creating the dictionary by default should save us 84mb of memory just on the nodes, according to https://lerner.co.il/2019/05/12/python-dicts-and-memory-usage/.

350k * 240 bytes = 84 mb