### PR TITLE
[torchlib] Implement nll_loss_forward

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -1468,6 +1468,7 @@ def aten_nll_loss_forward(
         total_weight = op.CastLike(op.Size(output), weight)
     return output, total_weight
 
+
 def aten_nll_loss_nd(
     self: TensorType,
     target: TensorType,

--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -1389,7 +1389,7 @@ def aten_nll_loss(
         reduction_str = "sum"
 
     result = op.NegativeLogLikelihoodLoss(
-        self, target, ignore_index=ignore_index, reduction=reduction_str
+        self, target, weight, ignore_index=ignore_index, reduction=reduction_str
     )
 
     if self_rank_is_1:

--- a/tests/function_libs/torch_lib/ops_test_data.py
+++ b/tests/function_libs/torch_lib/ops_test_data.py
@@ -1144,15 +1144,6 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ),
     TorchLibOpInfo("nn.functional.mish", nn_ops.aten_mish),
     TorchLibOpInfo(
-        "nn.functional.nll_loss_weight",
-        nn_ops.aten_nll_loss_weight,
-        tolerance={torch.float16: (5e-2, 1e-2)},
-        input_wrangler=_nll_loss_input_wrangler,
-    ).skip(
-        matcher=lambda sample: "weight" not in sample.kwargs,
-        reason="this Aten overload need weight as kwargs",
-    ),
-    TorchLibOpInfo(
         "nn.functional.nll_loss",
         nn_ops.aten_nll_loss,
         input_wrangler=_nll_loss_input_wrangler,

--- a/tests/function_libs/torch_lib/ops_test_data.py
+++ b/tests/function_libs/torch_lib/ops_test_data.py
@@ -1147,6 +1147,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "nn.functional.nll_loss",
         nn_ops.aten_nll_loss,
         input_wrangler=_nll_loss_input_wrangler,
+        tolerance={torch.float16: (5e-2, 1e-2)},
     ),
     TorchLibOpInfo(
         "nn.functional.pixel_shuffle",

--- a/tests/function_libs/torch_lib/ops_test_data.py
+++ b/tests/function_libs/torch_lib/ops_test_data.py
@@ -1147,9 +1147,6 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         "nn.functional.nll_loss",
         nn_ops.aten_nll_loss,
         input_wrangler=_nll_loss_input_wrangler,
-    ).skip(
-        matcher=lambda sample: "weight" in sample.kwargs,
-        reason="this Aten overload doesn't accept weight as kwargs",
     ),
     TorchLibOpInfo(
         "nn.functional.pixel_shuffle",
@@ -2329,9 +2326,6 @@ ops_test_common.duplicate_opinfo(OPS_DB, "min", ("min_dim",))
 ops_test_common.duplicate_opinfo(OPS_DB, "minimum", ("minimum_bool",))
 ops_test_common.duplicate_opinfo(
     OPS_DB, "nn.functional.linear", ("nn.functional.linear_bias",)
-)
-ops_test_common.duplicate_opinfo(
-    OPS_DB, "nn.functional.nll_loss", ("nn.functional.nll_loss_weight",)
 )
 ops_test_common.duplicate_opinfo(
     OPS_DB,


### PR DESCRIPTION
softmax_cross_entropy_loss is decomposed by pytorch into `log_softmax` and `nll_loss_forward`. Since ONNX has this operator we should use it.