### PR TITLE
[IR] Expose convenience functions and set module name as public

### DIFF
--- a/onnxscript/ir/__init__.py
+++ b/onnxscript/ir/__init__.py
@@ -136,3 +136,13 @@ from onnxscript.ir._protocols import (
     ValueProtocol,
 )
 from onnxscript.ir.serde import TensorProtoTensor, from_proto, to_proto
+
+
+def __set_module() -> None:
+    """Set the module of all functions in this module to this public module."""
+    global_dict = globals()
+    for name in __all__:
+        global_dict[name].__module__ = __name__
+
+
+__set_module()

--- a/onnxscript/ir/_convenience.py
+++ b/onnxscript/ir/_convenience.py
@@ -5,7 +5,7 @@
 """Convenience methods for constructing and manipulating the IR.
 
 This is an internal only module. We should choose to expose some of the methods
-after they are proven to be useful.
+in convenience.py after they are proven to be useful.
 """
 
 from __future__ import annotations

--- a/onnxscript/ir/convenience.py
+++ b/onnxscript/ir/convenience.py
@@ -1,0 +1,28 @@
+"""Convenience methods for constructing and manipulating the IR."""
+
+from __future__ import annotations
+
+__all__ = [
+    "convert_attribute",
+    "convert_attributes",
+    "replace_all_uses_with",
+]
+
+from onnxscript.ir._convenience import (
+    convert_attribute,
+    convert_attributes,
+    replace_all_uses_with,
+)
+
+# NOTE: Do not implement any other functions in this module.
+# implement them in the _convenience module and import them here instead.
+
+
+def __set_module() -> None:
+    """Set the module of all functions in this module to this public module."""
+    global_dict = globals()
+    for name in __all__:
+        global_dict[name].__module__ = __name__
+
+
+__set_module()

--- a/onnxscript/ir/convenience_test.py
+++ b/onnxscript/ir/convenience_test.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import unittest
+
+from onnxscript.ir import convenience
+
+
+class NamespaceTest(unittest.TestCase):
+
+    def test_module_members_is_public(self):
+        for name in convenience.__all__:
+            function = getattr(convenience, name)
+            self.assertEqual(function.__module__, "onnxscript.ir.convenience")


### PR DESCRIPTION
We modify the `__module__` property for all public apis so that they appear correctly in documentation.