### PR TITLE
Propagate relevant info from old values to new values

### DIFF
--- a/onnxscript/rewriter/cast_constant_of_shape_test.py
+++ b/onnxscript/rewriter/cast_constant_of_shape_test.py
@@ -2,7 +2,6 @@ import unittest
 
 import onnx.checker
 import onnx.parser
-import onnx.printer
 
 from onnxscript import ir
 from onnxscript.rewriter import cast_constant_of_shape
@@ -27,7 +26,6 @@ class CastConstantOfShapeTest(unittest.TestCase):
         self.assertEqual(len(model.graph), 1)
         self.assertEqual(model.graph[0].attributes["value"].value.dtype, 10)
         output_model_proto = ir.serde.serialize_model(model)
-        print(onnx.printer.to_text(output_model_proto))
         onnx.checker.check_model(output_model_proto, True)
 
     def test_cast_after_constant_of_shape_without_value_is_fused(self):

--- a/onnxscript/rewriter/cast_constant_of_shape_test.py
+++ b/onnxscript/rewriter/cast_constant_of_shape_test.py
@@ -16,8 +16,7 @@ class CastConstantOfShapeTest(unittest.TestCase):
             agraph (int64[2] input_x) => (float16[1, 4] output)
             {
                 constant = ConstantOfShape <value: tensor = float[1] {1.}>(input_x)
-                temp = Cast <to = 10> (constant)
-                output = Identity (temp)
+                output = Cast <to = 10> (constant)
             }
             """
         )
@@ -25,11 +24,10 @@ class CastConstantOfShapeTest(unittest.TestCase):
         model = ir.serde.deserialize_model(input_model_proto)
         count = cast_constant_of_shape.rules.apply_to_model(model)
         self.assertEqual(count, 1)
-        self.assertEqual(len(model.graph), 2)
+        self.assertEqual(len(model.graph), 1)
         self.assertEqual(model.graph[0].attributes["value"].value.dtype, 10)
         output_model_proto = ir.serde.serialize_model(model)
-        # TODO: Eliminating `temp` in above example causes a failure.
-        # Rewriter changes graph output name, doesn't introduce type for it
+        print(onnx.printer.to_text(output_model_proto))
         onnx.checker.check_model(output_model_proto, True)
 
     def test_cast_after_constant_of_shape_without_value_is_fused(self):
@@ -39,15 +37,14 @@ class CastConstantOfShapeTest(unittest.TestCase):
             agraph (int64[2] input_x) => (float16[1, 4] output)
             {
                 constant = ConstantOfShape (input_x)
-                temp = Cast <to = 10> (constant)
-                output = Identity (temp)
+                output = Cast <to = 10> (constant)
             }
             """
         )
         model = ir.serde.deserialize_model(model_proto)
         count = cast_constant_of_shape.rules.apply_to_model(model)
         self.assertEqual(count, 1)
-        self.assertEqual(len(model.graph), 2)
+        self.assertEqual(len(model.graph), 1)
         self.assertEqual(model.graph[0].attributes["value"].value.dtype, 10)
         output_model_proto = ir.serde.serialize_model(model)
         onnx.checker.check_model(output_model_proto, True)


### PR DESCRIPTION
When we create new values to replace old ones, we lose some of the information associated with the old values. Propagate this information. (See https://github.com/microsoft/onnxscript/issues/1455)