### PR TITLE
[IR] Implement topological sorting on Graph

### DIFF
--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1980,53 +1980,73 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
     def sort(self) -> None:
         """Perform a topological sort of this graph and all subgraphs in O(#nodes + #values) time.
 
-        This method sorts the nodes that each node appears AFTER all its parents, while maintaining the original order as much as possible.
+        This method sorts the nodes that each node appears AFTER all its predecessors,
+        while maintaining the original order as much as possible.
 
         Raises:
             ValueError: If the graph contains a cycle, making topological sorting impossible.
         """
-        # 1. Initialization
-        nodes = list(
-            onnxscript.ir.traversal.RecursiveGraphIterator(self)
-        )  # traverse all nodes
+        # Obtain all nodes from the graph and its subgraphs for sorting
+        nodes = list(onnxscript.ir.traversal.RecursiveGraphIterator(self))
+        # Store the sorted nodes of each subgraph
         sorted_nodes_by_graph: dict[Graph, list[Node]] = {
-            graph: []  # type: ignore[misc]
-            for graph in {node.graph for node in nodes}  # type: ignore[misc]
-        }  # store the sorted nodes of each subgraph
-        node_depth: dict[Node, int] = dict.fromkeys(nodes, 0)  # number of direct children
-        node_parents: dict[Node, list[Node]] = {node: [] for node in nodes}  # direct parents
-        node_index: dict[Node, int] = {
-            node: -i for i, node in enumerate(nodes)
-        }  # NEGATIVE original order
+            graph: [] for graph in {node.graph for node in nodes if node.graph is not None}
+        }
+        # TODO: Explain why we need to store direct predecessors and children and why
+        # we only need to store the direct ones
 
-        # a helper function to add a parent of a node, and increment the depth of the parent
-        def add_parent(child: Node, parent: Node | None) -> None:
-            if parent:
-                node_parents[child].append(parent)
-                node_depth[parent] += 1
+        # The depth of a node is defined as the number of direct children it has
+        node_depth: dict[Node, int] = dict.fromkeys(nodes, 0)
+        # Direct predecessors of a node
+        node_predecessors: dict[Node, list[Node]] = {node: [] for node in nodes}
+        # Store the negative index of the nodes because heapq is a min heap and we
+        # want to pop the node with largest index value first, effectively turning
+        # it to a max heap
+        neg_node_index: dict[Node, int] = {node: -i for i, node in enumerate(nodes)}
 
+        def add_predecessor(child: Node, predecessor: Node | None) -> None:
+            """Add a predecessor of a node, and increment the depth of the predecessor."""
+            if predecessor is None:
+                return
+            node_predecessors[child].append(predecessor)
+            node_depth[predecessor] += 1
+
+        # 1. Build the direct predecessors of each node and the depth of each node
+        # for sorting topolocally using Kahn's algorithm.
+        # Note that when a node contains graph attributes (aka. has subgraphs),
+        # we consider all nodes in the subgraphs *predecessors* of this node. This
+        # way we ensure the implicit dependencies of the subgraphs are captured
+        # as predecessors of the node.
         for node in nodes:
-            # All producers of input values are considered as direct parents.
+            # All producers of input values are considered as direct predecessors.
             for input_value in node.inputs:
                 if input_value is None:
                     continue
-                parent_node = input_value.producer()
-                add_parent(node, parent_node)
-            # All nodes in attribute graphs are considered as direct parents.
+                predecessor_node = input_value.producer()
+                add_predecessor(node, predecessor_node)
+            # All nodes in attribute graphs are considered as direct predecessors.
             for attr in node.attributes.values():
                 if not isinstance(attr, Attr):
                     continue
+                # A nice thing about this algorithm is that we only need to record
+                # direct predecessors. This continues to be true even with subgraphs.
+                # When a node in a subgraph (a) contains its own subgraphs (b), the
+                # node in subgraphs (b) are guranteed to appear before the node
+                # in (a).
                 if attr.type == _enums.AttributeType.GRAPH:
-                    for parent_node in attr.value:
-                        add_parent(node, parent_node)
+                    for predecessor_node in attr.value:
+                        add_predecessor(node, predecessor_node)
                 elif attr.type == _enums.AttributeType.GRAPHS:
                     for attribute_graph in attr.value:
