### PR TITLE
[torchlib] Fix wrong bias shape of ConvTranspose

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -2030,12 +2030,6 @@ def aten_convolution(
         stride = (stride, stride)
     strides = list(stride)
 
-    if bias is None:
-        weight_dim_0 = op.Shape(weight, start=0, end=1)
-        bias_shape = op.Expand(weight_dim_0, op.Constant(value_ints=[1]))
-        zero = op.CastLike(0.0, input)
-        bias = op.Expand(zero, bias_shape)
-
     result = _aten_convolution_onnx(
         input,
         weight,


### PR DESCRIPTION
Previously, the bias shape of ConvTranpose was wrong since, unlike Conv, it should using the 1st dimension of weight shape and not the 0th. See described in https://github.com/microsoft/onnxscript/issues/1299

In other words,
```
    if bias is None:
        weight_dim_0 = op.Shape(weight, start=0, end=1)
        bias_shape = op.Expand(weight_dim_0, op.Constant(value_ints=[1]))
        zero = op.CastLike(0.0, input)
        bias = op.Expand(zero, bias_shape)
```
should be changed to something like:
```
weight_dim_0 = op.Shape(weight, start=1, end=2) if transposed else op.Shape(weight, start=0, end=1)
```

However, I think it's more efficient to just eliminate bias altogether if it's not provided instead of filling it with zeros, since the ONNX spec allows bias to be absent.