### PR TITLE
[torchlib] Implement quantize/dequantize operators

### DIFF
--- a/onnxscript/_internal/ast_utils.py
+++ b/onnxscript/_internal/ast_utils.py
@@ -8,18 +8,18 @@ import ast
 import inspect
 import sys
 import textwrap
-import types
+from typing import Callable
 
 PY_VERSION_GE_39 = sys.version_info >= (3, 9)
 
 
-def get_src_and_ast(f: types.FunctionType) -> tuple[str, ast.FunctionDef]:
+def get_src_and_ast(func: Callable, /) -> tuple[str, ast.FunctionDef]:
     try:
-        src = inspect.getsource(f)
+        src = inspect.getsource(func)
     except OSError as e:
         raise RuntimeError(
             f"Decorator script does not work on dynamically "
-            f"compiled function {f.__name__}."
+            f"compiled function {func.__name__}."
         ) from e
     src = textwrap.dedent(src)
     top_level_ast = ast.parse(src)

--- a/onnxscript/function_libs/torch_lib/ops/__init__.py
+++ b/onnxscript/function_libs/torch_lib/ops/__init__.py
@@ -7,9 +7,21 @@ __all__ = [
     "nested",
     "nn",
     "prims",
+    "quantized_decomposed",
     "sparse",
     "special",
     "vision",
 ]
 
-from . import core, fft, linalg, nested, nn, prims, sparse, special, vision
+from . import (
+    core,
+    fft,
+    linalg,
+    nested,
+    nn,
+    prims,
+    quantized_decomposed,
+    sparse,
+    special,
+    vision,
+)

--- a/onnxscript/function_libs/torch_lib/ops/quantized_decomposed.py
+++ b/onnxscript/function_libs/torch_lib/ops/quantized_decomposed.py
@@ -1,0 +1,60 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# mypy: disable-error-code="misc,arg-type,type-arg,valid-type,assignment,return-value"
+# pylint: disable=unused-argument
+"""quantized_decomposed ops defined in https://github.com/pytorch/pytorch/blob/main/torch/ao/quantization/fx/_decomposed.py
+
+- No inplace operators.
+- All functions should not have the script() decorator. This is because
+    we want to delay the compilation of the function.
+"""
+
+from __future__ import annotations
+
+from onnxscript.function_libs.torch_lib.registration import torch_op
+from onnxscript.onnx_opset import opset18 as op
+from onnxscript.onnx_types import TensorType
+
+
+@torch_op(
+    (
+        "quantized_decomposed::quantize_per_tensor",
+        "quantized_decomposed::quantize_per_tensor.tensor",
+        "quantized_decomposed::quantize_per_tensor.tensor2",
+    ),
+    trace_only=True,
+)
+def quantized_decomposed_quantize_per_tensor(
+    input: TensorType,
+    scale: float,
+    zero_point: int,
+    quant_min: int,
+    quant_max: int,
+    dtype: int,
+) -> TensorType:
+    # TODO(justinchuby): Use quant_min and quant_max
+    # TODO(justinchuby): Use dtype when we use opset 21
+    return op.QuantizeLinear(input, scale, zero_point)
+
+
+@torch_op(
+    (
+        "quantized_decomposed::dequantize_per_tensor",
+        "quantized_decomposed::dequantize_per_tensor.tensor",
+        "quantized_decomposed::dequantize_per_tensor.tensor2",
+    ),
+    trace_only=True,
+)
+def quantized_decomposed_dequantize_per_tensor(
+    input: TensorType,
+    scale: float,
+    zero_point: int,
+    quant_min: int,
+    quant_max: int,
+    dtype: int,
+    *,
+    out_dtype: int | None = None,
+) -> TensorType:
+    # TODO(justinchuby): Use quant_min and quant_max
+    # TODO(justinchuby): Use dtype when we use opset 21
+    return op.DequantizeLinear(input, scale, zero_point)

--- a/onnxscript/function_libs/torch_lib/ops/quantized_decomposed.py
+++ b/onnxscript/function_libs/torch_lib/ops/quantized_decomposed.py
@@ -52,7 +52,7 @@ def quantized_decomposed_dequantize_per_tensor(
     quant_min: int,
     quant_max: int,
     dtype: int,
-    out_dtype: int | None = None,
+    out_dtype: int = -1,
 ) -> TensorType:
     # TODO(justinchuby): Use quant_min and quant_max
     # TODO(justinchuby): Use dtype when we use opset 21

--- a/onnxscript/function_libs/torch_lib/ops/quantized_decomposed.py
+++ b/onnxscript/function_libs/torch_lib/ops/quantized_decomposed.py
@@ -52,7 +52,6 @@ def quantized_decomposed_dequantize_per_tensor(
     quant_min: int,
     quant_max: int,
     dtype: int,
-    *,
     out_dtype: int | None = None,
 ) -> TensorType:
     # TODO(justinchuby): Use quant_min and quant_max

