### PR TITLE
[torchlib] Fix upsample_output_size

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -2365,7 +2365,8 @@ def _aten_upsample_output_size(
     starts = op.Constant(value_ints=[0])
     ends = op.Constant(value_ints=[2])
     batch_channel = op.Slice(self_shape, starts, ends)
-    # When output_size is passed in as a list of integers, op.Concat may fail
+    # When output_size is passed in as a list of integers, the torch.onnx
+    # graph builder when handling op.Concat may fail
     # to determine the output type. We cast it to INT64 to ensure the output
     output_size = op.Cast(output_size, to=INT64.dtype)
     output_size = op.Concat(batch_channel, output_size, axis=0)

--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -2361,15 +2361,12 @@ def _aten_upsample_output_size(
     mode: str,
     coordinate_transformation_mode: str,
 ) -> TReal:
-    self_shape = op.Shape(self)
-    starts = op.Constant(value_ints=[0])
-    ends = op.Constant(value_ints=[2])
-    batch_channel = op.Slice(self_shape, starts, ends)
+    batch_channels = op.Shape(self, end=2, start=0)
     # When output_size is passed in as a list of integers, the torch.onnx
     # graph builder when handling op.Concat may fail
     # to determine the output type. We cast it to INT64 to ensure the output
     output_size = op.Cast(output_size, to=INT64.dtype)
-    output_size = op.Concat(batch_channel, output_size, axis=0)
+    output_size = op.Concat(batch_channels, output_size, axis=0)
     return op.Resize(
         self,
         None,

--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -2361,12 +2361,13 @@ def _aten_upsample_output_size(
     mode: str,
     coordinate_transformation_mode: str,
 ) -> TReal:
-    batch_channels = op.Shape(self, end=2, start=0)
+    batch_and_channel = op.Shape(self, end=2, start=0)
     # When output_size is passed in as a list of integers, the torch.onnx
     # graph builder when handling op.Concat may fail
     # to determine the output type. We cast it to INT64 to ensure the output
     output_size = op.Cast(output_size, to=INT64.dtype)
-    output_size = op.Concat(batch_channels, output_size, axis=0)
+    # Append the batch and channel dimensions to the requested output size
+    output_size = op.Concat(batch_and_channel, output_size, axis=0)
     return op.Resize(
         self,
         None,

--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -2365,6 +2365,9 @@ def _aten_upsample_output_size(
     starts = op.Constant(value_ints=[0])
     ends = op.Constant(value_ints=[2])
     batch_channel = op.Slice(self_shape, starts, ends)
+    # When output_size is passed in as a list of integers, op.Concat may fail
+    # to determine the output type. We cast it to INT64 to ensure the output
+    output_size = op.Cast(output_size, to=INT64.dtype)
     output_size = op.Concat(batch_channel, output_size, axis=0)
     return op.Resize(
         self,


### PR DESCRIPTION
Add a line to cast inputs to INT64 because when output_size is passed in as a list of integers, the graph builder in PyTorch exporter may fail to determine the output type. We cast it to INT64 to ensure the output