### PR TITLE
[IR] Fix external tensor path handling

### DIFF
--- a/onnxscript/__init__.py
+++ b/onnxscript/__init__.py
@@ -122,7 +122,7 @@ from ._internal.utils import external_tensor
 from .values import OnnxFunction, TracedOnnxFunction
 
 # Set DEBUG to True to enable additional debug checks
-DEBUG = False
+DEBUG: bool = False
 
 try:  # noqa: SIM105
     __version__ = importlib.metadata.version("onnxscript")

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -473,7 +473,8 @@ class ExternalTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=
     The :attr:`location` must be a relative path conforming to the ONNX
     specification. Given the correct :attr:`base_dir`, the :attr:`path` is computed
     to be the full path to the data file. Users should expect that the :attr:`path`
-    always leads to the correct file.
+    always leads to the correct file. At initialization, paths are not checked.
+    It is the user's responsibility to ensure the paths are valid and accessible.
 
     Attributes:
         location: The location of the data file. It is the path relative to the base directory.
@@ -530,7 +531,7 @@ class ExternalTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=
             metadata_props: The metadata properties.
             base_dir: The base directory for the external data. It is used to resolve relative paths.
         """
-        # Do not verify the location by default. This is because the location field
+        # NOTE: Do not verify the location by default. This is because the location field
         # in the tensor proto can be anything and we would like deserialization from
         # proto to IR to not fail.
         self._location = location

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -534,6 +534,9 @@ class ExternalTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=
         # NOTE: Do not verify the location by default. This is because the location field
         # in the tensor proto can be anything and we would like deserialization from
         # proto to IR to not fail.
+        if onnxscript.DEBUG:
+            if os.path.isabs(location):
+                raise ValueError("The location must be a relative path. Please specify base_dir as well.")
         self._location = location
         self._base_dir = base_dir
         self._offset: int | None = offset

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -470,7 +470,7 @@ class ExternalTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=
     To obtain an array, call :meth:`numpy`. To obtain the bytes,
     call :meth:`tobytes`.
 
-    The :attr:`location` must be a relative directory conforming to the ONNX
+    The :attr:`location` must be a relative path conforming to the ONNX
     specification. Given the correct :attr:`base_dir`, the :attr:`path` is computed
     to be the full path to the data file. Users should expect that the :attr:`path`
     always leads to the correct file.

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -530,12 +530,11 @@ class ExternalTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=
             metadata_props: The metadata properties.
             base_dir: The base directory for the external data. It is used to resolve relative paths.
         """
-        if os.path.isabs(location):
-            raise ValueError(
-                "The location must be a relative path. Please also specify the base_dir."
-            )
-        self._base_dir = base_dir
+        # Do not verify the location by default. This is because the location field
+        # in the tensor proto can be anything and we would like deserialization from
+        # proto to IR to not fail.
         self._location = location
+        self._base_dir = base_dir
         self._offset: int | None = offset
         self._length: int | None = length
         self._dtype: _enums.DataType = dtype

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -536,7 +536,9 @@ class ExternalTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=
         # proto to IR to not fail.
         if onnxscript.DEBUG:
             if os.path.isabs(location):
-                raise ValueError("The location must be a relative path. Please specify base_dir as well.")
+                raise ValueError(
+                    "The location must be a relative path. Please specify base_dir as well."
+                )
         self._location = location
         self._base_dir = base_dir
         self._offset: int | None = offset

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -476,10 +476,10 @@ class ExternalTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=
     always leads to the correct file.
 
     Attributes:
-        path: The path to the data file.
         location: The location of the data file. It is the path relative to the base directory.
         base_dir: The base directory for the external data. It is used to resolve relative paths.
-            At serialization, only the ``path`` is serialized into the "location" field of the TensorProto.
+            At serialization, only the :attr:`location` is serialized into the "location" field of the ``TensorProto``.
+        path: The path to the data file. This is computed by joining :attr:`base_dir` and :attr:`location`.
         offset: The offset in bytes from the start of the file.
         length: The length of the data in bytes.
         dtype: The data type of the tensor.
@@ -517,6 +517,19 @@ class ExternalTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=
         metadata_props: dict[str, str] | None = None,
         base_dir: os.PathLike | str = "",
     ) -> None:
+        """Initialize an external tensor.
+
+        Args:
+            location: The location of the data file. It is the path relative to the base directory.
+            offset: The offset in bytes from the start of the file.
+            length: The length of the data in bytes.
+            dtype: The data type of the tensor.
+            shape: The shape of the tensor.
+            name: The name of the tensor..
+            doc_string: The documentation string.
+            metadata_props: The metadata properties.
+            base_dir: The base directory for the external data. It is used to resolve relative paths.
+        """
         if os.path.isabs(location):
             raise ValueError(
                 "The location must be a relative path. Please also specify the base_dir."

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -518,7 +518,9 @@ class ExternalTensor(TensorBase, _protocols.TensorProtocol):  # pylint: disable=
         base_dir: os.PathLike | str = "",
     ) -> None:
         if os.path.isabs(location):
-            raise ValueError("The location must be a relative path. Please also specify the base_dir.")
+            raise ValueError(
+                "The location must be a relative path. Please also specify the base_dir."
+            )
         self._base_dir = base_dir
         self._location = location
         self._offset: int | None = offset

--- a/onnxscript/ir/_core_test.py
+++ b/onnxscript/ir/_core_test.py
@@ -276,10 +276,11 @@ class ExternalTensorTest(unittest.TestCase):
         external_tensor2 = self.model.graph.initializer[1]
         external_info2 = onnx.external_data_helper.ExternalDataInfo(external_tensor2)
         tensor2 = _core.ExternalTensor(
-            pathlib.Path(self.base_path) / external_info2.location,
+            external_info2.location,
             offset=external_info2.offset,
             length=external_info2.length,
             dtype=ir.DataType.FLOAT16,
+            base_dir=self.base_path,
             name="input",
             shape=_core.Shape(external_tensor2.dims),
         )

