### PR TITLE
[IR] Remove the Input type

### DIFF
--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1632,7 +1632,12 @@ def Input(
     type: _protocols.TypeProtocol | None = None,
     doc_string: str | None = None,
 ) -> Value:
-    """Create an input of a Graph or a Function."""
+    """Create an input of a Graph or a Function.
+
+    This is equivalent to calling ``Value(name=name, shape=shape, type=type, doc_string=doc_string)``.
+    """
+
+    # The function name is capitalized to maintain API backward compatibility.
 
     return Value(name=name, shape=shape, type=type, doc_string=doc_string)
 

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1626,20 +1626,15 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
         return any(output is self for output in graph.outputs)
 
 
-class Input(Value):
-    """Input of a Graph or a Function."""
+def Input(
+    name: str | None = None,
+    shape: Shape | None = None,
+    type: _protocols.TypeProtocol | None = None,
+    doc_string: str | None = None,
+) -> Value:
+    """Create an input of a Graph or a Function."""
 
-    # Slots already defined in Value
-    __slots__ = ()
-
-    def __init__(
-        self,
-        name: str | None = None,
-        shape: Shape | None = None,
-        type: _protocols.TypeProtocol | None = None,
-        doc_string: str | None = None,
-    ) -> None:
-        super().__init__(name=name, shape=shape, type=type, doc_string=doc_string)
+    return Value(name=name, shape=shape, type=type, doc_string=doc_string)
 
 
 def _check_node_safe_to_remove(
@@ -1720,7 +1715,7 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
 
     def __init__(
         self,
-        inputs: Sequence[Input],
+        inputs: Sequence[Value],
         outputs: Sequence[Value],
         *,
         nodes: Iterable[Node],
@@ -1758,7 +1753,7 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
         self.extend(nodes)
 
     @property
-    def inputs(self) -> list[Input]:
+    def inputs(self) -> list[Value]:
         return self._inputs
 
     @property
@@ -2334,7 +2329,7 @@ class Function(_protocols.FunctionProtocol, Sequence[Node], _display.PrettyPrint
         self._overload = value
 
     @property
-    def inputs(self) -> list[Input]:
+    def inputs(self) -> list[Value]:
         return self._graph.inputs
 
     @property

--- a/onnxscript/ir/_core_test.py
+++ b/onnxscript/ir/_core_test.py
@@ -684,8 +684,8 @@ class NodeTest(unittest.TestCase):
 
 class GraphTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.v0 = _core.Input(name="v0")
-        self.v1 = _core.Input(name="v1")
+        self.v0 = _core.Value(name="v0")
+        self.v1 = _core.Value(name="v1")
         self.node = _core.Node(
             "", "Add", inputs=(self.v0, self.v1), num_outputs=1, name="node_add"
         )
@@ -759,8 +759,8 @@ class GraphTest(unittest.TestCase):
             self.graph.remove(self.node, safe=True)
 
     def test_remove_safe_raises_when_node_has_users(self):
-        v0 = _core.Input(name="v0")
-        v1 = _core.Input(name="v1")
+        v0 = _core.Value(name="v0")
+        v1 = _core.Value(name="v1")
         add_node = _core.Node("", "Add", inputs=(v0, v1), num_outputs=1)
         identity_node = _core.Node("", "Identity", inputs=add_node.outputs, num_outputs=1)
         graph = _core.Graph(
@@ -773,8 +773,8 @@ class GraphTest(unittest.TestCase):
             graph.remove(add_node, safe=True)
 
     def test_remove_safe_removes_uses_of_removed_nodes(self):
-        v0 = _core.Input(name="v0")
-        v1 = _core.Input(name="v1")
+        v0 = _core.Value(name="v0")
+        v1 = _core.Value(name="v1")
         add_node = _core.Node("", "Add", inputs=(v0, v1), num_outputs=1)
         identity_node = _core.Node("", "Identity", inputs=add_node.outputs, num_outputs=1)
         graph = _core.Graph(

--- a/onnxscript/rewriter/onnxruntime/bfloat16_utils/bfloat16_converter.py
+++ b/onnxscript/rewriter/onnxruntime/bfloat16_utils/bfloat16_converter.py
@@ -7,7 +7,7 @@ from onnxscript import ir
 logger = logging.getLogger(__name__)
 
 
-def _convert_inputs_from_bfloat16_to_float16(value: ir.Input) -> None:
+def _convert_inputs_from_bfloat16_to_float16(value: ir.Value) -> None:
     if value.dtype != ir.DataType.BFLOAT16:
         return
     value.dtype = ir.DataType.FLOAT16
@@ -20,7 +20,7 @@ def _convert_outputs_from_bfloat16_to_float16(value: ir.Value) -> None:
     _insert_cast_nodes_for_bfloat16_to_float16_to_outputs(value)
 
 
-def _insert_cast_nodes_for_float16_to_bfloat16_to_inputs(value: ir.Input) -> None:
+def _insert_cast_nodes_for_float16_to_bfloat16_to_inputs(value: ir.Value) -> None:
     user_nodes_and_indices = tuple(value.uses())
 
     attr = ir.AttrInt64(name="to", value=ir.DataType.BFLOAT16)


### PR DESCRIPTION
Remove the Input type as it is only a special case of Value, and the inputs are not guaranteed to be of type `Input` when users subclass Value and provide those as inputs to the graph.

This change removes the `Input` class and changed it to be a function to maintain backward compatibility.