### PR TITLE
Fix annotations on Python 3.8

### DIFF
--- a/onnxscript/optimizer/_inliner.py
+++ b/onnxscript/optimizer/_inliner.py
@@ -19,7 +19,11 @@ NodeReplacement = Tuple[Sequence[ir.Node], Sequence[ir.Value]]
 # outermost call site, and the last element is the innermost call site. This is used
 # primarily for generating unique names for values in the inlined functions.
 CallSiteId = str
-CallStack = list[CallSiteId]
+try:
+    CallStack = list[CallSiteId]
+except TypeError:
+    # python 3.8
+    CallStack = list
 
 
 def _make_unique_name(name: str, callstack: CallStack, used_names: set[str]) -> str:


### PR DESCRIPTION
onnxruntime fails on python 3.8 due to this annotation not supported by python 3.8: https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=1487526&view=logs&j=27376bd6-dcc5-5003-357b-1bdbfd73bf61&t=9ca19f38-9f20-5e24-7fb6-b0929d01dde8.