### PR TITLE
Register `aten::pow.Scalar` for `aten::pow`

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6556,7 +6556,7 @@ def aten_positive(self: TensorType) -> TensorType:
 
 
 @torch_op(
-    ("aten::pow", "aten::pow.Tensor_Tensor", "aten::pow.Tensor_Scalar", "_operator::pow")
+    ("aten::pow.Scalar", "aten::pow.Tensor_Tensor", "aten::pow.Tensor_Scalar", "_operator::pow")
 )
 def aten_pow(self: TReal, exponent: TTensor) -> TReal:
     """pow(Tensor self, Tensor exponent) -> Tensor"""

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6556,7 +6556,12 @@ def aten_positive(self: TensorType) -> TensorType:
 
 
 @torch_op(
-    ("aten::pow.Scalar", "aten::pow.Tensor_Tensor", "aten::pow.Tensor_Scalar", "_operator::pow")
+    (
+        "aten::pow.Scalar",
+        "aten::pow.Tensor_Tensor",
+        "aten::pow.Tensor_Scalar",
+        "_operator::pow",
+    )
 )
 def aten_pow(self: TReal, exponent: TTensor) -> TReal:
     """pow(Tensor self, Tensor exponent) -> Tensor"""

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6555,7 +6555,9 @@ def aten_positive(self: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
-@torch_op(("aten::pow.Tensor_Tensor", "aten::pow.Tensor_Scalar", "_operator::pow"))
+@torch_op(
+    ("aten::pow", "aten::pow.Tensor_Tensor", "aten::pow.Tensor_Scalar", "_operator::pow")
+)
 def aten_pow(self: TReal, exponent: TTensor) -> TReal:
     """pow(Tensor self, Tensor exponent) -> Tensor"""
 


### PR DESCRIPTION
Hello,

After upgrading onnxscript from version `0.1.0.dev20240516` to the latest version, I encountered an error while trying to export my Torch model to ONNX:
```
torch.onnx._internal.diagnostics.infra.context.RuntimeErrorWithDiagnostic: Unsupported FX nodes: {'call_function': ['aten.pow.Scalar']}. 
```
Upon investigating the issue, I found that the changes made to `aten_pow` in PR #1612 are causing this problem. Reverting these changes allows the model to be exported to ONNX successfully again.

Could support for `aten::pow` be reintroduced to enable smooth exporting of models?

Thank you for your consideration.