### PR TITLE
Simplifying pattern implementation

### DIFF
--- a/onnxscript/rewriter/cast_constant_of_shape.py
+++ b/onnxscript/rewriter/cast_constant_of_shape.py
@@ -19,7 +19,7 @@ def cast_constant_of_shape(shape, scalar, dtype):
 def fused_cast_constant_of_shape(op, shape: ir.Value, scalar: ir.Attr, dtype: ir.Attr, **_):
     # Cast scalar (a TensorProto attribute) to the specified dtype
     scalar_value = scalar.value.numpy().item()
-    cast_value = onnx.helper.make_tensor("value", dtype.value, (), [scalar_value])
+    cast_value = onnx.helper.make_tensor("value", dtype.value, (1,), [scalar_value])
     return op.ConstantOfShape(shape, value=cast_value)
 
 
@@ -29,7 +29,7 @@ def cast_constant_of_shape_without_value(shape, dtype):
 
 
 def fused_cast_constant_of_shape_without_value(op, shape, dtype, **_):
-    zero = onnx.helper.make_tensor("value", dtype.value, (), [0])
+    zero = onnx.helper.make_tensor("value", dtype.value, (1,), [0])
     return op.ConstantOfShape(shape, value=zero)
 
 

--- a/onnxscript/rewriter/cast_constant_of_shape_test.py
+++ b/onnxscript/rewriter/cast_constant_of_shape_test.py
@@ -1,6 +1,8 @@
 import unittest
 
+import onnx.checker
 import onnx.parser
+import onnx.printer
 
 from onnxscript import ir
 from onnxscript.rewriter import cast_constant_of_shape
@@ -8,21 +10,27 @@ from onnxscript.rewriter import cast_constant_of_shape
 
 class CastConstantOfShapeTest(unittest.TestCase):
     def test_cast_after_constant_of_shape_is_fused(self):