-                        for parent_node in attribute_graph:
-                            add_parent(node, parent_node)
-        # 2. Priority Queue: Track nodes with zero direct children in a priority queue, using NEGATIVE original index for ordering.
-        # This ensures nodes appearing LATER in the original order are processed EARLIER. We get REVERSED topological order of each subgraph.
+                        for predecessor_node in attribute_graph:
+                            add_predecessor(node, predecessor_node)
+
+        # 2. Priority Queue: Track nodes with zero direct children in a priority queue,
+        # using NEGATIVE original index for ordering.
+        # This ensures nodes appearing LATER in the original order are processed EARLIER.
+        # We get REVERSED topological order of each subgraph.
         priority_queue: list[tuple[int, Node]] = [
-            (node_index[node], node) for node in nodes if node_depth[node] == 0
+            (neg_node_index[node], node) for node in nodes if node_depth[node] == 0
         ]
         heapq.heapify(priority_queue)
 
@@ -2035,21 +2055,25 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
         while priority_queue:
             # Pop the node with the most negative index and add it to the sorted nodes by subgraph.
             _, current_node = heapq.heappop(priority_queue)
-            sorted_nodes_by_graph[current_node.graph].append(current_node)  # type: ignore[index]
+            assert current_node.graph is not None
+            sorted_nodes_by_graph[current_node.graph].append(current_node)
             num_of_sorted_nodes += 1
-            # Decrement the depth of its parents. If any parent node has zero direct children, push it into the queue.
-            for parent_node in node_parents[current_node]:
-                node_depth[parent_node] -= 1
-                if node_depth[parent_node] == 0:
-                    heapq.heappush(priority_queue, (node_index[parent_node], parent_node))
+            # Decrement the depth of its predecessors. If any predecessor node has zero direct children, push it into the queue.
+            for predecessor_node in node_predecessors[current_node]:
+                node_depth[predecessor_node] -= 1
+                if node_depth[predecessor_node] == 0:
+                    heapq.heappush(
+                        priority_queue, (neg_node_index[predecessor_node], predecessor_node)
+                    )
 
         # 4. Cycle Check: Ensure all nodes are processed. If not, raise a ValueError indicating a cycle.
         if num_of_sorted_nodes != len(nodes):
             raise ValueError("Graph contains a cycle, topological sort is not possible.")
 
         # 5. Reverse: Reverse the sorted nodes of each subgraph to get the topological order.
