### PR TITLE
[torchlib] Update type annotation for type_as

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5986,16 +5986,12 @@ def aten_native_channel_shuffle(self: TensorType, groups: int) -> TensorType:
     raise NotImplementedError()
 
 
-@torch_op("aten::native_dropout")
+@torch_op("aten::native_dropout", trace_only=True)
 def aten_native_dropout(
     input: TFloatOrBFloat16, p: float, train: bool = True
 ) -> Tuple[TFloatOrBFloat16, BOOL]:
     """native_dropout(Tensor input, float p, bool? train) -> (Tensor, Tensor)"""
 
-    # Python bool attributes need to be explicitly converted to BOOL
-    # because the underlying attribute type is int
-    # TODO(#872): Allow ONNX Script to handle this conversion
-    train = op.Cast(train, to=BOOL.dtype)
     result, mask = op.Dropout(input, p, train)
     return result, mask
 
@@ -8393,7 +8389,7 @@ def aten_trunc(self: TFloatOrBFloat16) -> TFloatOrBFloat16:
 
 
 @torch_op("aten::type_as", traceable=True)
-def aten_type_as(self: TensorType, other: TensorType) -> TensorType:
+def aten_type_as(self: TTensor, other: TTensor2) -> TTensor2:
     """type_as(Tensor self, Tensor other) -> Tensor"""
 
     return op.CastLike(self, other)


### PR DESCRIPTION
Also make `native_dropout` trace_only to simplify the function.