### PR TITLE
Add test cases for pattern matching against optional inputs

### DIFF
--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -592,9 +592,11 @@ class NodeOutputPattern(ValuePattern):
 
 Var = ValuePattern
 
+
 def _is_pattern_variable(x: Any) -> bool:
     # The derived classes of ValuePattern represent constant patterns and node-output patterns.
     return type(x) is ValuePattern
+
 
 class Constant(ValuePattern):
     """Represents a pattern that matches against a scalar constant value."""
@@ -988,16 +990,16 @@ class SimplePatternMatcher(PatternMatcher):
 
     def _match_value(self, pattern_value: ValuePattern, value: ir.Value | None) -> bool:
         """Match an IR value against a ValuePattern instance."""
-        if value is None:
-            if not _is_pattern_variable(pattern_value):
-                return self.fail("Mismatch: input value is None, but pattern value is not a variable.")
-
         if not self._bind_value(pattern_value, value):
             return False
 
         if isinstance(pattern_value, NodeOutputPattern):
+            if value is None:
+                return self.fail("Mismatch: Computed node pattern does not match None.")
             return self._match_node_output(pattern_value, value)
         if isinstance(pattern_value, Constant):
+            if value is None:
+                return self.fail("Mismatch: Constant pattern does not match None.")
             return self._match_constant(pattern_value, value)
         return True
 

--- a/onnxscript/rewriter/pattern_test.py
+++ b/onnxscript/rewriter/pattern_test.py
@@ -15,11 +15,6 @@ from onnxscript.rewriter import _ir_utils, cast_constant_of_shape, pattern
 logger = logging.getLogger(__name__)
 
 
-def _parse_model_ir(onnxtxt: str) -> ir.Model:
-    model_proto = onnx.parser.parse_model(onnxtxt)
-    return ir.serde.deserialize_model(model_proto)
-
-
 class ReciprocalMulTest(unittest.TestCase):
     def rule(self) -> pattern.RewriteRule:
         def reciprocal_mul_pattern(op, x, y):

--- a/onnxscript/rewriter/pattern_test.py
+++ b/onnxscript/rewriter/pattern_test.py
@@ -448,7 +448,7 @@ class RewriteRuleTest(unittest.TestCase):
         self.assertEqual(model.graph.node(0).op_type, "Replaced")
         self.assertEqual(model.graph.node(1).op_type, "Original")
 
-    def test_match_none_input(self):
+    def test_match_optional_input(self):
         def none_pattern(op, optional_input, x):
             # match against a call to Original where the first input may or may not be None
             return op.Original(optional_input, x)


### PR DESCRIPTION
I updated the pattern matcher to support matching against optional inputs. The change was accidentally pushed into the main branch (not a sub-branch as I thought) ... guess the branch protections were not good enough, changed it now.

Adding test-cases now to test it in this PR.