### PR TITLE
[BE] Remove the external_tensor helper from onnxscript namespace

### DIFF
--- a/onnxscript/__init__.py
+++ b/onnxscript/__init__.py
@@ -118,7 +118,6 @@ from .onnx_types import (
 # isort: on
 
 from . import ir, optimizer, rewriter
-from ._internal.utils import external_tensor
 from .values import OnnxFunction, TracedOnnxFunction
 
 # Set DEBUG to True to enable additional debug checks


### PR DESCRIPTION
It is not intended to be an onnxscript feature