### PR TITLE
Bump onnx-weekly in CI

### DIFF
--- a/requirements/ci/requirements-onnx-weekly.txt
+++ b/requirements/ci/requirements-onnx-weekly.txt
@@ -1,1 +1,1 @@
-onnx-weekly==1.17.0.dev20240715
+onnx-weekly==1.18.0.dev20240930


### PR DESCRIPTION
To 1.18.0.dev20240930 because the previous weekly was cleaned up in pypi