### PR TITLE
Set 0d shape to python constant tensors

### DIFF
--- a/onnxscript/function_libs/torch_lib/graph_building/_graph_building_torch.py
+++ b/onnxscript/function_libs/torch_lib/graph_building/_graph_building_torch.py
@@ -739,7 +739,7 @@ class TorchScriptGraph:
         )[0]
         value.setDebugName(_rename_intermediate_value(value.debugName()))
         if shape is not None:
-            value.setType(value.type().with_sizes(shape))
+            value.setType(value.type().with_sizes(shape))  # type: ignore[arg-type]
         return value
 
     def preprocess_inputs(self, onnx_inputs: Sequence[ValidInputType]) -> List[torch.Value]:

--- a/onnxscript/function_libs/torch_lib/graph_building/_graph_building_torch.py
+++ b/onnxscript/function_libs/torch_lib/graph_building/_graph_building_torch.py
@@ -704,13 +704,17 @@ class TorchScriptGraph:
             value.setDebugName(_rename_intermediate_value(value.debugName()))
             return value
 
+        shape: list[int] | None = None
         if isinstance(constant, bool):
             # Be sure to put bool before int, because bool is a subclass of int
             constant_tensor = torch.tensor(constant, dtype=torch.bool)
+            shape = []
         elif isinstance(constant, float):
             constant_tensor = torch.tensor(constant, dtype=torch.float)
+            shape = []
         elif isinstance(constant, int):
             constant_tensor = torch.tensor(constant, dtype=torch.int64)
+            shape = []
         elif isinstance(constant, (tuple, list)) and all(
             isinstance(val, int) for val in constant
         ):
@@ -734,6 +738,8 @@ class TorchScriptGraph:
             attributes=dict(value=constant_tensor),
         )[0]
         value.setDebugName(_rename_intermediate_value(value.debugName()))
+        if shape is not None:
+            value.setType(value.type().with_sizes(shape))
         return value
 
     def preprocess_inputs(self, onnx_inputs: Sequence[ValidInputType]) -> List[torch.Value]:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5752,9 +5752,14 @@ def aten_nansum(
 def aten_narrow(self: TTensor, dim: INT64, start: INT64, length: INT64) -> TTensor:
     """narrow(Tensor(a) self, int dim, SymInt start, SymInt length) -> Tensor(a)"""
 
-    dim = op.Reshape(dim, op.Constant(value_ints=[-1]))
-    start = op.Reshape(start, op.Constant(value_ints=[-1]))
-    length = op.Reshape(length, op.Constant(value_ints=[-1]))
+    if IsScalar(dim):
+        dim = op.Reshape(dim, op.Constant(value_ints=[-1]))
+
+    if IsScalar(start):
+        start = op.Reshape(start, op.Constant(value_ints=[-1]))
+
+    if IsScalar(length):
+        length = op.Reshape(length, op.Constant(value_ints=[-1]))
 
     end = op.Add(start, length)
     return op.Slice(self, start, end, dim)


### PR DESCRIPTION
From #1916, it is found that the undefined shape disables the functionality of IsScalar op: https://github.com/microsoft/onnxscript/blob/561a6006ff48b744c7a03d80994fd74ea06be5f7/onnxscript/function_libs/torch_lib/graph_building/_graph_building_torch.py#L357 This PR annotates python scalar to be 0d tensor.