### PR TITLE
Bug fixes in split-sequence optimization

### DIFF
--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -448,7 +448,7 @@ def split_to_sequence(node: ir.Node, op, state: OptimizerState) -> ReturnValue:
         return None
     if keepdims == 0:
         # squeeze the split dimension if keepdims is 0
-        axis_val = op.Constant(value_int=axis, _outputs=[f"{output.name}_axis"])
+        axis_val = op.Constant(value_ints=[axis], _outputs=[f"{output.name}_axis"])
         squeezed_values = []
         for i in range(num_outputs):
             squeezed = op.Squeeze(

--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -439,6 +439,10 @@ def split_to_sequence(node: ir.Node, op, state: OptimizerState) -> ReturnValue:
     else:
         return None
 
+    # If Split returns a single value, we need to wrap it into a list.
+    if isinstance(split_values, ir.Value):
+        split_values = [split_values]
+
     keepdims = _get_int_attribute(node, "keepdims", 1)
     if keepdims is None:
         return None


### PR DESCRIPTION
A couple of bugs in the optimization for split-sequence:

* Handle the case where there is only one split-value (as the op-builder returns a single IR value instead of a list of IR values in this case).
* Use 1D constant [axis] instead of scalar axis in Squeeze op. 