### PR TITLE
[torchlib] Use traced function param schema to process inputs

### DIFF
--- a/onnxscript/function_libs/torch_lib/_flags.py
+++ b/onnxscript/function_libs/torch_lib/_flags.py
@@ -51,8 +51,3 @@ EXPERIMENTAL_PREFER_TRACING: bool = _load_boolean_flag(
     this_will="trace all traceable functions to fold if branches and collapse constant expressions",
     default=True,
 )
-EXPERIMENTAL_USE_IR: bool = _load_boolean_flag(
-    "TORCHLIB_EXPERIMENTAL_USE_IR",
-    this_will="use the ONNX IR instead of the PyTorch Graph for graph building",
-    deprecated=True,
-)

--- a/onnxscript/function_libs/torch_lib/graph_building/__init__.py
+++ b/onnxscript/function_libs/torch_lib/graph_building/__init__.py
@@ -40,17 +40,9 @@ __all__ = [
     "TorchScriptTracingEvaluator",
 ]
 
-from onnxscript.function_libs.torch_lib import _flags
 
-if _flags.EXPERIMENTAL_USE_IR:
-    from ._graph_building_ir import (
-        TorchScriptGraph,
-        TorchScriptTensor,
-        TorchScriptTracingEvaluator,
-    )
-else:
-    from ._graph_building_torch import (  # type: ignore[assignment]
-        TorchScriptGraph,
-        TorchScriptTensor,
-        TorchScriptTracingEvaluator,
-    )
+from ._graph_building_ir import (
+    TorchScriptGraph,
+    TorchScriptTensor,
+    TorchScriptTracingEvaluator,
+)


### PR DESCRIPTION
The firs step of https://github.com/microsoft/onnxscript/issues/1914, this is setting up onnxscript CI to test whether traced_only function has enough information to process inputs to tensors.