### PR TITLE
[torchlib] Fix registration typo in expm1

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -3340,12 +3340,6 @@ def aten_expand_copy(self: TensorType, size: INT64, implicit: bool = False) -> T
     raise NotImplementedError()
 
 
-def aten_expm1(self: TensorType) -> TensorType:
-    """expm1(Tensor self) -> Tensor"""
-
-    raise NotImplementedError()
-
-
 def aten_eye(n: int) -> TensorType:
     """eye(int n, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"""
 
@@ -8539,7 +8533,7 @@ def aten_unsafe_chunk(self: TensorType, chunks: int, dim: int = 0) -> TensorType
     raise NotImplementedError()
 
 
-@torch_op(("aten::unsafe_split", "aten::unsafe_split.Tensor"))
+@torch_op("aten::unsafe_split.Tensor")
 def aten_unsafe_split(self: TTensor, split_size: INT64, dim: int = 0) -> Sequence[TTensor]:
     """unsafe_split.Tensor(Tensor self, SymInt split_size, int dim=0) -> Tensor[]"""
 

--- a/onnxscript/function_libs/torch_lib/ops/special.py
+++ b/onnxscript/function_libs/torch_lib/ops/special.py
@@ -130,7 +130,7 @@ def aten_special_expit(self: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
-@torch_op(("aten::expm1", "aten::special_expm"))
+@torch_op(("aten::expm1", "aten::special_expm1"))
 def aten_special_expm1(self: TFloatOrBFloat16) -> TFloatOrBFloat16:
     """special_expm1(Tensor self) -> Tensor"""
 


### PR DESCRIPTION
Also remove the default overload for `unsafe_split` because it does not exist.