### PR TITLE
Minor cleanup for multi-output-matcher verbose trace output

### DIFF
--- a/examples/pattern_rewriting.py
+++ b/examples/pattern_rewriting.py
@@ -82,6 +82,7 @@ def rotary_match_pattern(op, x, pos_ids, axis):
     cast2 = op.Cast(cos, to=onnx.TensorProto.FLOAT)
     return cast1, cast2
 
+
 def rotary_apply_pattern(op, x, pos_ids, axis):
     """The replacement pattern."""
     cos_cache = op.Constant(value=onh.from_array(np.random.rand(256, 256).astype(np.float16)))

--- a/examples/pattern_rewriting.py
+++ b/examples/pattern_rewriting.py
@@ -67,18 +67,15 @@ ir_model = ir.serde.deserialize_model(model)
 # The rewriting pattern
 # =====================
 
-op = onnxscript.opset18
-msft_op = onnxscript.values.Opset("com.microsoft", 1)
 
-
-def rotary_match_pattern(x, pos_ids, axis):
+def rotary_match_pattern(op, x, pos_ids, axis):
     """The pattern to match."""
     unsqueeze = op.Unsqueeze(x, axis)
     cast = op.Cast(unsqueeze, to=onnx.TensorProto.FLOAT)
 
     matmul = op.MatMul(pos_ids, cast)
     transpose = op.Transpose(matmul)
-    output, length = msft_op.ConcatTraining(transpose, transpose)
+    output, length = op.ConcatTraining(transpose, transpose, domain="com.microsoft", outputs=2)
 
     sin = op.Sin(output)
     cast1 = op.Cast(sin, to=onnx.TensorProto.FLOAT)
@@ -86,26 +83,11 @@ def rotary_match_pattern(x, pos_ids, axis):
     cast2 = op.Cast(cos, to=onnx.TensorProto.FLOAT)
     return cast1, cast2
 
-
-def validate_rotary_mapping(g, match_result) -> bool:
-    """The validation post matching.
-
-    Returns True to validate the replacement,
-    False not to apply it.
-
-    :param g: model
-    :param match_result: matched nodes
-    """
-    del g
-    del match_result
-    return True
-
-
-def rotary_apply_pattern(x, pos_ids, axis):
+def rotary_apply_pattern(op, x, pos_ids, axis):
     """The replacement pattern."""
     cos_cache = op.Constant(value=onh.from_array(np.random.rand(256, 256).astype(np.float16)))
     sin_cache = op.Constant(value=onh.from_array(np.random.rand(256, 256).astype(np.float16)))
-    part1, part2 = msft_op.RotaryEmbedding(x, pos_ids, cos_cache, sin_cache)
+    part1, part2 = op.RotaryEmbedding(x, pos_ids, cos_cache, sin_cache, domain="com.microsoft", outputs=2)
     return part1, part2
 
 
@@ -114,17 +96,6 @@ def rotary_apply_pattern(x, pos_ids, axis):
 # ========
 #
 # The rule is easy to create.
-
-
-rule_with_validation_function = generic_pattern.make_pattern_rule(
-    rotary_match_pattern,
-    rotary_apply_pattern,
-    validate_rotary_mapping,
-)
-
-################################
-# ``validate_rotary_mapping`` always return True.
-# This argument can be ignored in that case.
 
 rule = generic_pattern.make_pattern_rule(rotary_match_pattern, rotary_apply_pattern)
 
@@ -166,6 +137,8 @@ rule = generic_pattern.make_pattern_rule(
 )
 
 rule.apply_to_model(ir_model)
+
+# TODO(rama): Update the following, the trace-printed looks different now.
 
 ######################################
 # The logs shows every time the algorithm rejected a pattern.

--- a/onnxscript/rewriter/generic_pattern.py
+++ b/onnxscript/rewriter/generic_pattern.py
@@ -96,16 +96,19 @@ def _opt_value_to_str(value: ir.Value | orp.ValuePattern | None) -> str:
     return _value_to_str(value) if value is not None else "None"
 
 
-def _node_to_str(node: ir.Node) -> str:
+def _node_to_str(node: ir.Node | orp.NodePattern) -> str:
     inputs = ", ".join(_opt_value_to_str(input) for input in node.inputs)
     outputs = ", ".join(_opt_value_to_str(output) for output in node.outputs)
-    return f"{outputs} = {node.op_type}({inputs})"
+    op_type = node.op_type
+    domain = str(node.domain)
+    qualified_op = f"{domain}.{op_type}" if domain else op_type
+    return f"{outputs} = {qualified_op}({inputs})"
 
 
-def _pattern_node_to_str(node: orp.NodePattern) -> str:
-    inputs = ", ".join(_opt_value_to_str(input) for input in node.inputs)
-    outputs = ", ".join(_opt_value_to_str(output) for output in node.outputs)
-    return f"{outputs} = {node.op_type}({inputs})"
+# def _pattern_node_to_str(node: orp.NodePattern) -> str:
+#     inputs = ", ".join(_opt_value_to_str(input) for input in node.inputs)
+#     outputs = ", ".join(_opt_value_to_str(output) for output in node.outputs)
+#     return f"{outputs} = {node.op_type}({inputs})"
 
 
 class GenericPatternMatcher(orp.PatternMatcher):
