### PR TITLE
[torchlib] Opportunistically implement prims ops

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/prims.py
+++ b/onnxscript/function_libs/torch_lib/ops/prims.py
@@ -22,28 +22,33 @@ from onnxscript.onnx_opset import opset18 as op
 from onnxscript.onnx_types import TensorType
 
 
-def prims_abs(self: TensorType) -> TensorType:
+@torch_op("prims::abs", traceable=True)
+def prims_abs(self: TTensor) -> TTensor:
     """abs(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Abs(self)
 
 
+@torch_op("prims::acos", traceable=True)
 def prims_acos(self: TensorType) -> TensorType:
     """acos(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Acos(self)
 
 
+@torch_op("prims::acosh", traceable=True)
 def prims_acosh(self: TensorType) -> TensorType:
     """acosh(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Acosh(self)
 
 
-def prims_add(self: TensorType, other: TensorType) -> TensorType:
+
+@torch_op("prims::add", traceable=True)
+def prims_add(self: TTensor, other: TTensor) -> TTensor:
     """add(Tensor self, Tensor other) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Add(self, other)
 
 
 def prims_amax(
@@ -78,22 +83,25 @@ def prims_as_strided_scatter(
     raise NotImplementedError()
 
 
-def prims_asin(self: TensorType) -> TensorType:
+@torch_op("prims::asin", traceable=True)
+def prims_asin(self: TTensor) -> TTensor:
     """asin(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Asin(self)
 
 
-def prims_asinh(self: TensorType) -> TensorType:
+@torch_op("prims::asinh", traceable=True)
+def prims_asinh(self: TTensor) -> TTensor:
     """asinh(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Asinh(self)
 
 
-def prims_atan(self: TensorType) -> TensorType:
+@torch_op("prims::atan", traceable=True)
+def prims_atan(self: TTensor) -> TTensor:
     """atan(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Atan(self)
 
 
 def prims_atan2(self: TensorType, other: TensorType) -> TensorType:
@@ -102,10 +110,11 @@ def prims_atan2(self: TensorType, other: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
-def prims_atanh(self: TensorType) -> TensorType:
+@torch_op("prims::atanh", traceable=True)
+def prims_atanh(self: TTensor) -> TTensor:
     """atanh(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Atanh(self)
 
 
 def prims_bessel_i0(self: TensorType) -> TensorType:
@@ -188,10 +197,11 @@ def prims_cbrt(self: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
-def prims_ceil(self: TensorType) -> TensorType:
+@torch_op("prims::ceil", traceable=True)
+def prims_ceil(self: TTensor) -> TTensor:
     """ceil(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Ceil(self)
 
 
 def prims_clone(self: TensorType, memory_format: Optional[str] = None) -> TensorType:
@@ -239,16 +249,18 @@ def prims_copy_to(a: TensorType, b: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
-def prims_cos(self: TensorType) -> TensorType:
+@torch_op("prims::cos", traceable=True)
+def prims_cos(self: TTensor) -> TTensor:
     """cos(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Cos(self)
 
 
-def prims_cosh(self: TensorType) -> TensorType:
+@torch_op("prims::cosh", traceable=True)
+def prims_cosh(self: TTensor) -> TTensor:
     """cosh(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Cosh(self)
 
 
 @torch_op("prims::device_put")
@@ -268,10 +280,11 @@ def prims_digamma(self: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
-def prims_div(self: TensorType, other: TensorType) -> TensorType:
+@torch_op("prims::div", traceable=True)
+def prims_div(self: TTensor, other: TTensor) -> TTensor:
     """div(Tensor self, Tensor other) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Div(self, other)
 
 
 def prims_empty(shape: INT64, dtype: int, device: str, requires_grad: bool) -> TensorType:
@@ -288,16 +301,18 @@ def prims_empty_strided(
     raise NotImplementedError()
 
 
-def prims_eq(self: TensorType, other: TensorType) -> TensorType:
+@torch_op("prims::eq", traceable=True)
+def prims_eq(self: TTensor, other: TTensor) -> TTensor:
     """eq(Tensor self, Tensor other) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Equal(self, other)
 
 
-def prims_erf(self: TensorType) -> TensorType:
+@torch_op("prims::erf", traceable=True)
+def prims_erf(self: TTensor) -> TTensor:
     """erf(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Erf(self)
 
 
 def prims_erf_inv(self: TensorType) -> TensorType:
@@ -318,10 +333,11 @@ def prims_erfcx(self: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
-def prims_exp(self: TensorType) -> TensorType:
+@torch_op("prims::exp", traceable=True)
+def prims_exp(self: TTensor) -> TTensor:
     """exp(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Exp(self)
 
 
 def prims_exp2(self: TensorType) -> TensorType:
@@ -360,10 +376,11 @@ def prims_fill(self: TensorType, value: float) -> TensorType:
     raise NotImplementedError()
 
 
-def prims_floor(self: TensorType) -> TensorType:
+@torch_op("prims::floor", traceable=True)
+def prims_floor(self: TTensor) -> TTensor:
     """floor(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Floor(self)
 
 
 def prims_fmax(self: TensorType, other: TensorType) -> TensorType:
@@ -406,16 +423,18 @@ def prims_gcd(self: TensorType, other: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
-def prims_ge(self: TensorType, other: TensorType) -> TensorType:
+@torch_op("prims::ge", traceable=True)
+def prims_ge(self: TTensor, other: TTensor) -> TTensor:
     """ge(Tensor self, Tensor other) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.GreaterOrEqual(self, other)
 
 
-def prims_gt(self: TensorType, other: TensorType) -> TensorType:
+@torch_op("prims::gt", traceable=True)
+def prims_gt(self: TTensor, other: TTensor) -> TTensor:
     """gt(Tensor self, Tensor other) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Greater(self, other)
 
 
 def prims_hypot(self: TensorType, other: TensorType) -> TensorType:
@@ -462,10 +481,11 @@ def prims_item(a: TensorType) -> float:
     raise NotImplementedError()
 
 
+@torch_op("prims::le", traceable=True)
 def prims_le(self: TensorType, other: TensorType) -> TensorType:
     """le(Tensor self, Tensor other) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.LessOrEqual(self, other)
 
 
 def prims_lgamma(self: TensorType) -> TensorType:
@@ -474,10 +494,11 @@ def prims_lgamma(self: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
+@torch_op("prims::log", traceable=True)
 def prims_log(self: TensorType) -> TensorType:
     """log(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Log(self)
 
 
 def prims_log10(self: TensorType) -> TensorType:
@@ -498,10 +519,11 @@ def prims_log2(self: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
+@torch_op("prims::lt", traceable=True)
 def prims_lt(self: TensorType, other: TensorType) -> TensorType:
     """lt(Tensor self, Tensor other) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Less(self, other)
 
 
 def prims_maximum(self: TensorType, other: TensorType) -> TensorType:
@@ -528,10 +550,11 @@ def prims_minium_value(dtype: int) -> float:
     raise NotImplementedError()
 
 
-def prims_mul(self: TensorType, other: TensorType) -> TensorType:
+@torch_op("prims::mul", traceable=True)
+def prims_mul(self: TTensor, other: TTensor) -> TTensor:
     """mul(Tensor self, Tensor other) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Mul(self, other)
 
 
 def prims_ndtri(self: TensorType) -> TensorType:
@@ -540,16 +563,18 @@ def prims_ndtri(self: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
-def prims_ne(self: TensorType, other: TensorType) -> TensorType:
+@torch_op("prims::ne", traceable=True)
+def prims_ne(self: TTensor, other: TTensor) -> TTensor:
     """ne(Tensor self, Tensor other) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Not(op.Equal(self, other))
 
 
-def prims_neg(self: TensorType) -> TensorType:
+@torch_op("prims::neg", traceable=True)
+def prims_neg(self: TTensor) -> TTensor:
     """neg(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Neg(self)
 
 
 def prims_nextafter(self: TensorType, other: TensorType) -> TensorType:
@@ -566,10 +591,11 @@ def prims_normal(
     raise NotImplementedError()
 
 
-def prims_pow(self: TensorType, other: TensorType) -> TensorType:
+@torch_op("prims::pow", traceable=True)
+def prims_pow(self: TTensor, other: TTensor) -> TTensor:
     """pow(Tensor self, Tensor other) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Pow(self, other)
 
 
 def prims_prod(
@@ -598,16 +624,18 @@ def prims_remainder(self: TensorType, other: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
-def prims_reshape(a: TensorType, shape: INT64) -> TensorType:
+@torch_op("prims::reshape", traceable=True)
+def prims_reshape(a: TTensor, shape: INT64) -> TTensor:
     """reshape(Tensor a, SymInt[] shape) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Reshape(a, shape)
 
 
+@torch_op("prims::resize", traceable=True)
 def prims_resize(a: TensorType, shape: INT64) -> TensorType:
     """resize(Tensor a, SymInt[] shape) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Expand(a, shape)
 
 
 def prims_rev(a: TensorType, dims: Sequence[int]) -> TensorType:
@@ -616,10 +644,11 @@ def prims_rev(a: TensorType, dims: Sequence[int]) -> TensorType:
     raise NotImplementedError()
 
 
+@torch_op("prims::round", traceable=True)
 def prims_round(self: TensorType) -> TensorType:
     """round(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Round(self)
 
 
 def prims_rsqrt(self: TensorType) -> TensorType:
@@ -660,16 +689,18 @@ def prims_signbit(self: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
-def prims_sin(self: TensorType) -> TensorType:
+@torch_op("prims::sin", traceable=True)
+def prims_sin(self: TTensor) -> TTensor:
     """sin(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Sin(self)
 
 
-def prims_sinh(self: TensorType) -> TensorType:
+@torch_op("prims::sinh", traceable=True)
+def prims_sinh(self: TTensor) -> TTensor:
     """sinh(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Sinh(self)
 
 
 def prims_slice(
@@ -700,22 +731,25 @@ def prims_split_dim(a: TensorType, dim: int, outer_length: INT64) -> TensorType:
     raise NotImplementedError()
 
 
-def prims_sqrt(self: TensorType) -> TensorType:
+@torch_op("prims::sqrt", traceable=True)
+def prims_sqrt(self: TTensor) -> TTensor:
     """sqrt(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Sqrt(self)
 
 
-def prims_squeeze(a: TensorType, dimensions: Sequence[int]) -> TensorType:
+@torch_op("prims::squeeze", traceable=True)
+def prims_squeeze(a: TTensor, dimensions: Sequence[int]) -> TTensor:
     """squeeze(Tensor(a) a, int[] dimensions) -> Tensor(a)"""
 
-    raise NotImplementedError()
+    return op.Squeeze(a, axes=dimensions)
 
 
-def prims_sub(self: TensorType, other: TensorType) -> TensorType:
+@torch_op("prims::sub", traceable=True)
+def prims_sub(self: TTensor, other: TTensor) -> TTensor:
     """sub(Tensor self, Tensor other) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Sub(self, other)
 
 
 def prims_sum(
@@ -732,10 +766,11 @@ def prims_svd(A: TensorType, full_matrices: bool) -> tuple[TensorType, TensorTyp
     raise NotImplementedError()
 
 
+@torch_op("prims::tan", traceable=True)
 def prims_tan(self: TensorType) -> TensorType:
     """tan(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Tan(self)
 
 
 def prims_tanh(self: TensorType) -> TensorType:

--- a/onnxscript/function_libs/torch_lib/ops/prims.py
+++ b/onnxscript/function_libs/torch_lib/ops/prims.py
@@ -19,7 +19,7 @@ from onnxscript.function_libs.torch_lib.ops import common as common_ops
 from onnxscript.function_libs.torch_lib.registration import torch_op
 from onnxscript.function_libs.torch_lib.tensor_typing import RealType, TTensor
 from onnxscript.onnx_opset import opset18 as op
-from onnxscript.onnx_types import TensorType
+from onnxscript.onnx_types import BOOL, TensorType
 
 
 @torch_op("prims::abs", traceable=True)
@@ -41,7 +41,6 @@ def prims_acosh(self: TensorType) -> TensorType:
     """acosh(Tensor self) -> Tensor"""
 
     return op.Acosh(self)
-
 
 
 @torch_op("prims::add", traceable=True)
@@ -767,22 +766,24 @@ def prims_svd(A: TensorType, full_matrices: bool) -> tuple[TensorType, TensorTyp
 
 
 @torch_op("prims::tan", traceable=True)
-def prims_tan(self: TensorType) -> TensorType:
+def prims_tan(self: TTensor) -> TTensor:
     """tan(Tensor self) -> Tensor"""
 
     return op.Tan(self)
 
 
-def prims_tanh(self: TensorType) -> TensorType:
+@torch_op("prims::tanh", traceable=True)
+def prims_tanh(self: TTensor) -> TTensor:
     """tanh(Tensor self) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Tanh(self)
 
 
+@torch_op("prims::transpose", traceable=True)
 def prims_transpose(a: TensorType, permutation: Sequence[int]) -> TensorType:
     """transpose(Tensor(a) a, int[] permutation) -> Tensor(a)"""
 
-    raise NotImplementedError()
+    return op.Transpose(a, perm=permutation)
 
 
 def prims_trunc(self: TensorType) -> TensorType:
@@ -816,10 +817,11 @@ def prims_view_of(a: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
-def prims_where(pred: TensorType, a: TensorType, b: TensorType) -> TensorType:
+@torch_op("prims::where", traceable=True)
+def prims_where(pred: BOOL, a: TTensor, b: TTensor) -> TTensor:
     """where(Tensor pred, Tensor a, Tensor b) -> Tensor"""
 
-    raise NotImplementedError()
+    return op.Where(pred, a, b)
 
 
 def prims_zeta(self: TensorType, other: TensorType) -> TensorType:


### PR DESCRIPTION
Opportunistically implement prims ops since I have seen `prims::mul` being used in a model. No tests (yet) as `aten::mul` and `prims::mul` have different signatures.