### PR TITLE
Trace Op (aten::addmm) | feat(torchlib)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -238,7 +238,7 @@ def aten_addcmul(
     return op.Add(self, op.Mul(op.Mul(value, tensor1), tensor2))
 
 
-@torch_op("aten::addmm", traceable=True)
+@torch_op("aten::addmm", trace_only=True)
 def aten_addmm(
     self: TReal, mat1: TReal, mat2: TReal, beta: float = 1.0, alpha: float = 1.0
 ) -> TReal:
@@ -246,6 +246,9 @@ def aten_addmm(
 
     # NOTE: ONNX Runtime does not support int inputs to Gemm as of 1.16.
     # To support int inputs, consider an overriding implementation that casts to float and back.
+
+    alpha = float(alpha)
+    beta = float(beta)
 
     # addmm only accepts 2d tensors: https://pytorch.org/docs/stable/generated/torch.addmm.html
     return op.Gemm(mat1, mat2, self, alpha=alpha, beta=beta)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -238,7 +238,7 @@ def aten_addcmul(
     return op.Add(self, op.Mul(op.Mul(value, tensor1), tensor2))
 
 
-@torch_op("aten::addmm")
+@torch_op("aten::addmm", traceable=True)
 def aten_addmm(
     self: TReal, mat1: TReal, mat2: TReal, beta: float = 1.0, alpha: float = 1.0
 ) -> TReal:

--- a/tests/function_libs/torch_lib/ops_test_data.py
+++ b/tests/function_libs/torch_lib/ops_test_data.py
@@ -547,14 +547,6 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     TorchLibOpInfo("addcmul", core_ops.aten_addcmul, tolerance={torch.float16: (4e-3, 3e-3)}),
     TorchLibOpInfo("addmm", core_ops.aten_addmm)
     .xfail(
-        "decomposed",
-        reason=(
-            "The float attributes alpha/beta come in as int in the test cases, which breaks"
-            "eager mode. We don't need to care about this as long as the full graph tests pass"
-        ),
-        test_class_name="TestOutputConsistencyEager",
-    )
-    .xfail(
         dtypes=(torch.int16, torch.int32, torch.int64),
         reason="ONNX Runtime does not support int inputs to Gemm",
     )


### PR DESCRIPTION
addmm is used a lot, and it's not traced yet. We trace it for better debugging and graph experience.