### PR TITLE
[torch api] Enable `_TORCH_ONNX_SAVE_EXTERNAL_DATA_WITH_IR`

### DIFF
--- a/onnxscript/_framework_apis/torch_2_5.py
+++ b/onnxscript/_framework_apis/torch_2_5.py
@@ -25,7 +25,7 @@ from onnxscript.ir import _external_data
 
 # Internal flag. Will go away.
 _TORCH_ONNX_SAVE_EXTERNAL_DATA_WITH_IR = (
-    os.getenv("TORCH_ONNX_OFFLOAD_EXTERNAL_DATA_WITH_IR") == "1"
+    os.getenv("TORCH_ONNX_OFFLOAD_EXTERNAL_DATA_WITH_IR") != "0"
 )
 
 


### PR DESCRIPTION
Enable the `_TORCH_ONNX_SAVE_EXTERNAL_DATA_WITH_IR` flag to use the new external data logic. This will

- Reduce peak memory usage
- Align external data to 64k

for the torch exporter.