### PR TITLE
Add device to TorchScriptTensor

### DIFF
--- a/onnxscript/function_libs/torch_lib/graph_building/graph_building_test.py
+++ b/onnxscript/function_libs/torch_lib/graph_building/graph_building_test.py
@@ -26,6 +26,16 @@ class TestTorchScriptTracingEvaluator(unittest.TestCase):
         self.onnxscript_graph = graph_building.TorchScriptGraph()
         self.tracer = graph_building.TorchScriptTracingEvaluator(self.onnxscript_graph)
 
+    def test_torchscript_tensor_keeps_torch_device(self):
+        x_tensor = torch.ones((1, 2, 3), dtype=torch.float32)
+        x = self.onnxscript_graph.add_input(
+            "x", x_tensor.shape, x_tensor.dtype, x_tensor.device
+        )
+        self.assertEqual(x.device, x_tensor.device)
+
+        x.device = torch.device("cuda")
+        self.assertEqual(x.device, torch.device("cuda"))
+
     def test_traced_constant_op_is_same_as_compiled_graph(self):
         """Test for op.Constant created in graph builder"""
         with evaluator.default_as(self.tracer):


### PR DESCRIPTION
In torchlib, we have [device specific onnx function](https://github.com/microsoft/onnxscript/blob/8dba367fb000e3696c79b618638861b5cdf759dc/onnxscript/function_libs/torch_lib/ops/core.py#L5797-L5804), therefore, we need `TorchScriptTensor` to carry device property, so converter dispatcher can dispatch the best fitted function to the ATen op.