-        for subgraph, sorted_nodes in sorted_nodes_by_graph.items():
-            subgraph.extend(reversed(sorted_nodes))
+        for graph, sorted_nodes in sorted_nodes_by_graph.items():
+            # The graph container ensures all the nodes are unique so we can safely extend
+            graph.extend(reversed(sorted_nodes))
 
     # End of mutation methods
 

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1980,8 +1980,7 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
     def sort(self) -> None:
         """Perform a topological sort of this graph and all subgraphs in O(#nodes + #values) time.
 
-        This method sorts the nodes that each node appears AFTER all its predecessors,
-        while maintaining the original order as much as possible.
+        This sort is stable. It preserves the original order as much as possible.
 
         Raises:
             ValueError: If the graph contains a cycle, making topological sorting impossible.

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1982,6 +1982,8 @@ class Graph(_protocols.GraphProtocol, Sequence[Node], _display.PrettyPrintable):
 
         This sort is stable. It preserves the original order as much as possible.
 
+        Referece: https://github.com/madelson/MedallionTopologicalSort#stable-sort
+
         Raises:
             ValueError: If the graph contains a cycle, making topological sorting impossible.
         """

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -2522,7 +2522,7 @@ class Function(_protocols.FunctionProtocol, Sequence[Node], _display.PrettyPrint
         self._graph.insert_before(node, new_nodes)
 
     def sort(self) -> None:
-        """Topologically sort the nodes in the function."""
+        """Perform a topological sort of this graph and all subgraphs in O(#nodes + #values) time."""
         self._graph.sort()
 
     # End of mutation methods

--- a/onnxscript/ir/_core_test.py
+++ b/onnxscript/ir/_core_test.py
@@ -797,6 +797,13 @@ class GraphTest(unittest.TestCase):
         self.assertEqual(add_node.inputs, (None, None))
 
     # TODO(justinchuby): Test graph mutation methods
+
+    # Test topological sort.
+    # Graph structure:
+    #   nodes: [node, ...]
+    #   edges: [(parent_node, child_node), ...]
+    #   subgraphs: {node: [subgraph, ...]}
+
     def test_topological_sort_empty(self):
         graph = _core.Graph(
             inputs=(),
@@ -808,7 +815,7 @@ class GraphTest(unittest.TestCase):
         self.assertEqual(tuple(graph), ())
 
     def test_topological_sort_linear(self):
-        # edges=[(1,2),(2,3)]
+        # nodes=[1,2,3], edges=[(1,2),(2,3)]
         v0 = _core.Value(name="v0")
         node1 = _core.Node("", "Node1", inputs=(v0,), num_outputs=1)
         node2 = _core.Node("", "Node2", inputs=(node1.outputs[0],), num_outputs=1)
@@ -825,7 +832,7 @@ class GraphTest(unittest.TestCase):
         self.assertEqual(sorted_nodes, expected_order)
 
     def test_topological_sort_independent_subgraphs(self):
-        # edges=[(1,3),(2,4)]
+        # nodes=[1,2,3,4], edges=[(1,3),(2,4)]
         v0 = _core.Value(name="v0")
         v1 = _core.Value(name="v1")
         node1 = _core.Node("", "Node1", inputs=(v0,), num_outputs=1)
@@ -844,7 +851,7 @@ class GraphTest(unittest.TestCase):
         self.assertEqual(sorted_nodes, expected_order)
 
     def test_topological_sort_shared_child(self):
-        # edges=[(1,3),(2,3)]
+        # nodes=[1,2,3], edges=[(1,3),(2,3)]
         v0 = _core.Value(name="v0")
         node1 = _core.Node("", "Node1", inputs=(v0,), num_outputs=1)
         node2 = _core.Node("", "Node2", inputs=(v0,), num_outputs=1)
@@ -863,7 +870,7 @@ class GraphTest(unittest.TestCase):
         self.assertEqual(sorted_nodes, expected_order)
 
     def shared_parent_nodes(self):
-        # edges=[(1,2),(1,3)]
+        # nodes=[1,2,3], edges=[(1,2),(1,3)]
         v0 = _core.Value(name="v0")
         node1 = _core.Node("", "Node1", inputs=(v0,), num_outputs=1)
         node2 = _core.Node("", "Node2", inputs=(node1.outputs[0],), num_outputs=1)
@@ -919,7 +926,7 @@ class GraphTest(unittest.TestCase):
         self.assertEqual(sorted_nodes, expected_order)
 
     def test_topological_sort_cycle_detection(self):
-        # edges=[(1,2),(2,3),(3,2)]
+        # nodes=[1,2,3], edges=[(1,2),(2,3),(3,2)]
         v0 = _core.Value(name="v0")
         node1 = _core.Node("", "Node1", inputs=(v0,), num_outputs=1)
         node2 = _core.Node("", "Node2", inputs=(node1.outputs[0], v0), num_outputs=1)
@@ -935,6 +942,9 @@ class GraphTest(unittest.TestCase):
             graph.sort()
 
     def test_topological_sort_subgraph(self):
+        # main_graph: nodes=[a,b,c,d,>,if], edges=[(a,>),(b,>),(>,if)], subgraphs={if:[then_graph,else_graph]}
+        # then_graph: nodes=[sub], edges=[(c,sub),(d,sub)]
+        # else_graph: nodes=[add], edges=[(c,add),(d,add)]
         v0 = _core.Value(name="va")
         v1 = _core.Value(name="vb")
         v2 = _core.Value(name="vc")

--- a/onnxscript/ir/_core_test.py
+++ b/onnxscript/ir/_core_test.py
@@ -695,6 +695,7 @@ class GraphTest(unittest.TestCase):
             (self.v0, self.v1),
             self.node.outputs,
             nodes=(self.node,),
+            opset_imports={"": 1},
         )
 
     def test_initialize(self):
@@ -768,6 +769,7 @@ class GraphTest(unittest.TestCase):
             (v0, v1),
             identity_node.outputs,
             nodes=(add_node, identity_node),
+            opset_imports={"": 1},
         )
         with self.assertRaisesRegex(ValueError, "used by other nodes"):
             graph.remove(add_node, safe=True)