@@ -206,7 +209,7 @@ class GenericPatternMatcher(orp.PatternMatcher):
 
     def print_match(self, graph_node: ir.Node, pattern_node: orp.NodePattern) -> str:
         s1 = _node_to_str(graph_node)
-        s2 = _pattern_node_to_str(pattern_node)
+        s2 = _node_to_str(pattern_node)
         return f"match {s1} with pattern: {s2}"
 
     def _debug_print(self) -> str:
@@ -304,7 +307,7 @@ class GenericPatternMatcher(orp.PatternMatcher):
                 self._hint(
                     "BACKWARD: different node types",
                     "--pattern",
-                    _pattern_node_to_str(pattern_pred),
+                    _node_to_str(pattern_pred),
                     "-- model",
                     _node_to_str(graph_pred),
                 )

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -41,6 +41,9 @@ class StringConstantPattern(Pattern[str]):
     def matches(self, item: str) -> bool:
         return item == self._value
 
+    def __str__(self) -> str:
+        return self._value
+
 
 class PrefixPattern(Pattern[str]):
     """Matches strings with a given prefix."""
@@ -50,6 +53,9 @@ class PrefixPattern(Pattern[str]):
 
     def matches(self, value: str) -> bool:
         return value.startswith(self._value)
+
+    def __str__(self) -> str:
+        return f"{self._value}*"
 
 
 class AttrPattern(Pattern[Union[ir.Attr, ir.RefAttr]]):
@@ -396,6 +402,9 @@ class ValuePattern:
     def __pow__(self, other):
         return onnxop.Pow(self, other)
 
+    def __str__(self) -> str:
+        return self._name or "None"
+
 
 class NodePattern:
     """Represents a pattern that matches against a Node.
@@ -440,9 +449,7 @@ class NodePattern:
 
     @property
     def op_type(self) -> str:
-        if self._op_identifier is not None:
-            return self._op_identifier[1]
-        return "unknown"  # used primarily for debugging
+        return str(self.op)
 
     def matches(self, node: ir.Node) -> bool:
         """Matches the pattern represented by self against a node.
@@ -696,6 +703,9 @@ class GraphPattern:
             for n in nodes
         ]
 
+    def __str__(self) -> str:
+        return "TODO: GraphPattern.__str__"
+
 
 def _to_graph_pattern(pattern_constructor: Callable) -> GraphPattern:
     """Convert a pattern-construction function to a GraphPattern.
@@ -865,6 +875,9 @@ class PatternMatcher(abc.ABC):
         verbose: int = 0,
     ) -> MatchResult:
         pass
+
+    def __str__(self) -> str:
+        return str(self.pattern)
 
 
 class SimplePatternMatcher(PatternMatcher):

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -74,6 +74,7 @@ class AttrPattern(Pattern[Union[ir.Attr, ir.RefAttr]]):
     def __str__(self) -> str:
         return self._name if self._name is not None else "anonymous:" + str(id(self))
 
+
 # TODO: Support tensors. Align with usage elsewhere.
 SupportedAttrTypes = Union[
     int,
@@ -101,6 +102,7 @@ class AttrConstantPattern(AttrPattern):
 
     def __str__(self) -> str:
         return str(self._value)
+
 
 def _to_attr_pattern(value: AttrPattern | ValuePattern | SupportedAttrTypes) -> AttrPattern:
     """Represents promotion of values allowed as keyword-arguments in a pattern-builder call to an AttrPattern."""
@@ -164,6 +166,7 @@ class OpsetPatternBuilder(Pattern[str]):
 
     def __str__(self) -> str:
         return str(self._domain_pattern)
+
 
 onnxop = OpsetPatternBuilder("")
 
@@ -411,6 +414,7 @@ class ValuePattern:
     def __str__(self) -> str:
         return self._name if self._name is not None else "anonymous:" + str(id(self))
 
+
 class NodePattern:
     """Represents a pattern that matches against a Node.
 
@@ -628,6 +632,7 @@ class Constant(ValuePattern):
     def __str__(self) -> str:
         return str(self._value)
 
+
 def _nodes_in_pattern(outputs: Sequence[ValuePattern]) -> list[NodePattern]:
     """Returns all nodes used in a pattern, given the outputs of the pattern."""
     node_patterns: list[NodePattern] = []
@@ -755,7 +760,6 @@ def _to_graph_pattern(pattern_constructor: Callable) -> GraphPattern:
     if isinstance(pattern_outputs, ValuePattern):
         pattern_outputs = [pattern_outputs]
     return GraphPattern(pattern_inputs, pattern_outputs)
-
 
 
 def _valid_to_replace(matched_nodes: Sequence[ir.Node]) -> bool:


### PR DESCRIPTION
Add `__str__` methods to pattern objects and use them in the multi-output-matcher trace output.