### PR TITLE
[IR] Make tensor types hashable

### DIFF
--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1315,7 +1315,7 @@ class SparseTensorType(_TensorTypeBase):
     """A type that represents a sparse tensor."""
 
 
-class _RecursiveTypeBase(_protocols.TypeProtocol, _display.PrettyPrintable):
+class _RecursiveTypeBase(_protocols.TypeProtocol, _display.PrettyPrintable, Hashable):
     """Base for recursive types like Optional and Sequence."""
 
     __slots__ = ("_elem_type", "denotation")

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -28,6 +28,7 @@ from typing import (
     Any,
     Collection,
     Generic,
+    Hashable,
     Iterable,
     Iterator,
     OrderedDict,
@@ -1267,7 +1268,7 @@ class Node(_protocols.NodeProtocol, _display.PrettyPrintable):
         super().display(page=page)
 
 
-class _TensorTypeBase(_protocols.TypeProtocol, _display.PrettyPrintable):
+class _TensorTypeBase(_protocols.TypeProtocol, _display.PrettyPrintable, Hashable):
     """Tensor types that are non recursive types."""
 
     __slots__ = ("_dtype", "denotation")
@@ -1288,6 +1289,9 @@ class _TensorTypeBase(_protocols.TypeProtocol, _display.PrettyPrintable):
     def elem_type(self) -> _enums.DataType:
         """Return the element type of the tensor type"""
         return self.dtype
+
+    def __hash__(self) -> int:
+        return hash(repr(self))
 
     def __eq__(self, other: object) -> bool:
         if self.__class__ is not other.__class__:
@@ -1333,6 +1337,9 @@ class _RecursiveTypeBase(_protocols.TypeProtocol, _display.PrettyPrintable):
     @property
     def elem_type(self) -> _protocols.TypeProtocol:
         return self._elem_type
+
+    def __hash__(self) -> int:
+        return hash(repr(self))
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, _RecursiveTypeBase):

--- a/onnxscript/ir/_core_test.py
+++ b/onnxscript/ir/_core_test.py
@@ -576,6 +576,11 @@ class ValueTest(unittest.TestCase):
     def test_initialize(self):
         _ = _core.Value()
 
+    def test_it_is_hashable(self):
+        value = _core.Value()
+        self.assertIsInstance(hash(value), int)
+        self.assertIn(value, {value})
+
     def test_meta(self):
         value = _core.Value()
         value.meta["test"] = 1
@@ -591,6 +596,10 @@ class NodeTest(unittest.TestCase):
         self.v0 = _core.Value()
         self.v1 = _core.Value()
         self.node = _core.Node("test", "TestOp", inputs=(self.v0, self.v1), num_outputs=3)
+
+    def test_it_is_hashable(self):
+        self.assertIsInstance(hash(self.node), int)
+        self.assertIn(self.node, {self.node})
 
     def test_init_with_values(self):
         self.assertEqual(self.node.domain, "test")
@@ -678,6 +687,10 @@ class GraphTest(unittest.TestCase):
         self.assertEqual(self.graph.opset_imports, {"": 1})
         self.assertEqual(self.graph.initializers, {})
         self.assertIsNone(self.graph.doc_string)
+
+    def test_it_is_hashable(self):
+        self.assertIsInstance(hash(self.graph), int)
+        self.assertIn(self.graph, {self.graph})
 
     def test_it_is_iterable_of_nodes(self):
         self.assertEqual(list(self.graph), [self.node])

--- a/onnxscript/ir/_core_test.py
+++ b/onnxscript/ir/_core_test.py
@@ -767,5 +767,26 @@ class GraphTest(unittest.TestCase):
     # TODO(justinchuby): Test graph mutation methods
 
 
+class TypeTest(unittest.TestCase):
+    @parameterized.parameterized.expand(
+        [
+            ("tensor", _core.TensorType(ir.DataType.FLOAT)),
+            ("sequence", _core.SequenceType(_core.TensorType(ir.DataType.BOOL))),
+            ("optional", _core.OptionalType(_core.TensorType(ir.DataType.FLOAT16))),
+            (
+                "sequence_optional",
+                _core.SequenceType(_core.OptionalType(_core.TensorType(ir.DataType.INT8))),
+            ),
+            (
+                "optional_sequence",
+                _core.OptionalType(_core.SequenceType(_core.TensorType(ir.DataType.INT16))),
+            ),
+        ]
+    )
+    def test_type_is_hashable(self, _: str, type_: ir.TypeProtocol):
+        self.assertIsInstance(hash(type_), int)
+        self.assertIn(type_, {type_})  # type: ignore
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Make tensor types hashable so that it is easy to check types in a set of accepted types during schema matching.

Test hashable properties on more classes in the IR.