### PR TITLE
Add `packaging` to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "License :: OSI Approved :: MIT License",
 ]
-dependencies = ["numpy", "onnx>=1.16", "typing_extensions", "ml_dtypes"]
+dependencies = ["numpy", "onnx>=1.16", "typing_extensions", "ml_dtypes", "packaging"]
 
 [tool.setuptools.packages.find]
 include = ["onnxscript*"]


### PR DESCRIPTION
`packaging` is used to obtain version of the package. Without it there will be an import error.