### PR TITLE
[typing] Make the `runtime_typing.checked` always typed

### DIFF
--- a/onnxscript/_internal/runtime_typing.py
+++ b/onnxscript/_internal/runtime_typing.py
@@ -17,8 +17,10 @@ __all__ = [
 T = typing.TypeVar("T", bound=typing.Callable[..., typing.Any])
 
 try:
-    from beartype import beartype as checked
+    from beartype import beartype as _beartype_decorator
     from beartype import roar as _roar
+
+    checked = typing.cast(typing.Callable[[T], T], _beartype_decorator)
 
     # Beartype warns when we import from typing because the types are deprecated
     # in Python 3.9. But there will be a long time until we can move to using


### PR DESCRIPTION
Otherwise mypy raises

```
  Error (MYPY) misc
    Untyped decorator makes function "to_model_proto" untyped
    
    To disable, use `  # type: ignore[misc]`

        1001  |        )
        1002  |        return onnx_function
        1003  |
    >>> 1004  |    @runtime_typing.checked
        1005  |    def to_model_proto(
        1006  |        self, opset_version: int, include_initializers: bool = True
        1007  |    ) -> onnx.ModelProto:
```