### PR TITLE
Relax transformers version in requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,7 +32,7 @@ pytest-xdist
 pytest!=7.1.0
 pyyaml
 torch>=2.1
-transformers==4.37.2
+transformers>=4.37.2
 
 # Lint
 lintrunner>=0.10.7


### PR DESCRIPTION
Pinning transformers to certain version causes conflict between this package and pytorch/benchmark: https://github.com/pytorch/benchmark/blob/10801fb0a6e1a7a3b8139bbc08c2520e334f8e9b/requirements.txt#L14, which makes torchbench docker image builder fail to build: https://dev.azure.com/onnxconverter/ONNXConverter/_build?definitionId=1.

NOTE: When we actually run the torchbench (the other pipeline), we manually install 4.37.2 back to apply all function-rewriting rules.