### PR TITLE
Update function opset imports in rewriter

### DIFF
--- a/onnxscript/rewriter/generic_pattern.py
+++ b/onnxscript/rewriter/generic_pattern.py
@@ -113,7 +113,7 @@ class GenericRewriteRule(orp.RewriteRule):
         raise RuntimeError(f"This pattern {self} is meant to replace not to only match.")
 
     def try_rewrite(
-        self, model: ir.Model, node: ir.Node
+        self, model: ir.Model, graph_or_function: ir.Graph | ir.Function, node: ir.Node
     ) -> tuple[int, list[ir.Node], list[ir.Node]] | None:
         """See :meth:`RewriteRule.try_rewrite`."""
 

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -768,7 +768,7 @@ class ReplacementPatternFunction:
         return ReplacementSubgraph(new_values, context.nodes, context.used_opsets)
 
 
-def _update_opset_impots(
+def _update_opset_imports(
     graph_or_function: ir.Graph | ir.Function, delta: ReplacementSubgraph
 ):
     imports = graph_or_function.opset_imports
@@ -864,8 +864,8 @@ class RewriteRule:
                 # appears incorrect for single-pattern matcher. Best to alter iteration to apply
                 # each rewrite immediately, instead of accumulating them.
                 # (iv) return delta here
-                _update_opset_impots(graph_or_function, delta)
-                _update_opset_impots(model.graph, delta)
+                _update_opset_imports(graph_or_function, delta)
+                _update_opset_imports(model.graph, delta)
                 return match.values, delta.new_nodes
         return None
 

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -768,6 +768,21 @@ class ReplacementPatternFunction:
         return ReplacementSubgraph(new_values, context.nodes, context.used_opsets)
 
 
+def _update_opset_impots(
+    graph_or_function: ir.Graph | ir.Function, delta: ReplacementSubgraph
+):
+    imports = graph_or_function.opset_imports
+    for domain, version in delta.used_opsets:
+        if domain not in imports:
+            # use 1 as default version if not explicitly specified
+            imports[domain] = version if version is not None else 1
+        elif version is not None and version != imports[domain]:
+            raise ValueError(
+                f"Multiple versions of opset {domain} used. "
+                f"Expected version {imports[domain]}, but got {version}."
+            )
+
+
 class RewriteRule:
     def __init__(
         self,
@@ -828,7 +843,7 @@ class RewriteRule:
         return match
 
     def try_rewrite(
-        self, model: ir.Model, node: ir.Node
+        self, model: ir.Model, graph_or_function: ir.Graph | ir.Function, node: ir.Node
     ):  # TODO(rama) -> ReplacementSubgraph | None:
         """If the node matches the pattern, then replace the node with the replacement pattern."""
         match = self.matches(node, model)
@@ -844,21 +859,13 @@ class RewriteRule:
                     )
                 # TODO(rama): Check/update opset-imports
                 # (i) Integrate following with the multi-output matcher and code elsewhere:
-                # (ii) For functions, we need to do this with function, not model's main graph.
+                # (ii) Remove the opset imports from deleted nodes?
                 # (iii) Code in the caller (below) checks if match overlaps previous match, which
                 # appears incorrect for single-pattern matcher. Best to alter iteration to apply
                 # each rewrite immediately, instead of accumulating them.
                 # (iv) return delta here
-                imports = model.graph.opset_imports
-                for domain, version in delta.used_opsets:
-                    if domain not in imports:
-                        # use 1 as default version if not explicitly specified
-                        imports[domain] = version if version is not None else 1
-                    elif version is not None and version != imports[domain]:
-                        raise ValueError(
-                            f"Multiple versions of opset {domain} used. "
-                            f"Expected version {imports[domain]}, but got {version}."
-                        )
+                _update_opset_impots(graph_or_function, delta)
+                _update_opset_impots(model.graph, delta)
                 return match.values, delta.new_nodes
         return None
 
@@ -975,7 +982,7 @@ class RewriteRuleSet:
         for rule in self.rules:
             deltas = []
             for i, node in enumerate(graph_or_function):
-                delta = rule.try_rewrite(model, node)
+                delta = rule.try_rewrite(model, graph_or_function, node)
 
                 if delta is None:
                     continue


### PR DESCRIPTION
Previous to this PR, if rewrite pattern includes custom domain, and it's rewriting nodes inside a function. The invalid model will be generated because of lack of registered domain.