--- a/onnxscript/function_libs/torch_lib/registration.py
+++ b/onnxscript/function_libs/torch_lib/registration.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import re
-from types import FunctionType
 from typing import Any, Callable, Generator, Optional
 
 import onnxscript
@@ -141,7 +140,6 @@ def torch_op(
         if trace_only:
             processed_func = onnxscript.values.TracedOnnxFunction(custom_opset, func)
         else:
-            assert isinstance(func, FunctionType)
             processed_func = onnxscript.script(opset=custom_opset)(func)
             processed_func.traceable = traceable
 

--- a/onnxscript/function_libs/torch_lib/registration.py
+++ b/onnxscript/function_libs/torch_lib/registration.py
@@ -132,7 +132,7 @@ def torch_op(
         registry = default_registry
 
     def wrapper(
-        func: FunctionType,
+        func: Callable,
     ) -> onnxscript.OnnxFunction | onnxscript.values.TracedOnnxFunction:
         # Compile the function
         custom_opset = onnxscript.values.Opset(domain=_constants.DOMAIN, version=1)

--- a/onnxscript/function_libs/torch_lib/registration.py
+++ b/onnxscript/function_libs/torch_lib/registration.py
@@ -102,7 +102,7 @@ def torch_op(
     private: bool = False,
     complex: bool = False,
     traceable: bool = False,
-) -> Callable[[FunctionType], onnxscript.OnnxFunction | onnxscript.values.TracedOnnxFunction]:
+) -> Callable[[Callable], onnxscript.OnnxFunction | onnxscript.values.TracedOnnxFunction]:
     """Register a torch op.
 
     Args:

--- a/onnxscript/main.py
+++ b/onnxscript/main.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import ast
 import inspect
 import sys
-import types
 from typing import Any, Callable, Optional, Sequence
 
 import onnx.helper
@@ -40,7 +39,7 @@ def script(
     opset: Optional[values.Opset] = None,
     default_opset: Optional[values.Opset] = None,
     **kwargs: Any,
-) -> Callable[[types.FunctionType], onnxscript.OnnxFunction]:
+) -> Callable[[Callable], onnxscript.OnnxFunction]:
     """Main decorator. Declares a function as an onnx function.
 
     Args:
@@ -76,7 +75,7 @@ def script(
             "Script parameter must be an opset. Did you use @script instead of @script()?"
         )
 
-    def transform(f: types.FunctionType) -> onnxscript.OnnxFunction:
+    def transform(f: Callable) -> onnxscript.OnnxFunction:
         if not inspect.isfunction(f):
             raise TypeError("The ONNXScript decorator should be applied to functions only.")
 
@@ -96,7 +95,7 @@ def script(
     return transform
 
 
-def graph() -> Callable[[types.FunctionType], values.OnnxClosure]:
+def graph() -> Callable[[Callable], values.OnnxClosure]:
     """A parametric decorator used to annotate nested-functions that are used
     as graph-attributes.
 
@@ -143,7 +142,7 @@ def graph() -> Callable[[types.FunctionType], values.OnnxClosure]:
     onnx_function = wrapper_frame.f_locals["self"]
     nested_functions = onnx_function.function_ir.nested_functions
 
-    def transform(f: types.FunctionType) -> values.OnnxClosure:
+    def transform(f: Callable) -> values.OnnxClosure:
         return values.OnnxClosure(nested_functions[f.__name__], function_frame, f)
 
     return transform

--- a/onnxscript/values.py
+++ b/onnxscript/values.py
@@ -11,6 +11,7 @@ import typing
 from enum import IntFlag
 from typing import (  # type: ignore[attr-defined]
     Any,
+    Callable,
     ClassVar,
     Optional,
     Protocol,
@@ -452,7 +453,7 @@ class OnnxFunction(Op):
     def __init__(
         self,
         opset: Optional[Opset],
-        pyfun: types.FunctionType,
+        pyfun: Callable,
         irfun: irbuilder.IRFunction,
         source: str,
         kwargs: dict[str, Any],
@@ -571,7 +572,7 @@ class TracedOnnxFunction(Op):
         func: Function.
     """
 
-    def __init__(self, opset: Opset, func: types.FunctionType):
+    def __init__(self, opset: Opset, func: Callable):
         super().__init__(opset, func.__name__)
         self.func = func
 


### PR DESCRIPTION
Initial implementations for the quantization operators defined in https://github.com/pytorch/pytorch/blob/main/torch/ao/quantization/fx/_decomposed.py. Related: https://github.com/pytorch/pytorch/issues/106748

I created a new module called `quantized_decomposed.py` to host all ops that are defined under the `quantized_decomposed` namespace seen in https://github.com/pytorch/pytorch/issues/106748. I created functions for the most common linear quantize/dequantize operators.

- Also updates `FunctionType` -> `Callable` in decorators to make them play well with type checkers