-        model_proto = onnx.parser.parse_model(
+        input_model_proto = onnx.parser.parse_model(
             """
             <ir_version: 7, opset_import: [ "" : 17]>
             agraph (int64[2] input_x) => (float16[1, 4] output)
             {
                 constant = ConstantOfShape <value: tensor = float[1] {1.}>(input_x)
-                output = Cast <to = 10> (constant)
+                temp = Cast <to = 10> (constant)
+                output = Identity (temp)
             }
             """
         )
-        model = ir.serde.deserialize_model(model_proto)
+        onnx.checker.check_model(input_model_proto, True)
+        model = ir.serde.deserialize_model(input_model_proto)
         count = cast_constant_of_shape.rules.apply_to_model(model)
         self.assertEqual(count, 1)
-        self.assertEqual(len(model.graph), 1)
+        self.assertEqual(len(model.graph), 2)
         self.assertEqual(model.graph[0].attributes["value"].value.dtype, 10)
+        output_model_proto = ir.serde.serialize_model(model)
+        # TODO: Eliminating `temp` in above example causes a failure.
+        # Rewriter changes graph output name, doesn't introduce type for it
+        onnx.checker.check_model(output_model_proto, True)
 
     def test_cast_after_constant_of_shape_without_value_is_fused(self):
         model_proto = onnx.parser.parse_model(
@@ -31,15 +39,18 @@ class CastConstantOfShapeTest(unittest.TestCase):
             agraph (int64[2] input_x) => (float16[1, 4] output)
             {
                 constant = ConstantOfShape (input_x)
-                output = Cast <to = 10> (constant)
+                temp = Cast <to = 10> (constant)
+                output = Identity (temp)
             }
             """
         )
         model = ir.serde.deserialize_model(model_proto)
         count = cast_constant_of_shape.rules.apply_to_model(model)
         self.assertEqual(count, 1)
-        self.assertEqual(len(model.graph), 1)
+        self.assertEqual(len(model.graph), 2)
         self.assertEqual(model.graph[0].attributes["value"].value.dtype, 10)
+        output_model_proto = ir.serde.serialize_model(model)
+        onnx.checker.check_model(output_model_proto, True)
 
 
 if __name__ == "__main__":

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -224,10 +224,7 @@ class OpsetPattern:
     input model.
     """
 
-    def __init__(
-        self,
-        domain_pattern: PythonPattern | PrefixPattern | str
-    ) -> None:
+    def __init__(self, domain_pattern: PythonPattern | PrefixPattern | str) -> None:
         if isinstance(domain_pattern, str):
             domain_pattern = PythonPattern(domain_pattern)
         self.domain_pattern = domain_pattern
@@ -509,9 +506,7 @@ class NodePattern:
                         yield [pattern, *rest]
 
         inputs = list(enumerate_inputs(list_of_lists, 0))
-        if self.domain.matches(("", None)) and (
-            self.op.matches("Add") or self.op.matches("Mul")
-        ):
+        if self.domain.matches("") and (self.op.matches("Add") or self.op.matches("Mul")):
             # TODO: handle cases where number of inputs is not 2.
             swapped = [[x[1], x[0]] for x in inputs]
             inputs.extend(swapped)

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -383,8 +383,7 @@ class MatchResult:
         self.matched_values = None
         self.bindings = {}
 
-    def extend(self, other: MatchResult | bool, model):
-        del model  # Unused
+    def extend(self, other: MatchResult | bool):
         if not self.success:
             return
         if not other:
@@ -492,7 +491,7 @@ class NodePattern:
             if arg_value is None or previous_node_output_pattern is None:
                 return MatchResult.FAIL()
             sub_match = previous_node_output_pattern.matches(arg_value, model)  # type: ignore[attr-defined]
-            match.extend(sub_match, model)
+            match.extend(sub_match)
             if not match:  # If sub-match failed,
                 return match
         # Sub-graphs not handled yet.
@@ -503,7 +502,7 @@ class NodePattern:
             sub_match = attr_pattern.matches(attr_value, model)  # type: ignore[arg-type]
             if not sub_match:
                 return MatchResult.FAIL()
-            match.extend(sub_match, model)
+            match.extend(sub_match)
         for name in node.attributes:
             # TODO: Support matching default values for attributes.
             if name not in self.attributes:

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -635,8 +635,11 @@ def _handle_pattern_return_value(
         num_outputs = len(node_output_pattern)
         for i, p in enumerate(node_output_pattern):
             assert isinstance(p, NodeOutputPattern)
-            assert p.node_pattern is node_pattern
-            assert p.output_index == i
+            if (p.node_pattern is not node_pattern) or (p.output_index != i):
+                raise NotImplementedError(
+                    "Multi-output pattern not handled by this API. "
+                    "Use other APIs to handle multi-output patterns."
+                )
     else:
         raise TypeError(f"Invalid type {type(node_output_pattern)} for pattern")
     return node_pattern, num_outputs

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -474,20 +474,6 @@ class NodePattern:
         self.attributes = attributes
         self.bound_value = None
 
-    def matches(self, value: ir.Value, model: ir.Model):
-        if self.bound_value is not None:
-            # DAG-matching, not Tree-matching.
-            if self.bound_value.is_same_as(value):
-                return MatchResult([])
-            else:
-                return MatchResult.FAIL()
-        node = value.producer()
-        if node is None:
-            # Eg., value could be an input parameter, which will not match a value
-            # computed by the op in this pattern.
-            return MatchResult.FAIL()
-        return self.matches_node(node, model)
-
     def matches_node(self, node: ir.Node, model: ir.Model) -> MatchResult:
         """Examine if the IR node matches the self pattern."""
         node_version = model.graph.opset_imports.get(node.domain, 1)

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -558,6 +558,12 @@ class NodeOutputPattern(ValuePattern):
             return MatchResult.FAIL()
         return self.node_pattern.matches_node(node, model)
 
+    def commute(self) -> Sequence[ValuePattern]:
+        return [
+            NodeOutputPattern(pattern, self.output_index, self.name)
+            for pattern in self.node_pattern.commute()
+        ]
+
 
 Var = ValuePattern
 

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -404,6 +404,12 @@ class ValuePattern:
         return MatchResult([], {self.name: value})
 
     def commute(self) -> Sequence[ValuePattern]:
+        """Return a list of commuted patterns.
+
+        This is used to handle commutative operations like addition and multiplication.
+        A single pattern is converted into a list of equivalent patterns by swapping
+        the parameters of commutative operations.
+        """
         return [self]
 
     def __add__(self, other):


### PR DESCRIPTION
(Continuation of refactoring of pattern implementation)

* Remove an unused method (dead code)
* Remove unused model parameter 
* Simplify opset pattern matching to check only domain (not version)
* Fix a missing commute implementation
* Fix constant-of-shape fusion to ensure that constant is a 1D tensor, not 0D

Fixes #1447 