### PR TITLE
Make environment check dynamic

### DIFF
--- a/onnxscript/_framework_apis/torch_2_5.py
+++ b/onnxscript/_framework_apis/torch_2_5.py
@@ -28,9 +28,6 @@ _TORCH_ONNX_SAVE_EXTERNAL_DATA_WITH_IR = (
     os.getenv("TORCH_ONNX_OFFLOAD_EXTERNAL_DATA_WITH_IR") != "0"
 )
 
-# Internal flag. Will go away.
-_TORCH_ONNX_ENABLE_OPTIMIZATION = os.getenv("TORCH_ONNX_ENABLE_OPTIMIZATION") == "1"
-
 
 @dataclasses.dataclass(frozen=True)
 class _OnnxFunctionMeta:
@@ -52,8 +49,9 @@ class _OnnxFunctionMeta:
 
 def optimize(model: ir.Model) -> ir.Model:
     """Optimize the model."""
-
-    if _TORCH_ONNX_ENABLE_OPTIMIZATION:
+    # Internal flag. Will go away.
+    enabled = os.getenv("TORCH_ONNX_ENABLE_OPTIMIZATION") == "1"
+    if enabled:
         optimizer.optimize_ir(model)
     return model
 


### PR DESCRIPTION
Change the check on environment variable to be at runtime. This allows benchmarking code to set the environment variable as needed before export.