### PR TITLE
[IR] Simplify display()

### DIFF
--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -116,7 +116,7 @@ class TensorBase(abc.ABC, _protocols.TensorProtocol, _display.PrettyPrintable):
         # Use math.ceil because when dtype is INT4, the itemsize is 0.5
         return math.ceil(self.dtype.itemsize * self.size)
 
-    def display(self, *, page: bool | None = None) -> None:
+    def display(self, *, page: bool = False) -> None:
         rich = _display.require_rich()
 
         if rich is None:
@@ -169,7 +169,7 @@ class TensorBase(abc.ABC, _protocols.TensorProtocol, _display.PrettyPrintable):
             import rich.console  # type: ignore[import-not-found, no-redef]  # pylint: disable=import-outside-toplevel
 
             console = rich.console.Console()
-            with console.pager(styles=True):
+            with console.pager():
                 console.print(text)
         else:
             rich.print(text)

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1280,7 +1280,7 @@ class Node(_protocols.NodeProtocol, _display.PrettyPrintable):
     def op_identifier(self) -> _protocols.OperatorIdentifier:
         return self.domain, self.op_type, self.overload
 
-    def display(self, *, page: bool | None = None) -> None:
+    def display(self, *, page: bool = False) -> None:
         # Add the node's name to the displayed text
         print(f"Node: {self.name!r}")
         if self.doc_string:

--- a/onnxscript/ir/_display.py
+++ b/onnxscript/ir/_display.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 from typing import Any
 
-_LONG_TEXT_LIMIT = 3000
-
 
 def require_rich() -> Any:
     """Raise an ImportError if rich is not installed."""
@@ -24,11 +22,11 @@ def require_rich() -> Any:
 
 
 class PrettyPrintable:
-    def display(self, *, page: bool | None = None) -> None:
+    def display(self, *, page: bool = False) -> None:
         """Pretty print the object.
 
         Args:
-            page: Whether to page the output if it is too long.
+            page: Whether to page the output.
         """
         rich = require_rich()
         text = str(self)
@@ -41,16 +39,11 @@ class PrettyPrintable:
             )
             return
 
-        if page is None and len(text) > _LONG_TEXT_LIMIT:
-            # By default, page the output if it is too long
-            page = True
         if page:
             import rich.console
-            import rich.syntax
 
             console = rich.console.Console()
-            syntax = rich.syntax.Syntax(text, "cpp", theme="ansi_light")
-            with console.pager(styles=True):
-                console.print(syntax)
+            with console.pager():
+                console.print(text)
         else:
             rich.print(text)


### PR DESCRIPTION
1. Default the paging behavior to False so calling `.display()` on objects does not hang execution when the code is not running interactively.
2. Remove coloring in the rich console to simplify the rendering process.