### PR TITLE
Create a recursive graph iterator and use it to refactor UnusedFunctionRemover

### DIFF
--- a/onnxscript/ir/__init__.py
+++ b/onnxscript/ir/__init__.py
@@ -70,9 +70,10 @@ __all__ = [
     "to_proto",
     # Pass infrastructure
     "passes",
+    "traversal",
 ]
 
-from onnxscript.ir import passes, serde
+from onnxscript.ir import passes, serde, traversal
 from onnxscript.ir._core import (
     Attr,
     AttrFloat32,

--- a/onnxscript/ir/passes/__init__.py
+++ b/onnxscript/ir/passes/__init__.py
@@ -7,7 +7,6 @@ __all__ = [
     "PassBase",
     "PassResult",
     "PassManager",
-    "NodeTransformer",
     # Errors
     "InvariantError",
     "PreconditionError",
@@ -17,7 +16,6 @@ __all__ = [
 
 from onnxscript.ir.passes._pass_infra import (
     InvariantError,
-    NodeTransformer,
     PassBase,
     PassError,
     PassManager,

--- a/onnxscript/ir/traversal.py
+++ b/onnxscript/ir/traversal.py
@@ -25,8 +25,6 @@ class RecursiveGraphIterator(Iterator[_core.Node], Reversible[_core.Node]):
 
         Args:
             graph: The graph to traverse.
-            enter_graph_handler: A callback that is called when a subgraph is entered.
-            exit_graph_handler: A callback that is called when a subgraph is exited.
             recursive: A callback that determines whether to recursively visit the subgraphs
                 contained in a node. If not provided, all nodes in subgraphs are visited.
             reverse: Whether to iterate in reverse order.

--- a/onnxscript/ir/traversal.py
+++ b/onnxscript/ir/traversal.py
@@ -1,3 +1,7 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
 """Utilities for traversing the IR graph."""
 
 from __future__ import annotations

--- a/onnxscript/ir/traversal.py
+++ b/onnxscript/ir/traversal.py
@@ -54,7 +54,7 @@ class RecursiveGraphIterator(Iterator[_core.Node]):
         if self._enter_graph_handler is not None:
             self._enter_graph_handler(graph)
         iterable = reversed(graph) if self._reversed else graph
-        for node in iterable:
+        for node in iterable:  # type: ignore[union-attr]
             yield node
             if self._recursive is not None and not self._recursive(node):
                 continue

--- a/onnxscript/ir/traversal.py
+++ b/onnxscript/ir/traversal.py
@@ -2,46 +2,66 @@
 
 from __future__ import annotations
 
+from typing_extensions import Self
+
 from onnxscript.ir import _core, _enums
 
 __all__ = [
-    "recursive_node_iter",
+    "RecursiveNodeIterator",
 ]
 
-from typing import Callable, Iterable, Iterator
+from typing import Callable, Iterator
 
 
-class _RecursiveNodeIterator(Iterable[_core.Node]):
-    def __init__(self,
+class RecursiveNodeIterator(Iterator[_core.Node]):
+    def __init__(
+        self,
         graph: _core.Graph,
         enter_graph_handler: Callable[[_core.Graph], None],
         exit_graph_handler: Callable[[_core.Graph], None],
         recursive: Callable[[_core.Node], bool],
         reversed: bool = False,
     ):
+        """Iterate over the nodes in the graph, recursively visiting subgraphs.
+
+        Args:
+            graph: The graph to traverse.
+            enter_graph_handler: A callback that is called when a subgraph is entered.
+            exit_graph_handler: A callback that is called when a subgraph is exited.
+            recursive: A callback that determines whether to recursively visit a node.
+            reversed: Whether to iterate in reverse order.
+        """
         self._graph = graph
         self._enter_graph_handler = enter_graph_handler
         self._exit_graph_handler = exit_graph_handler
         self._recursive = recursive
         self._subgraph_stack = []
         self._reversed = reversed
+        self._iterator = self._recursive_node_iter(graph)
 
-    def __iter__(self) -> Iterator[_core.Node]:
-        self._enter_graph_handler(self._graph)
-        iterable = reversed(self._graph) if self._reversed else self._graph
+    def __iter__(self) -> Self:
+        self._iterator = self._recursive_node_iter(self._graph)
+        return self
+
+    def __next__(self) -> _core.Node:
+        return next(self._iterator)
+
+    def _recursive_node_iter(self, graph: _core.Graph) -> Iterator[_core.Node]:
+        self._enter_graph_handler(graph)
+        iterable = reversed(graph) if self._reversed else graph
         for node in iterable:
             yield node
             if not self._recursive(node):
                 continue
             yield from self._iterate_subgraphs(node)
-        self._exit_graph_handler(self._graph)
+        self._exit_graph_handler(graph)
 
     def _iterate_subgraphs(self, node: _core.Node):
         for attr in node.attributes.values():
             if not isinstance(attr, _core.Attr):
                 continue
             if attr.type == _enums.AttributeType.GRAPH:
-                yield from _RecursiveNodeIterator(
+                yield from RecursiveNodeIterator(
                     attr.value,
                     self._enter_graph_handler,
                     self._exit_graph_handler,
@@ -50,7 +70,7 @@ class _RecursiveNodeIterator(Iterable[_core.Node]):
                 )
             elif attr.type == _enums.AttributeType.GRAPHS:
                 for graph in attr.value:
-                    yield from _RecursiveNodeIterator(
+                    yield from RecursiveNodeIterator(
                         graph,
                         self._enter_graph_handler,
                         self._exit_graph_handler,
@@ -59,26 +79,10 @@ class _RecursiveNodeIterator(Iterable[_core.Node]):
                     )
 
     def __reversed__(self) -> Iterator[_core.Node]:
-        return _RecursiveNodeIterator(
+        return RecursiveNodeIterator(
             self._graph,
             self._enter_graph_handler,
             self._exit_graph_handler,
             self._recursive,
             reversed=not self._reversed,
         )
-
-
-def recursive_node_iter(
-    graph: _core.Graph,
-    enter_graph_handler: Callable[[_core.Graph], None],
-    exit_graph_handler: Callable[[_core.Graph], None],
-    recursive: Callable[[_core.Node], bool],
-) -> Iterator[_core.Node]:
-    """Iterate over the nodes in the graph, recursively visiting subgraphs.
-
-    Args:
-        graph: The graph to traverse.
-        enter_graph_handler: A callback that is called when a subgraph is entered.
-        exit_graph_handler: A callback that is called when a subgraph is exited.
-        recursive: A callback that determines whether to recursively visit a node.
-    """

--- a/onnxscript/ir/traversal.py
+++ b/onnxscript/ir/traversal.py
@@ -56,10 +56,7 @@ class RecursiveGraphIterator(Iterator[_core.Node], Reversible[_core.Node]):
             yield from self._iterate_subgraphs(node)
 
     def _iterate_subgraphs(self, node: _core.Node):
-        iterator = (
-            reversed(node.attributes.values()) if self._reverse else node.attributes.values()
-        )
-        for attr in iterator:
+        for attr in node.attributes.values():
             if not isinstance(attr, _core.Attr):
                 continue
             if attr.type == _enums.AttributeType.GRAPH:

--- a/onnxscript/ir/traversal.py
+++ b/onnxscript/ir/traversal.py
@@ -1,0 +1,84 @@
+"""Utilities for traversing the IR graph."""
+
+from __future__ import annotations
+
+from onnxscript.ir import _core, _enums
+
+__all__ = [
+    "recursive_node_iter",
+]
+
+from typing import Callable, Iterable, Iterator
+
+
+class _RecursiveNodeIterator(Iterable[_core.Node]):
+    def __init__(self,
+        graph: _core.Graph,
+        enter_graph_handler: Callable[[_core.Graph], None],
+        exit_graph_handler: Callable[[_core.Graph], None],
+        recursive: Callable[[_core.Node], bool],
+        reversed: bool = False,
+    ):
+        self._graph = graph
+        self._enter_graph_handler = enter_graph_handler
+        self._exit_graph_handler = exit_graph_handler
+        self._recursive = recursive
+        self._subgraph_stack = []
+        self._reversed = reversed
+
+    def __iter__(self) -> Iterator[_core.Node]:
+        self._enter_graph_handler(self._graph)
+        iterable = reversed(self._graph) if self._reversed else self._graph
+        for node in iterable:
+            yield node
+            if not self._recursive(node):
+                continue
+            yield from self._iterate_subgraphs(node)
+        self._exit_graph_handler(self._graph)
+
+    def _iterate_subgraphs(self, node: _core.Node):
+        for attr in node.attributes.values():
+            if not isinstance(attr, _core.Attr):
+                continue
+            if attr.type == _enums.AttributeType.GRAPH:
+                yield from _RecursiveNodeIterator(
+                    attr.value,
+                    self._enter_graph_handler,
+                    self._exit_graph_handler,
+                    self._recursive,
+                    reversed=self._reversed,
+                )
+            elif attr.type == _enums.AttributeType.GRAPHS:
+                for graph in attr.value:
+                    yield from _RecursiveNodeIterator(
+                        graph,
+                        self._enter_graph_handler,
+                        self._exit_graph_handler,
+                        self._recursive,
+                        reversed=self._reversed,
+                    )
+
+    def __reversed__(self) -> Iterator[_core.Node]:
+        return _RecursiveNodeIterator(
+            self._graph,
+            self._enter_graph_handler,
+            self._exit_graph_handler,
+            self._recursive,
+            reversed=not self._reversed,
+        )
+
+
+def recursive_node_iter(
+    graph: _core.Graph,
+    enter_graph_handler: Callable[[_core.Graph], None],
+    exit_graph_handler: Callable[[_core.Graph], None],
+    recursive: Callable[[_core.Node], bool],
+) -> Iterator[_core.Node]:
+    """Iterate over the nodes in the graph, recursively visiting subgraphs.
+
+    Args:
+        graph: The graph to traverse.
+        enter_graph_handler: A callback that is called when a subgraph is entered.
+        exit_graph_handler: A callback that is called when a subgraph is exited.
+        recursive: A callback that determines whether to recursively visit a node.
+    """

--- a/onnxscript/ir/traversal.py
+++ b/onnxscript/ir/traversal.py
@@ -16,9 +16,11 @@ from onnxscript.ir import _core, _enums
 class RecursiveGraphIterator(Iterator[_core.Node]):
     def __init__(
         self,
-        graph: _core.Graph | _core.Function,
-        enter_graph_handler: Callable[[_core.Graph | _core.Function], None] | None = None,
-        exit_graph_handler: Callable[[_core.Graph | _core.Function], None] | None = None,
+        graph: _core.Graph | _core.Function | _core.GraphView,
+        enter_graph_handler: Callable[[_core.Graph | _core.Function | _core.GraphView], None]
+        | None = None,
+        exit_graph_handler: Callable[[_core.Graph | _core.Function | _core.GraphView], None]
+        | None = None,
         recursive: Callable[[_core.Node], bool] | None = None,
         reversed: bool = False,
     ):
@@ -36,7 +38,6 @@ class RecursiveGraphIterator(Iterator[_core.Node]):
         self._enter_graph_handler = enter_graph_handler
         self._exit_graph_handler = exit_graph_handler
         self._recursive = recursive
-        self._subgraph_stack = []
         self._reversed = reversed
         self._iterator = self._recursive_node_iter(graph)
 
@@ -47,7 +48,9 @@ class RecursiveGraphIterator(Iterator[_core.Node]):
     def __next__(self) -> _core.Node:
         return next(self._iterator)
 
-    def _recursive_node_iter(self, graph: _core.Graph | _core.Function) -> Iterator[_core.Node]:
+    def _recursive_node_iter(
+        self, graph: _core.Graph | _core.Function | _core.GraphView
+    ) -> Iterator[_core.Node]:
         if self._enter_graph_handler is not None:
             self._enter_graph_handler(graph)
         iterable = reversed(graph) if self._reversed else graph

--- a/onnxscript/ir/traversal.py
+++ b/onnxscript/ir/traversal.py
@@ -16,9 +16,9 @@ from onnxscript.ir import _core, _enums
 class RecursiveGraphIterator(Iterator[_core.Node]):
     def __init__(
         self,
-        graph: _core.Graph,
-        enter_graph_handler: Callable[[_core.Graph], None] | None = None,
-        exit_graph_handler: Callable[[_core.Graph], None] | None = None,
+        graph: _core.Graph | _core.Function,
+        enter_graph_handler: Callable[[_core.Graph | _core.Function], None] | None = None,
+        exit_graph_handler: Callable[[_core.Graph | _core.Function], None] | None = None,
         recursive: Callable[[_core.Node], bool] | None = None,
         reversed: bool = False,
     ):
@@ -28,7 +28,8 @@ class RecursiveGraphIterator(Iterator[_core.Node]):
             graph: The graph to traverse.
             enter_graph_handler: A callback that is called when a subgraph is entered.
             exit_graph_handler: A callback that is called when a subgraph is exited.
-            recursive: A callback that determines whether to recursively visit a node.
+            recursive: A callback that determines whether to recursively visit a node. If
+                not provided, all nodes are visited.
             reversed: Whether to iterate in reverse order.
         """
         self._graph = graph
@@ -46,7 +47,7 @@ class RecursiveGraphIterator(Iterator[_core.Node]):
     def __next__(self) -> _core.Node:
         return next(self._iterator)
 
-    def _recursive_node_iter(self, graph: _core.Graph) -> Iterator[_core.Node]:
+    def _recursive_node_iter(self, graph: _core.Graph | _core.Function) -> Iterator[_core.Node]:
         if self._enter_graph_handler is not None:
             self._enter_graph_handler(graph)
         iterable = reversed(graph) if self._reversed else graph

--- a/onnxscript/ir/traversal_test.py
+++ b/onnxscript/ir/traversal_test.py
@@ -52,7 +52,7 @@ class RecursiveGraphIteratorTest(unittest.TestCase):
     @parameterized.parameterized.expand(
         [
             ("forward", False, ("Node1", "Node2", "If", "Node3", "Node4", "Node5", "Node6")),
-            ("reversed", True, ("If", "Node6", "Node5", "Node4", "Node3", "Node2", "Node1")),
+            ("reversed", True, ("If", "Node4", "Node3", "Node6", "Node5", "Node2", "Node1")),
         ]
     )
     def test_recursive_graph_iterator(self, _: str, reverse: bool, expected: tuple[str, ...]):

--- a/onnxscript/ir/traversal_test.py
+++ b/onnxscript/ir/traversal_test.py
@@ -1,3 +1,9 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+from __future__ import annotations
+
 import unittest
 
 import parameterized

--- a/onnxscript/ir/traversal_test.py
+++ b/onnxscript/ir/traversal_test.py
@@ -58,54 +58,6 @@ class RecursiveGraphIteratorTest(unittest.TestCase):
 
     @parameterized.parameterized.expand(
         [
-            ("forward", False, ["main_graph", "then_graph", "else_graph"]),
-            ("reversed", True, ["main_graph", "else_graph", "then_graph"]),
-        ]
-    )
-    def test_recursive_graph_iterator_enter_graph_handler(
-        self, _: str, reverse: bool, expected: list[str]
-    ):
-        scopes = []
-
-        def enter_graph_handler(graph):
-            scopes.append(graph.name)
-
-        for __ in traversal.RecursiveGraphIterator(
-            self.graph, enter_graph_handler=enter_graph_handler, reverse=reverse
-        ):
-            pass
-        self.assertEqual(scopes, expected)
-
-    @parameterized.parameterized.expand(
-        [
-            (
-                "forward",
-                False,
-                [
-                    "then_graph",
-                    "else_graph",
-                    "main_graph",
-                ],
-            ),
-            ("reversed", True, ["else_graph", "then_graph", "main_graph"]),
-        ]
-    )
-    def test_recursive_graph_iterator_exit_graph_handler(
-        self, _: str, reverse: bool, expected: list[str]
-    ):
-        scopes = []
-
-        def exit_graph_handler(graph):
-            scopes.append(graph.name)
-
-        for __ in traversal.RecursiveGraphIterator(
-            self.graph, exit_graph_handler=exit_graph_handler, reverse=reverse
-        ):
-            pass
-        self.assertEqual(scopes, expected)
-
-    @parameterized.parameterized.expand(
-        [
             ("forward", False, ("Node1", "Node2", "If")),
             ("reversed", True, ("If", "Node2", "Node1")),
         ]

--- a/onnxscript/ir/traversal_test.py
+++ b/onnxscript/ir/traversal_test.py
@@ -1,0 +1,93 @@
+import unittest
+
+from onnxscript import ir
+from onnxscript.ir import traversal
+import parameterized
+
+
+class RecursiveGraphIteratorTest(unittest.TestCase):
+    def setUp(self):
+        self.graph = ir.Graph(
+            [],
+            [],
+            nodes=[
+                ir.Node("", "Node1", []),
+                ir.Node("", "Node2", []),
+                ir.Node(
+                    "",
+                    "If",
+                    [],
+                    attributes=[
+                        ir.AttrGraph(
+                            "then_branch",
+                            ir.Graph(
+                                [],
+                                [],
+                                nodes=[ir.Node("", "Node3", []), ir.Node("", "Node4", [])],
+                                name="then_graph",
+                            ),
+                        ),
+                        ir.AttrGraph(
+                            "else_branch",
+                            ir.Graph(
+                                [],
+                                [],
+                                nodes=[ir.Node("", "Node5", []), ir.Node("", "Node6", [])],
+                                name="else_graph",
+                            ),
+                        ),
+                    ],
+                ),
+            ],
+            name="main_graph",
+        )
+
+    @parameterized.parameterized.expand(
+        [
+            ("forward", False, ("Node1", "Node2", "If", "Node3", "Node4", "Node5", "Node6")),
+            ("reversed", True, ("If", "Node6", "Node5", "Node4", "Node3", "Node2", "Node1")),
+        ]
+    )
+    def test_recursive_graph_iterator(self, _: str, reverse: bool, expected: tuple[str, ...]):
+        nodes = list(traversal.RecursiveGraphIterator(self.graph, reverse=reverse))
+        self.assertEqual(tuple(node.op_type for node in nodes), expected)
+
+    @parameterized.parameterized.expand(
+        [
+            ("forward", False, ["main_graph", "then_graph", "else_graph"]),
+            ("reversed", True, ["main_graph", "else_graph", "then_graph"]),
+        ]
+    )
+    def test_recursive_graph_iterator_enter_graph_handler(self, _: str, reverse: bool, expected: list[str]):
+        scopes = []
+
+        def enter_graph_handler(graph):
+            scopes.append(graph.name)
+
+        for __ in traversal.RecursiveGraphIterator(
+                self.graph, enter_graph_handler=enter_graph_handler, reverse=reverse
+            ):
+            pass
+        self.assertEqual(scopes, expected)
+
+    @parameterized.parameterized.expand(
+        [
+            ("forward", False, ["then_graph", "else_graph", "main_graph",]),
+            ("reversed", True, ["else_graph", "then_graph", "main_graph"]),
+        ]
+    )
+    def test_recursive_graph_iterator_exit_graph_handler(self, _: str, reverse: bool, expected: list[str]):
+        scopes = []
+
+        def exit_graph_handler(graph):
+            scopes.append(graph.name)
+
+        for __ in traversal.RecursiveGraphIterator(
+                self.graph, exit_graph_handler=exit_graph_handler, reverse=reverse
+            ):
+            pass
+        self.assertEqual(scopes, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnxscript/ir/traversal_test.py
+++ b/onnxscript/ir/traversal_test.py
@@ -50,7 +50,10 @@ class RecursiveGraphIteratorTest(unittest.TestCase):
         ]
     )
     def test_recursive_graph_iterator(self, _: str, reverse: bool, expected: tuple[str, ...]):
-        nodes = list(traversal.RecursiveGraphIterator(self.graph, reverse=reverse))
+        iterator = traversal.RecursiveGraphIterator(self.graph)
+        if reverse:
+            iterator = reversed(iterator)
+        nodes = list(iterator)
         self.assertEqual(tuple(node.op_type for node in nodes), expected)
 
     @parameterized.parameterized.expand(

--- a/onnxscript/ir/traversal_test.py
+++ b/onnxscript/ir/traversal_test.py
@@ -59,35 +59,63 @@ class RecursiveGraphIteratorTest(unittest.TestCase):
             ("reversed", True, ["main_graph", "else_graph", "then_graph"]),
         ]
     )
-    def test_recursive_graph_iterator_enter_graph_handler(self, _: str, reverse: bool, expected: list[str]):
+    def test_recursive_graph_iterator_enter_graph_handler(
+        self, _: str, reverse: bool, expected: list[str]
+    ):
         scopes = []
 
         def enter_graph_handler(graph):
             scopes.append(graph.name)
 
         for __ in traversal.RecursiveGraphIterator(
-                self.graph, enter_graph_handler=enter_graph_handler, reverse=reverse
-            ):
+            self.graph, enter_graph_handler=enter_graph_handler, reverse=reverse
+        ):
             pass
         self.assertEqual(scopes, expected)
 
     @parameterized.parameterized.expand(
         [
-            ("forward", False, ["then_graph", "else_graph", "main_graph",]),
+            (
+                "forward",
+                False,
+                [
+                    "then_graph",
+                    "else_graph",
+                    "main_graph",
+                ],
+            ),
             ("reversed", True, ["else_graph", "then_graph", "main_graph"]),
         ]
     )
-    def test_recursive_graph_iterator_exit_graph_handler(self, _: str, reverse: bool, expected: list[str]):
+    def test_recursive_graph_iterator_exit_graph_handler(
+        self, _: str, reverse: bool, expected: list[str]
+    ):
         scopes = []
 
         def exit_graph_handler(graph):
             scopes.append(graph.name)
 
         for __ in traversal.RecursiveGraphIterator(
-                self.graph, exit_graph_handler=exit_graph_handler, reverse=reverse
-            ):
+            self.graph, exit_graph_handler=exit_graph_handler, reverse=reverse
+        ):
             pass
         self.assertEqual(scopes, expected)
+
+    @parameterized.parameterized.expand(
+        [
+            ("forward", False, ("Node1", "Node2", "If")),
+            ("reversed", True, ("If", "Node2", "Node1")),
+        ]
+    )
+    def test_recursive_graph_iterator_recursive_controls_recursive_behavior(
+        self, _: str, reverse: bool, expected: list[str]
+    ):
+        nodes = list(
+            traversal.RecursiveGraphIterator(
+                self.graph, recursive=lambda node: node.op_type != "If", reverse=reverse
+            )
+        )
+        self.assertEqual(tuple(node.op_type for node in nodes), expected)
 
 
 if __name__ == "__main__":

--- a/onnxscript/ir/traversal_test.py
+++ b/onnxscript/ir/traversal_test.py
@@ -1,8 +1,9 @@
 import unittest
 
+import parameterized
+
 from onnxscript import ir
 from onnxscript.ir import traversal
-import parameterized
 
 
 class RecursiveGraphIteratorTest(unittest.TestCase):

--- a/onnxscript/optimizer/remove_unused_function.py
+++ b/onnxscript/optimizer/remove_unused_function.py
@@ -13,7 +13,7 @@ from onnxscript import ir
 logger = logging.getLogger(__name__)
 
 
-class UnusedFunctionRemover(ir.passes.NodeTransformer):
+class UnusedFunctionRemover(ir.passes.PassBase):
     def __init__(self):
         super().__init__()
         self.used: set[ir.OperatorIdentifier] = set()
@@ -23,7 +23,7 @@ class UnusedFunctionRemover(ir.passes.NodeTransformer):
             # The function and its nodes are already recorded as used
             return
         self.used.add(function.identifier())
-        for node in function:
+        for node in ir.traversal.RecursiveGraphIterator(function):
             self.call_node_recursive(node)
 
     def call_node(self, node: ir.Node) -> None:

--- a/onnxscript/optimizer/remove_unused_function.py
+++ b/onnxscript/optimizer/remove_unused_function.py
@@ -23,7 +23,7 @@ def _clean_up_unused_functions(model: ir.Model, unused: set[ir.OperatorIdentifie
     logger.debug("Functions removed: %s", unused)
 
 
-class UnusedFunctionRemover(ir.passes.PassBase):
+class RemoveUnusedFunctionPass(ir.passes.PassBase):
     def __init__(self):
         super().__init__()
         self.used: set[ir.OperatorIdentifier] | None = None
@@ -63,7 +63,7 @@ def remove_unused_functions(model_proto: onnx.ModelProto) -> onnx.ModelProto:
     """Removes unused function protos from the model."""
 
     model = ir.serde.deserialize_model(model_proto)
-    result = UnusedFunctionRemover()(model)
+    result = RemoveUnusedFunctionPass()(model)
     model_proto = ir.serde.serialize_model(result.model)
 
     return model_proto

--- a/onnxscript/optimizer/remove_unused_function.py
+++ b/onnxscript/optimizer/remove_unused_function.py
@@ -67,7 +67,7 @@ def remove_unused_functions(model: TModel) -> TModel:
     """Removes unused function protos from the model."""
 
     if isinstance(model, ir.Model):
-        return RemoveUnusedFunctionPass()(model).model
+        return RemoveUnusedFunctionPass()(model).model  # type: ignore[return-value]
 
     model_ = ir.serde.deserialize_model(model)
     result = RemoveUnusedFunctionPass()(model_)

--- a/onnxscript/optimizer/remove_unused_function.py
+++ b/onnxscript/optimizer/remove_unused_function.py
@@ -61,9 +61,9 @@ class UnusedFunctionRemover(ir.passes.PassBase):
 
 def remove_unused_functions(model_proto: onnx.ModelProto) -> onnx.ModelProto:
     """Removes unused function protos from the model."""
-    # TODO(justinchuby): Update this to accept an ir.Model
+
     model = ir.serde.deserialize_model(model_proto)
-    UnusedFunctionRemover()(model)
-    model_proto = ir.serde.serialize_model(model)
+    result = UnusedFunctionRemover()(model)
+    model_proto = ir.serde.serialize_model(result.model)
 
     return model_proto


### PR DESCRIPTION
- Create `traversal.py` for graph traversal utilities and implemented `RecursiveGraphIterator`. Expose `traversal` to the `ir` module. Fixes https://github.com/microsoft/onnxscript/issues/1556
- Remove `NodeTransformer` because `RecursiveGraphIterator` is more flexible.
- Refactor remove_unused_function.py to use `RecursiveGraphIterator`