--- a/onnxscript/ir/_core_test.py
+++ b/onnxscript/ir/_core_test.py
@@ -231,10 +231,11 @@ class ExternalTensorTest(unittest.TestCase):
         external_tensor = self.model.graph.initializer[0]
         external_info = onnx.external_data_helper.ExternalDataInfo(external_tensor)
         tensor = _core.ExternalTensor(
-            pathlib.Path(self.base_path) / external_info.location,
+            external_info.location,
             offset=external_info.offset,
             length=external_info.length,
             dtype=ir.DataType.FLOAT,
+            base_dir=self.base_path,
             name="input",
             shape=_core.Shape(external_tensor.dims),
         )
@@ -264,10 +265,11 @@ class ExternalTensorTest(unittest.TestCase):
         external_tensor = self.model.graph.initializer[0]
         external_info = onnx.external_data_helper.ExternalDataInfo(external_tensor)
         tensor = _core.ExternalTensor(
-            pathlib.Path(self.base_path) / external_info.location,
+            external_info.location,
             offset=external_info.offset,
             length=external_info.length,
             dtype=ir.DataType.FLOAT,
+            base_dir=self.base_path,
             name="input",
             shape=_core.Shape(external_tensor.dims),
         )

--- a/onnxscript/ir/_core_test.py
+++ b/onnxscript/ir/_core_test.py
@@ -231,7 +231,7 @@ class ExternalTensorTest(unittest.TestCase):
         external_tensor = self.model.graph.initializer[0]
         external_info = onnx.external_data_helper.ExternalDataInfo(external_tensor)
         tensor = _core.ExternalTensor(
-            path=pathlib.Path(self.base_path) / external_info.location,
+            pathlib.Path(self.base_path) / external_info.location,
             offset=external_info.offset,
             length=external_info.length,
             dtype=ir.DataType.FLOAT,
@@ -247,7 +247,7 @@ class ExternalTensorTest(unittest.TestCase):
         external_tensor = self.model.graph.initializer[0]
         external_info = onnx.external_data_helper.ExternalDataInfo(external_tensor)
         tensor = _core.ExternalTensor(
-            path=external_info.location,
+            external_info.location,
             offset=external_info.offset,
             length=external_info.length,
             dtype=ir.DataType.FLOAT,
@@ -264,7 +264,7 @@ class ExternalTensorTest(unittest.TestCase):
         external_tensor = self.model.graph.initializer[0]
         external_info = onnx.external_data_helper.ExternalDataInfo(external_tensor)
         tensor = _core.ExternalTensor(
-            path=pathlib.Path(self.base_path) / external_info.location,
+            pathlib.Path(self.base_path) / external_info.location,
             offset=external_info.offset,
             length=external_info.length,
             dtype=ir.DataType.FLOAT,
@@ -274,7 +274,7 @@ class ExternalTensorTest(unittest.TestCase):
         external_tensor2 = self.model.graph.initializer[1]
         external_info2 = onnx.external_data_helper.ExternalDataInfo(external_tensor2)
         tensor2 = _core.ExternalTensor(
-            path=pathlib.Path(self.base_path) / external_info2.location,
+            pathlib.Path(self.base_path) / external_info2.location,
             offset=external_info2.offset,
             length=external_info2.length,
             dtype=ir.DataType.FLOAT16,

--- a/onnxscript/ir/serde.py
+++ b/onnxscript/ir/serde.py
@@ -767,10 +767,11 @@ def deserialize_tensor(
     if proto.data_location == onnx.TensorProto.EXTERNAL:
         external_info = onnx.external_data_helper.ExternalDataInfo(proto)
         return _core.ExternalTensor(
-            path=os.path.join(base_path, external_info.location),
+            location=external_info.location,
             offset=external_info.offset,
             length=external_info.length,
             dtype=_enums.DataType(proto.data_type),
+            base_dir=base_path,
             name=_get_field(proto, "name"),
             shape=_core.Shape(proto.dims),
             doc_string=_get_field(proto, "doc_string"),
@@ -1333,7 +1334,7 @@ def serialize_tensor_into(
         # Store external tensors as is
         tensor_proto.data_location = onnx.TensorProto.EXTERNAL
         for k, v in {
-            "location": os.fspath(from_.path),
+            "location": os.fspath(from_.location),
             "offset": from_.offset,
             "length": from_.length,
         }.items():

--- a/onnxscript/ir/serde.py
+++ b/onnxscript/ir/serde.py
@@ -767,7 +767,7 @@ def deserialize_tensor(
     if proto.data_location == onnx.TensorProto.EXTERNAL:
         external_info = onnx.external_data_helper.ExternalDataInfo(proto)
         return _core.ExternalTensor(
-            location=external_info.location,
+            external_info.location,
             offset=external_info.offset,
             length=external_info.length,
             dtype=_enums.DataType(proto.data_type),


### PR DESCRIPTION
Previously the external tensors are deserialized with the base path and the relative location combined. This is in accurate because we lose information on which is the actual "location" that should be written to the proto.

With this change, I added a new `location` parameter/attribute to represent the ONNX proto relative "location", and update the `path` attribute to be computed by joining the base path with the relative location. As such users can always access the `tensor.path` attribute to get to the data file. Updated `serde` to make use of this attribute.

@shubhambhokare1 please also update the offload pass in #1796 to make use of the `path` attribute.

## BC breaking

The first parameter of the `ExternalTensor` initializer is renamed to `location`.