### PR TITLE
Preserve function signatures for OnnxFunction; stabilize `traceable` option

### DIFF
--- a/onnxscript/function_libs/torch_lib/graph_building/_graph_building_ir.py
+++ b/onnxscript/function_libs/torch_lib/graph_building/_graph_building_ir.py
@@ -235,7 +235,7 @@ class TorchScriptTracingEvaluator(evaluator.Evaluator):
                 else:
                     # Python constants are scalars
                     return 0
-            elif function.experimental_traceable:
+            elif function.traceable:
                 # Trace the function call instead of adding the function as a node
                 return function.function(*args, **kwargs)
 

--- a/onnxscript/function_libs/torch_lib/graph_building/_graph_building_torch.py
+++ b/onnxscript/function_libs/torch_lib/graph_building/_graph_building_torch.py
@@ -388,7 +388,7 @@ class TorchScriptTracingEvaluator(evaluator.Evaluator):
                 else:
                     # Python constants are scalars
                     return 0
-            elif function.experimental_traceable:
+            elif function.traceable:
                 # Trace the function call instead of adding the function as a node
                 return function.function(*args, **kwargs)
 

--- a/onnxscript/function_libs/torch_lib/registration.py
+++ b/onnxscript/function_libs/torch_lib/registration.py
@@ -141,7 +141,7 @@ def torch_op(
         else:
             assert isinstance(func, FunctionType)
             processed_func = onnxscript.script(opset=custom_opset)(func)
-            processed_func.experimental_traceable = traceable
+            processed_func.traceable = traceable
 
         assert registry is not None
         for name_ in _check_and_normalize_names(name):

--- a/onnxscript/values.py
+++ b/onnxscript/values.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import dataclasses
+import functools
 import inspect
 import logging
 import types
@@ -477,8 +478,12 @@ class OnnxFunction(Op):
         self._param_schemas: Optional[tuple[ParamSchema, ...]] = None
         self._op_schema: Optional[onnx.defs.OpSchema] = None
 
+        # Allow the object to be inspected as a function
+        self.__wrapped__ = pyfun
+        functools.update_wrapper(self, pyfun)
+
         # Experimental fields
-        self.experimental_traceable = False
+        self.traceable = False
 
     @property
     @deprecation.deprecated(
@@ -569,6 +574,10 @@ class TracedOnnxFunction(Op):
     def __init__(self, opset: Opset, func: types.FunctionType):
         super().__init__(opset, func.__name__)
         self.func = func
+
+        # Allow the object to be inspected as a function
+        self.__wrapped__ = func
+        functools.update_wrapper(self, func)
 
     def __call__(self, *args, **kwargs):
         return self.func(*args, **kwargs)

--- a/onnxscript/values.py
+++ b/onnxscript/values.py
@@ -479,7 +479,6 @@ class OnnxFunction(Op):
         self._op_schema: Optional[onnx.defs.OpSchema] = None
 
         # Allow the object to be inspected as a function
-        self.__wrapped__ = pyfun
         functools.update_wrapper(self, pyfun)
 
         # Experimental fields
@@ -576,7 +575,6 @@ class TracedOnnxFunction(Op):
         self.func = func
 
         # Allow the object to be inspected as a function
-        self.__wrapped__ = func
         functools.update_wrapper(self, func)
 
     def __call__(self, *args, **kwargs):

--- a/onnxscript/values_test.py
+++ b/onnxscript/values_test.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import inspect
+import typing
 import unittest
 
 import onnxscript
@@ -57,7 +58,7 @@ class TracedOnnxFunctionTest(unittest.TestCase):
         self.assertEqual(signature.parameters["input3"].name, "input3")
         self.assertEqual(signature.parameters["attr3"].name, "attr3")
 
-        annotations = inspect.get_annotations(traced_function, eval_str=True)
+        annotations = typing.get_type_hints(traced_function)
         self.assertEqual(annotations["attr1"], int)
         self.assertEqual(annotations["attr2"], float)
         self.assertEqual(annotations["attr3"], str)
@@ -99,7 +100,7 @@ class OnnxFunctionTest(unittest.TestCase):
         self.assertEqual(signature.parameters["input3"].name, "input3")
         self.assertEqual(signature.parameters["attr3"].name, "attr3")
 
-        annotations = inspect.get_annotations(function, eval_str=True)
+        annotations = typing.get_type_hints(function)
         self.assertEqual(annotations["attr1"], int)
         self.assertEqual(annotations["attr2"], float)
         self.assertEqual(annotations["attr3"], str)

--- a/onnxscript/values_test.py
+++ b/onnxscript/values_test.py
@@ -1,3 +1,9 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+from __future__ import annotations
+
 import inspect
 import unittest
 
@@ -51,7 +57,7 @@ class TracedOnnxFunctionTest(unittest.TestCase):
         self.assertEqual(signature.parameters["input3"].name, "input3")
         self.assertEqual(signature.parameters["attr3"].name, "attr3")
 
-        annotations = inspect.get_annotations(traced_function)
+        annotations = inspect.get_annotations(traced_function, eval_str=True)
         self.assertEqual(annotations["attr1"], int)
         self.assertEqual(annotations["attr2"], float)
         self.assertEqual(annotations["attr3"], str)
@@ -93,7 +99,7 @@ class OnnxFunctionTest(unittest.TestCase):
         self.assertEqual(signature.parameters["input3"].name, "input3")
         self.assertEqual(signature.parameters["attr3"].name, "attr3")
 
-        annotations = inspect.get_annotations(function)
+        annotations = inspect.get_annotations(function, eval_str=True)
         self.assertEqual(annotations["attr1"], int)
         self.assertEqual(annotations["attr2"], float)
         self.assertEqual(annotations["attr3"], str)

--- a/onnxscript/values_test.py
+++ b/onnxscript/values_test.py
@@ -1,3 +1,4 @@
+import inspect
 import unittest
 
 import onnxscript
@@ -18,6 +19,48 @@ class TracedOnnxFunctionTest(unittest.TestCase):
     def test_param_schemas_in_correct_order_with_mixed_inputs_and_attrs(self):
         opset = values.Opset("test", 1)
 
+        def function(input1, input2, attr1: int, attr2: float, input3, attr3: str = "default"):
+            return opset.CustomOp(input1 + input2, input3, attr1, attr2, attr3)
+
+        traced_function = values.TracedOnnxFunction(opset, function)
+        param_schemas = traced_function.param_schemas()
+        expected_ordered_param_names = [
+            "input1",
+            "input2",
+            "attr1",
+            "attr2",
+            "input3",
+            "attr3",
+        ]
+        self.assertEqual(len(param_schemas), len(expected_ordered_param_names))
+        for i, param_schema in enumerate(param_schemas):
+            self.assertEqual(param_schema.name, expected_ordered_param_names[i])
+
+    def test_it_preserves_the_function_signature(self):
+        opset = values.Opset("test", 1)
+
+        def function(input1, input2, attr1: int, attr2: float, input3, attr3: str = "default"):
+            return opset.CustomOp(input1 + input2, input3, attr1, attr2, attr3)
+
+        traced_function = values.TracedOnnxFunction(opset, function)
+        signature = inspect.signature(traced_function)
+        self.assertEqual(signature.parameters["input1"].name, "input1")
+        self.assertEqual(signature.parameters["input2"].name, "input2")
+        self.assertEqual(signature.parameters["attr1"].name, "attr1")
+        self.assertEqual(signature.parameters["attr2"].name, "attr2")
+        self.assertEqual(signature.parameters["input3"].name, "input3")
+        self.assertEqual(signature.parameters["attr3"].name, "attr3")
+
+        annotations = inspect.get_annotations(traced_function)
+        self.assertEqual(annotations["attr1"], int)
+        self.assertEqual(annotations["attr2"], float)
+        self.assertEqual(annotations["attr3"], str)
+
+
+class OnnxFunctionTest(unittest.TestCase):
+    def test_param_schemas_in_correct_order_with_mixed_inputs_and_attrs(self):
+        opset = values.Opset("test", 1)
+
         @onnxscript.script(default_opset=opset)
         def function(input1, input2, attr1: int, attr2: float, input3, attr3: str = "default"):
             return opset.CustomOp(input1 + input2, input3, attr1, attr2, attr3)
@@ -34,3 +77,27 @@ class TracedOnnxFunctionTest(unittest.TestCase):
         self.assertEqual(len(param_schemas), len(expected_ordered_param_names))
         for i, param_schema in enumerate(param_schemas):
             self.assertEqual(param_schema.name, expected_ordered_param_names[i])
+
+    def test_it_preserves_the_function_signature(self):
+        opset = values.Opset("test", 1)
+
+        @onnxscript.script(default_opset=opset)
+        def function(input1, input2, attr1: int, attr2: float, input3, attr3: str = "default"):
+            return opset.CustomOp(input1 + input2, input3, attr1, attr2, attr3)
+
+        signature = inspect.signature(function)
+        self.assertEqual(signature.parameters["input1"].name, "input1")
+        self.assertEqual(signature.parameters["input2"].name, "input2")
+        self.assertEqual(signature.parameters["attr1"].name, "attr1")
+        self.assertEqual(signature.parameters["attr2"].name, "attr2")
+        self.assertEqual(signature.parameters["input3"].name, "input3")
+        self.assertEqual(signature.parameters["attr3"].name, "attr3")
+
+        annotations = inspect.get_annotations(function)
+        self.assertEqual(annotations["attr1"], int)
+        self.assertEqual(annotations["attr2"], float)
+        self.assertEqual(annotations["attr3"], str)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Rename the `experimental_traceable` property to `traceable`
- Preserve function signatures for OnnxFunction and TracedFunction

Fixes https://github.com/microsoft/onnxscript/issues/401