### PR TITLE
Unregister aten_linear

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -822,7 +822,7 @@ def aten_leaky_relu_backward(
     raise NotImplementedError()
 
 
-@torch_op("aten::linear")
+# NOTE: Do not register - We rely on PyTorch decomposition to aten_addmm (Gemm)
 def aten_linear(input: TFloat, weight: TFloat) -> TFloat:
     """linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor"""
 
@@ -833,7 +833,7 @@ def aten_linear(input: TFloat, weight: TFloat) -> TFloat:
     return op.MatMul(input, weight_transposed)
 
 
-@torch_op("aten::linear")
+# NOTE: Do not register - We rely on PyTorch decomposition to aten_addmm (Gemm)
 def aten_linear_bias(input: TFloat, weight: TFloat, bias: TFloat) -> TFloat:
     """linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor"""
 

--- a/tests/function_libs/torch_lib/ops_test_data.py
+++ b/tests/function_libs/torch_lib/ops_test_data.py
@@ -1942,20 +1942,6 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         or not sample.input.shape,
         reason="fixme: Logic not implemented for size 0 inputs in op.Reshape",
     ),
-    TorchLibOpInfo("nn.functional.linear", nn_ops.aten_linear).skip(
-        # input: input, args: weight, bias; so len(args) == 2 means bias is provided
-        matcher=lambda sample: len(sample.args) != 1,
-        reason="this overload is implemented for bias=None",
-    ),
-    TorchLibOpInfo(
-        "nn.functional.linear_bias",
-        nn_ops.aten_linear_bias,
-        tolerance={torch.float16: (2e-1, 4e-4)},
-    ).skip(
-        # input: input, args: weight, bias; so len(args) == 2 means bias is provided
-        matcher=lambda sample: len(sample.args) != 2,
-        reason="this overload is implemented for bias!=None",
-    ),
     TorchLibOpInfo(
         "nn.functional.max_pool1d",
         nn_ops.aten_max_pool1d,


### PR DESCRIPTION
Fix https://github.com/microsoft/onnxscript/issues/1819

Instead, we rely on PyTorch decomposition to use aten::addmm (Gemm) for accuracy.