### PR TITLE
Use input size limits for constant folding

### DIFF
--- a/onnxscript/optimizer/__init__.py
+++ b/onnxscript/optimizer/__init__.py
@@ -111,17 +111,33 @@ def optimize(
     return model
 
 
+_DEFAULT_CONSTANT_FOLD_INPUT_SIZE_LIMIT = (
+    _constant_folding._DEFAULT_CONSTANT_FOLD_INPUT_SIZE_LIMIT
+)
+
+_DEFAULT_CONSTANT_FOLD_OUTPUT_SIZE_LIMIT = (
+    _constant_folding._DEFAULT_CONSTANT_FOLD_OUTPUT_SIZE_LIMIT
+)
+
+
 def optimize_ir(
     model: ir.Model,
     num_iterations: int = 2,
     *,
     onnx_shape_inference: bool = True,
     stop_if_no_change: bool = True,
+    input_size_limit: int = _DEFAULT_CONSTANT_FOLD_INPUT_SIZE_LIMIT,
+    output_size_limit: int = _DEFAULT_CONSTANT_FOLD_OUTPUT_SIZE_LIMIT,
 ) -> None:
     del stop_if_no_change  # Looks like rewriter doesn't support this yet.
     _inliner.inline(model)
     for _ in range(num_iterations):
-        _constant_folding.fold_constants(model, onnx_shape_inference=onnx_shape_inference)
+        _constant_folding.fold_constants(
+            model,
+            onnx_shape_inference=onnx_shape_inference,
+            input_size_limit=input_size_limit,
+            output_size_limit=output_size_limit,
+        )
         rewriter.rewrite(model, pattern_rewrite_rules=_DEFAULT_REWRITE_RULES)
     remove_unused_nodes(model)
 

--- a/onnxscript/optimizer/__init__.py
+++ b/onnxscript/optimizer/__init__.py
@@ -129,12 +129,11 @@ def optimize_ir(
     input_size_limit: int = _DEFAULT_CONSTANT_FOLD_INPUT_SIZE_LIMIT,
     output_size_limit: int = _DEFAULT_CONSTANT_FOLD_OUTPUT_SIZE_LIMIT,
 ) -> None:
-    """
-    Optimizes a model.
+    """Optimizes a model.
 
     Args:
-        model: The model to be optimized
-        num_iterations: Number of times the optimization loop is repeated
+        model: The model to be optimized.
+        num_iterations: Number of times the optimization loop is repeated.
         onnx_shape_inference: Applies node-level shape-inference as part of optimization
         input_size_limit: Will not apply constant folding to ops with any input of size
             greater than this. Does not apply to special ops like Shape() and Size().

--- a/onnxscript/optimizer/__init__.py
+++ b/onnxscript/optimizer/__init__.py
@@ -129,6 +129,20 @@ def optimize_ir(
     input_size_limit: int = _DEFAULT_CONSTANT_FOLD_INPUT_SIZE_LIMIT,
     output_size_limit: int = _DEFAULT_CONSTANT_FOLD_OUTPUT_SIZE_LIMIT,
 ) -> None:
+    """
+    Optimizes a model.
+
+    Args:
+        model: The model to be optimized
+        num_iterations: Number of times the optimization loop is repeated
+        onnx_shape_inference: Applies node-level shape-inference as part of optimization
+        input_size_limit: Will not apply constant folding to ops with any input of size
+            greater than this. Does not apply to special ops like Shape() and Size().
+        output_size_limit: Will not rewrite any foldable-op into a Constant op if the size
+            of the output tensor is greater than this.
+        stop_if_no_change: Not supported currently (has no effect). Meant to stop the
+            outer optimization loop if no change is detected in one iteration.
+    """
     del stop_if_no_change  # Looks like rewriter doesn't support this yet.
     _inliner.inline(model)
     for _ in range(num_iterations):

--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -703,9 +703,9 @@ class ConstantFolder:
         if any(x is None for x in input_values):
             return None
 
-        if any(input.size > self._input_size_limit for input in input_values):
+        if any(input.size > self._input_size_limit for input in input_values):  # type: ignore[union-attr]
             if logger.isEnabledFor(logging.DEBUG):
-                input_sizes = [input.size for input in input_values]
+                input_sizes = [input.size for input in input_values]  # type: ignore[union-attr]
                 logger.debug(
                     "Skipping constant folding for op %s due to large input size: %s",
                     node.op_type,

--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -707,7 +707,9 @@ class ConstantFolder:
             if logger.isEnabledFor(logging.DEBUG):
                 input_sizes = [input.size for input in input_values]
                 logger.debug(
-                    f"Skipping constant folding for op {node.op_type} due to large input size: {input_sizes}"
+                    "Skipping constant folding for op %s due to large input size: %s",
+                    node.op_type,
+                    input_sizes,
                 )
             return None
 


### PR DESCRIPTION
Add input size limits for constant folding. Helps avoid excessive time in optimizer in some edge cases. (The edge cases, where we have non-trivial ops applied to large tensors, are not relevant for the exporter itself. They may be of potential interest for optimization in other settings, but that can be done by user taking explicit steps.)

Still to be done: how do we specify these values from the benchmarking code? For now, the default values will be quite useful, but experimenting with these values from the benchmarking code will need a way to control these option values.