@@ -781,6 +783,7 @@ class GraphTest(unittest.TestCase):
             (v0, v1),
             identity_node.outputs,
             nodes=(add_node, identity_node),
+            opset_imports={"": 1},
         )
         # Remove add_node and check that it is no longer a consumer of v0 and v1
         sub_node = _core.Node("", "Sub", inputs=(v0, v1), num_outputs=1)

--- a/onnxscript/ir/_core_test.py
+++ b/onnxscript/ir/_core_test.py
@@ -862,18 +862,57 @@ class GraphTest(unittest.TestCase):
         expected_order = (node2, node1, node3)
         self.assertEqual(sorted_nodes, expected_order)
 
-    def test_topological_sort_shared_parent(self):
+    def shared_parent_nodes(self):
         # edges=[(1,2),(1,3)]
         v0 = _core.Value(name="v0")
         node1 = _core.Node("", "Node1", inputs=(v0,), num_outputs=1)
         node2 = _core.Node("", "Node2", inputs=(node1.outputs[0],), num_outputs=1)
         node3 = _core.Node("", "Node3", inputs=(node1.outputs[0],), num_outputs=1)
-        graph = _core.Graph(
-            (v0,),
-            (node2.outputs[0], node3.outputs[0]),
-            nodes=(node3, node2, node1),
-            opset_imports={"": 1},
-        )
+        return v0, node1, node2, node3
+
+    def test_topological_sort_shared_parent_test_123(self):
+        v0, node1, node2, node3 = self.shared_parent_nodes()
+        graph = _core.Graph((v0,), (), nodes=(node1, node2, node3), opset_imports={"": 1})
+        graph.sort()
+        sorted_nodes = tuple(graph)
+        expected_order = (node1, node2, node3)
+        self.assertEqual(sorted_nodes, expected_order)
+
+    def test_topological_sort_shared_parent_test_132(self):
+        v0, node1, node2, node3 = self.shared_parent_nodes()
+        graph = _core.Graph((v0,), (), nodes=(node1, node3, node2), opset_imports={"": 1})
+        graph.sort()
+        sorted_nodes = tuple(graph)
+        expected_order = (node1, node3, node2)
+        self.assertEqual(sorted_nodes, expected_order)
+
+    def test_topological_sort_shared_parent_test_213(self):
+        v0, node1, node2, node3 = self.shared_parent_nodes()
+        graph = _core.Graph((v0,), (), nodes=(node2, node1, node3), opset_imports={"": 1})
+        graph.sort()
+        sorted_nodes = tuple(graph)
+        expected_order = (node1, node2, node3)
+        self.assertEqual(sorted_nodes, expected_order)
+
+    def test_topological_sort_shared_parent_test_231(self):
+        v0, node1, node2, node3 = self.shared_parent_nodes()
+        graph = _core.Graph((v0,), (), nodes=(node2, node3, node1), opset_imports={"": 1})
+        graph.sort()
+        sorted_nodes = tuple(graph)
+        expected_order = (node1, node2, node3)
+        self.assertEqual(sorted_nodes, expected_order)
+
+    def test_topological_sort_shared_parent_test_312(self):
+        v0, node1, node2, node3 = self.shared_parent_nodes()
+        graph = _core.Graph((v0,), (), nodes=(node3, node1, node2), opset_imports={"": 1})
+        graph.sort()
+        sorted_nodes = tuple(graph)
+        expected_order = (node1, node3, node2)
+        self.assertEqual(sorted_nodes, expected_order)
+
+    def test_topological_sort_shared_parent_test_321(self):
+        v0, node1, node2, node3 = self.shared_parent_nodes()
+        graph = _core.Graph((v0,), (), nodes=(node3, node2, node1), opset_imports={"": 1})
         graph.sort()
         sorted_nodes = tuple(graph)
         expected_order = (node1, node3, node2)


### PR DESCRIPTION
A Priority Queue + Breadth First Search (PQ+BFS) stable topological sort.

1. Parent node is be always be ahead of its child node.
2. Nodes should keep original position as possible.

This algorithm handles nested subgraphs.

Fixes https://github.com/microsoft/onnxscript/issues/1427