### PR TITLE
Trace Ops (aten::scaled_dot_product_attention) | feat (torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -1829,7 +1829,6 @@ def aten_scaled_dot_product_attention(
     )
 
 
-@torch_op("aten::_scaled_dot_product_flash_attention", private=True, traceable=True)
 def _aten__scaled_dot_product_flash_attention_fillin_empty_outputs(
     query: TFloat,
 ) -> Tuple[FLOAT, INT64, INT64, FLOAT]:

--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -37,6 +37,9 @@ from onnxscript.onnx_types import TensorType
 _MATH_PI = math.pi
 Rank = common_ops.Rank
 
+_INT64_MAX = 9223372036854775807
+_INT64_MIN = -9223372036854775808
+
 # All float types but float32
 TFloatUnlessFloat32 = TypeVar("TFloatUnlessFloat32", bound=Union[BFLOAT16, FLOAT16, DOUBLE])
 
@@ -1716,7 +1719,7 @@ def aten_rrelu_with_noise_backward(
     raise NotImplementedError()
 
 
-@torch_op("aten::scaled_dot_product_attention", private=True)
+@torch_op("aten::scaled_dot_product_attention", private=True, traceable=True)
 def _causal_attention_mask(query: TFloat, key: TFloat) -> TFloat:
     """Create a causal mask for the given query and key tensors.
 
@@ -1732,20 +1735,31 @@ def _causal_attention_mask(query: TFloat, key: TFloat) -> TFloat:
     Returns:
         Tensor of shape [L, S]
     """
-    target_length = op.Shape(query)[-2:-1]
-    source_length = op.Shape(key)[-2:-1]
+    q_shape = op.Shape(query)
+    k_shape = op.Shape(key)
+
+    target_length = op.Slice(
+        q_shape, op.Constant(value_ints=[-2]), op.Constant(value_ints=[-1])
+    )
+    source_length = op.Slice(
+        k_shape, op.Constant(value_ints=[-2]), op.Constant(value_ints=[-1])
+    )
     # attn_mask = torch.ones(L, S) := {
     size = op.Concat(target_length, source_length, axis=0)
-    attn_mask = op.Expand(1.0, size)
+    attn_mask = op.Expand(op.Constant(value_float=1.0), size)
     # }
     attn_mask = op.Trilu(attn_mask, upper=0)
     # The causal mask has 0s in the lower triangle and -inf in the upper triangle.
-    attn_mask = op.Where(op.Equal(attn_mask, 0.0), op.Constant(value_float=-float("inf")), 0.0)
+    attn_mask = op.Where(
+        op.Equal(attn_mask, op.Constant(value_float=0.0)),
+        op.Constant(value_float=-float("inf")),
+        op.Constant(value_float=0.0),
+    )
     attn_mask = op.CastLike(attn_mask, query)
     return attn_mask
 
 
-@torch_op("aten::scaled_dot_product_attention", private=True)
+@torch_op("aten::scaled_dot_product_attention", private=True, traceable=True)
 def _attention_scale(query: TFloat) -> TFloat:
     """Calculate the scale factor for the attention result.
 
@@ -1756,7 +1770,7 @@ def _attention_scale(query: TFloat) -> TFloat:
         Scalar scale factor := 1 / math.sqrt(query.size(-1))
     """
     embedding_size = op.CastLike(op.Shape(query)[-1], query)
-    scale = op.Div(1.0, op.Sqrt(embedding_size))
+    scale = op.Div(op.Constant(value_float=1.0), op.Sqrt(embedding_size))
     return scale
 
 
@@ -1813,7 +1827,7 @@ def aten_scaled_dot_product_attention(
     )
 
 
-@torch_op("aten::_scaled_dot_product_flash_attention", private=True)
+@torch_op("aten::_scaled_dot_product_flash_attention", private=True, traceable=True)
 def _aten__scaled_dot_product_flash_attention_fillin_empty_outputs(
     query: TFloat,
 ) -> Tuple[FLOAT, INT64, INT64, FLOAT]:
@@ -1889,9 +1903,9 @@ def _aten_scaled_dot_product_efficient_attention_fillin_empty_outputs(
 
     query = op.Transpose(query, perm=[0, 2, 1, 3])
     query_shape = op.Shape(query)
-    query_first_dims = query_shape[:1]
-    query_second_dims = query_shape[1:2]
-    num_heads = query_shape[-2:-1]
+    query_first_dims = op.Slice(query_shape, op.Constant(value_ints=[_INT64_MIN]), [-1])
+    query_second_dims = op.Slice(query_shape, [1], [2])
+    num_heads = op.Slice(query_shape, [-2], [-1])
 
     if compute_log_sumexp:
         logsumexp_dim = op.Cast(
@@ -2034,7 +2048,7 @@ def aten_scaled_dot_product_attention_bool_mask(
     )
 
 
-@torch_op("aten::scaled_dot_product_attention", private=True)
+@torch_op("aten::scaled_dot_product_attention", private=True, traceable=True)
 def _aten_scaled_dot_product_attention_no_mask_onnx(
     query: TFloat,
     key: TFloat,
@@ -2044,9 +2058,9 @@ def _aten_scaled_dot_product_attention_no_mask_onnx(
 ) -> TFloat:
     # Swap the last two axes of key
     key_shape = op.Shape(key)
-    key_last_dim = key_shape[-1:]
-    key_second_last_dim = key_shape[-2:-1]
-    key_first_dims = key_shape[:-2]
+    key_last_dim = op.Slice(key_shape, [-1], op.Constant(value_ints=[_INT64_MAX]))
+    key_second_last_dim = op.Slice(key_shape, [-2], [-1])
+    key_first_dims = op.Slice(key_shape, op.Constant(value_ints=[_INT64_MIN]), [-2])
     # Contract the dimensions that are not the last two so we can transpose
     # with a static permutation.
     key_squeezed_shape = op.Concat(
@@ -2069,7 +2083,7 @@ def _aten_scaled_dot_product_attention_no_mask_onnx(
     return op.MatMul(attn_weight, value)
 
 
-@torch_op("aten::scaled_dot_product_attention", private=True)
+@torch_op("aten::scaled_dot_product_attention", private=True, traceable=True)
 def _aten_scaled_dot_product_attention_bool_mask_onnx(
     query: TFloat,
     key: TFloat,
@@ -2080,9 +2094,9 @@ def _aten_scaled_dot_product_attention_bool_mask_onnx(
 ) -> TFloat:
     # Swap the last two axes of key
     key_shape = op.Shape(key)
-    key_last_dim = key_shape[-1:]
-    key_second_last_dim = key_shape[-2:-1]
-    key_first_dims = key_shape[:-2]
+    key_last_dim = op.Slice(key_shape, [-1], op.Constant(value_ints=[_INT64_MAX]))
+    key_second_last_dim = op.Slice(key_shape, [-2], [-1])
+    key_first_dims = op.Slice(key_shape, op.Constant(value_ints=[_INT64_MIN]), [-2])
     # Contract the dimensions that are not the last two so we can transpose
     # with a static permutation.
     key_squeezed_shape = op.Concat(
@@ -2098,7 +2112,9 @@ def _aten_scaled_dot_product_attention_bool_mask_onnx(
     query_scaled = op.Mul(query, op.Sqrt(scale))
     key_transposed_scaled = op.Mul(key_transposed, op.Sqrt(scale))
     # Turn the Boolean mask to float: attn_mask.masked_fill(not attn_mask, -float('inf'))
-    attn_mask = op.Where(attn_mask, 0.0, op.Constant(value_float=-float("inf")))
+    attn_mask = op.Where(
+        attn_mask, op.Constant(value_float=0.0), op.Constant(value_float=-float("inf"))
+    )
     attn_weight = op.Softmax(
         op.Add(op.MatMul(query_scaled, key_transposed_scaled), attn_mask),
         axis=-1,
@@ -2107,7 +2123,7 @@ def _aten_scaled_dot_product_attention_bool_mask_onnx(
     return op.MatMul(attn_weight, value)
 
 
-@torch_op("aten::scaled_dot_product_attention", private=True)
+@torch_op("aten::scaled_dot_product_attention", private=True, traceable=True)
 def _aten_scaled_dot_product_attention_float_mask_onnx(
     query: TFloat,
     key: TFloat,
@@ -2118,9 +2134,9 @@ def _aten_scaled_dot_product_attention_float_mask_onnx(
 ) -> TFloat:
     # Swap the last two axes of key
     key_shape = op.Shape(key)
-    key_last_dim = key_shape[-1:]
-    key_second_last_dim = key_shape[-2:-1]
-    key_first_dims = key_shape[:-2]
+    key_last_dim = op.Slice(key_shape, [-1], op.Constant(value_ints=[_INT64_MAX]))
+    key_second_last_dim = op.Slice(key_shape, [-2], [-1])
+    key_first_dims = op.Slice(key_shape, op.Constant(value_ints=[_INT64_MIN]), [-2])
     # Contract the dimensions that are not the last two so we can transpose
     # with a static permutation.
     key_squeezed_shape = op.Concat(

--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -1903,7 +1903,7 @@ def _aten_scaled_dot_product_efficient_attention_fillin_empty_outputs(
 
     query = op.Transpose(query, perm=[0, 2, 1, 3])
     query_shape = op.Shape(query)
-    query_first_dims = op.Slice(query_shape, op.Constant(value_ints=[_INT64_MIN]), [-1])
+    query_first_dims = op.Slice(query_shape, op.Constant(value_ints=[_INT64_MIN]), [1])
     query_second_dims = op.Slice(query_shape, [1], [2])
     num_heads = op.Slice(query_shape, [-2], [-1])
 

--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -1719,7 +1719,6 @@ def aten_rrelu_with_noise_backward(
     raise NotImplementedError()
 
 
-@torch_op("aten::scaled_dot_product_attention", private=True, traceable=True)
 def _causal_attention_mask(query: TFloat, key: TFloat) -> TFloat:
     """Create a causal mask for the given query and key tensors.
 
@@ -1759,7 +1758,6 @@ def _causal_attention_mask(query: TFloat, key: TFloat) -> TFloat:
     return attn_mask
 
 
-@torch_op("aten::scaled_dot_product_attention", private=True, traceable=True)
 def _attention_scale(query: TFloat) -> TFloat:
     """Calculate the scale factor for the attention result.
 
@@ -1769,7 +1767,9 @@ def _attention_scale(query: TFloat) -> TFloat:
     Returns:
         Scalar scale factor := 1 / math.sqrt(query.size(-1))
     """
-    embedding_size = op.CastLike(op.Shape(query)[-1], query)
+    q_shape = op.Shape(query)
+    q_last_dim = op.Gather(q_shape, op.Constant(value_ints=[-1]))
+    embedding_size = op.CastLike(q_last_dim, query)
     scale = op.Div(op.Constant(value_float=1.0), op.Sqrt(embedding_size))
     return scale
 
@@ -2048,7 +2048,6 @@ def aten_scaled_dot_product_attention_bool_mask(
     )
 
 
-@torch_op("aten::scaled_dot_product_attention", private=True, traceable=True)
 def _aten_scaled_dot_product_attention_no_mask_onnx(
     query: TFloat,
     key: TFloat,
@@ -2083,7 +2082,6 @@ def _aten_scaled_dot_product_attention_no_mask_onnx(
     return op.MatMul(attn_weight, value)
 
 
-@torch_op("aten::scaled_dot_product_attention", private=True, traceable=True)
 def _aten_scaled_dot_product_attention_bool_mask_onnx(
     query: TFloat,
     key: TFloat,
@@ -2123,7 +2121,6 @@ def _aten_scaled_dot_product_attention_bool_mask_onnx(
     return op.MatMul(attn_weight, value)
 
 
-@torch_op("aten::scaled_dot_product_attention", private=True, traceable=True)
 def _aten_scaled_dot_product_attention_float_mask_onnx(
     query: TFloat,
     key: TFloat,

--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -1770,7 +1770,9 @@ def _attention_scale(query: TFloat) -> TFloat:
     q_shape = op.Shape(query)
     q_last_dim = op.Gather(q_shape, op.Constant(value_ints=[-1]))
     embedding_size = op.CastLike(q_last_dim, query)
-    scale = op.Div(op.Constant(value_float=1.0), op.Sqrt(embedding_size))
+    one = op.Constant(value_float=1.0)
+    cast_one = op.CastLike(one, query)
+    scale = op.Div(cast_one, op.Sqrt(embedding_size))
     return scale
 
 


### PR DESCRIPTION
Make aten::scaled_dot_product_attention fami traceable