### PR TITLE
[Rewriter Rules] Fix Expand-Identity rule

### DIFF
--- a/onnxscript/rewriter/llama_rule_sets.py
+++ b/onnxscript/rewriter/llama_rule_sets.py
@@ -71,6 +71,7 @@ class ExpandIdentity(orp.RewriteRuleAsClass):
             # Shape is not a constant and cannot be guessed.
             return False
         if (x_shape := x.shape) is None:
+            # We don't know the shape of the input
             return False
         return x_shape.dims == tuple(shape.const_value.numpy().tolist())
 

--- a/onnxscript/rewriter/llama_rule_sets.py
+++ b/onnxscript/rewriter/llama_rule_sets.py
@@ -239,11 +239,17 @@ class UnsqueezeUnsqueeze(orp.RewriteRuleAsClass):
 
     @classmethod
     def rewrite(cls, op, x: ir.Value, axes1: ir.Value, axes2: ir.Value):
+        assert axes1.const_value is not None
+        assert axes2.const_value is not None
+        v1 = axes1.const_value.numpy()
+        v2 = axes2.const_value.numpy()
         axes = cls._combine_axes(v1, v2)
         return op.Unsqueeze(x, op.Constant(value=onnx.numpy_helper.from_array(axes)))
 
     @classmethod
     def check(cls, context, x, axes1, axes2) -> bool:
+        del context  # Unused
+        del x  # Unused
         if axes1.const_value is None or axes2.const_value is None:
             return False
 

--- a/onnxscript/rewriter/llama_rule_sets.py
+++ b/onnxscript/rewriter/llama_rule_sets.py
@@ -241,8 +241,12 @@ class UnsqueezeUnsqueeze(orp.RewriteRuleAsClass):
 
     @classmethod
     def rewrite(cls, op, x: ir.Value, axes1: ir.Value, axes2: ir.Value):
-        v1 = axes1.const_value.numpy()  # type: ignore[union-attr]
-        v2 = axes2.const_value.numpy()  # type: ignore[union-attr]
+        if axes1.const_value is None or axes2.const_value is None:
+            return False
+        v1 = axes1.const_value.numpy()
+        v2 = axes2.const_value.numpy()
+        assert isinstance(v1, np.ndarray)
+        assert isinstance(v2, np.ndarray)
         if len(v1) != 1 or len(v2) != 1:
             # Implemented later if needed.
             return False

--- a/onnxscript/rewriter/llama_rule_sets.py
+++ b/onnxscript/rewriter/llama_rule_sets.py
@@ -239,15 +239,6 @@ class UnsqueezeUnsqueeze(orp.RewriteRuleAsClass):
 
     @classmethod
     def rewrite(cls, op, x: ir.Value, axes1: ir.Value, axes2: ir.Value):
-        if axes1.const_value is None or axes2.const_value is None:
-            return False
-        v1 = axes1.const_value.numpy()
-        v2 = axes2.const_value.numpy()
-        if not v1.shape or not v2.shape:
-            return False
-        if v1.shape[0] != 1 or v2.shape[0] != 1:
-            # Implemented later if needed.
-            return False
         axes = cls._combine_axes(v1, v2)
         return op.Unsqueeze(x, op.Constant(value=onnx.numpy_helper.from_array(axes)))
 
@@ -255,10 +246,19 @@ class UnsqueezeUnsqueeze(orp.RewriteRuleAsClass):
     def check(cls, context, x, axes1, axes2) -> bool:
         if axes1.const_value is None or axes2.const_value is None:
             return False
-        if axes1.const_value.numpy().min() < 0:
+
+        v1 = axes1.const_value.numpy()
+        v2 = axes2.const_value.numpy()
+        if not v1.shape or not v2.shape:
             return False
-        if axes2.const_value.numpy().min() < 0:
+        if v1.shape[0] != 1 or v2.shape[0] != 1:
+            # Implemented later if needed.
             return False
+        if v1.min() < 0:
+            return False
+        if v2.min() < 0:
+            return False
+
         return True
 
 

--- a/onnxscript/rewriter/llama_rule_sets.py
+++ b/onnxscript/rewriter/llama_rule_sets.py
@@ -55,7 +55,7 @@ class CastCast(orp.RewriteRuleAsClass):
 
 
 class ExpandIdentity(orp.RewriteRuleAsClass):
-    """Replaces ``Expand(., shape)`` by ``Identity`` if possible."""
+    """Replaces ``Expand(..., shape)`` by ``Identity`` if possible."""
 
     @classmethod
     def pattern(cls, op, x, shape):
@@ -70,8 +70,9 @@ class ExpandIdentity(orp.RewriteRuleAsClass):
         if shape.const_value is None:
             # Shape is not a constant and cannot be guessed.
             return False
-        shape_x = x.shape
-        return shape_x.dims == tuple(shape.const_value.numpy().tolist())
+        if (x_shape := x.shape) is None:
+            return False
+        return x_shape.dims == tuple(shape.const_value.numpy().tolist())
 
 
 class ReshapeReshape(orp.RewriteRuleAsClass):

--- a/onnxscript/rewriter/llama_rule_sets.py
+++ b/onnxscript/rewriter/llama_rule_sets.py
@@ -241,9 +241,7 @@ class UnsqueezeUnsqueeze(orp.RewriteRuleAsClass):
     def rewrite(cls, op, x: ir.Value, axes1: ir.Value, axes2: ir.Value):
         assert axes1.const_value is not None
         assert axes2.const_value is not None
-        v1 = axes1.const_value.numpy()
-        v2 = axes2.const_value.numpy()
-        axes = cls._combine_axes(v1, v2)
+        axes = cls._combine_axes(axes1.const_value.numpy(), axes2.const_value.numpy())
         return op.Unsqueeze(x, op.Constant(value=onnx.numpy_helper.from_array(axes)))
 
     @classmethod

--- a/onnxscript/rewriter/llama_rule_sets.py
+++ b/onnxscript/rewriter/llama_rule_sets.py
@@ -224,9 +224,7 @@ class TransposeTranspose(orp.RewriteRuleAsClass):
 
 
 class UnsqueezeUnsqueeze(orp.RewriteRuleAsClass):
-    """Replaces ``Unsqueeze(Unsqueeze(., axes1), axes2)``
-    with one Unsqueeze.
-    """
+    """Replaces ``Unsqueeze(Unsqueeze(., axes1), axes2)`` with one Unsqueeze."""
 
     @classmethod
     def pattern(cls, op, x, axes1, axes2):
@@ -245,9 +243,9 @@ class UnsqueezeUnsqueeze(orp.RewriteRuleAsClass):
             return False
         v1 = axes1.const_value.numpy()
         v2 = axes2.const_value.numpy()
-        assert isinstance(v1, np.ndarray)
-        assert isinstance(v2, np.ndarray)
-        if len(v1) != 1 or len(v2) != 1:
+        if not v1.shape or not v2.shape:
+            return False
+        if v1.shape[0] != 1 or v2.shape[0] != 1:
             # Implemented later if needed.
             return False
         axes = cls._combine_axes(v1, v2)

--- a/onnxscript/rewriter/llama_rule_sets_test.py
+++ b/onnxscript/rewriter/llama_rule_sets_test.py
@@ -19,6 +19,16 @@ from onnxscript.onnx_opset import opset18
 FLOAT = onnx.TensorProto.FLOAT
 
 
+@onnxscript.script()
+def cast_identity_model(x: ot.FLOAT["a", "b", "c"]) -> ot.FLOAT["a", "b", "c"]:  # noqa: F821, UP037
+    y = opset18.Cast(x, to=onnx.TensorProto.FLOAT)
+    return y
+
+
+def _make_model(*args, **kwargs) -> ir.Model:
+    return ir.serde.deserialize_model(onnx.helper.make_model(*args, **kwargs))
+
+
 class LlamaRuleSetsTest(unittest.TestCase):
     def _get_random_inputs(self, model: onnx.ModelProto) -> dict[str, Any]:
         feeds: dict[str, Any] = {}
@@ -54,188 +64,187 @@ class LlamaRuleSetsTest(unittest.TestCase):
         for a, b in zip(expected, got):
             np.testing.assert_allclose(a, b, atol=atol, rtol=rtol)
 
-    @classmethod
-    def _identity_models(cls):
-        models = [
-            onnx.helper.make_model(
-                onnx.helper.make_graph(
-                    [
-                        onnx.helper.make_node("Transpose", ["X"], ["Y"], perm=[0, 1, 2]),
-                    ],
-                    "name",
-                    [onnx.helper.make_tensor_value_info("X", FLOAT, [None, None, None])],
-                    [onnx.helper.make_tensor_value_info("Y", FLOAT, [None, None, None])],
+    @parameterized.parameterized.expand(
+        [
+            (
+                "no_op_transpose",
+                _make_model(
+                    onnx.helper.make_graph(
+                        [
+                            onnx.helper.make_node("Transpose", ["X"], ["Y"], perm=[0, 1, 2]),
+                        ],
+                        "name",
+                        [onnx.helper.make_tensor_value_info("X", FLOAT, [None, None, None])],
+                        [onnx.helper.make_tensor_value_info("Y", FLOAT, [None, None, None])],
+                    ),
+                    opset_imports=[onnx.helper.make_opsetid("", 18)],
                 ),
-                opset_imports=[onnx.helper.make_opsetid("", 18)],
             ),
-            onnx.helper.make_model(
-                onnx.helper.make_graph(
-                    [
-                        onnx.helper.make_node("Mul", ["X", "one"], ["Y"]),
-                    ],
-                    "name",
-                    [onnx.helper.make_tensor_value_info("X", FLOAT, [None])],
-                    [onnx.helper.make_tensor_value_info("Y", FLOAT, [None])],
-                    [
-                        onnx.numpy_helper.from_array(
-                            np.array([1], dtype=np.float32), name="one"
-                        )
-                    ],
+            (
+                "mul_by_one",
+                _make_model(
+                    onnx.helper.make_graph(
+                        [
+                            onnx.helper.make_node("Mul", ["X", "one"], ["Y"]),
+                        ],
+                        "name",
+                        [onnx.helper.make_tensor_value_info("X", FLOAT, [None])],
+                        [onnx.helper.make_tensor_value_info("Y", FLOAT, [None])],
+                        [
+                            onnx.numpy_helper.from_array(
+                                np.array([1], dtype=np.float32), name="one"
+                            )
+                        ],
+                    ),
+                    opset_imports=[onnx.helper.make_opsetid("", 18)],
                 ),
-                opset_imports=[onnx.helper.make_opsetid("", 18)],
             ),
-            onnx.helper.make_model(
-                onnx.helper.make_graph(
-                    [
-                        onnx.helper.make_node("Transpose", ["X"], ["xt"], perm=[1, 0]),
-                        onnx.helper.make_node("Transpose", ["xt"], ["Y"], perm=[1, 0]),
-                    ],
-                    "name",
-                    [onnx.helper.make_tensor_value_info("X", FLOAT, [None, None])],
-                    [onnx.helper.make_tensor_value_info("Y", FLOAT, [None, None])],
+            (
+                "canceled_out_transposes",
+                _make_model(
+                    onnx.helper.make_graph(
+                        [
+                            onnx.helper.make_node("Transpose", ["X"], ["xt"], perm=[1, 0]),
+                            onnx.helper.make_node("Transpose", ["xt"], ["Y"], perm=[1, 0]),
+                        ],
+                        "name",
+                        [onnx.helper.make_tensor_value_info("X", FLOAT, [None, None])],
+                        [onnx.helper.make_tensor_value_info("Y", FLOAT, [None, None])],
+                    ),
+                    opset_imports=[onnx.helper.make_opsetid("", 18)],
                 ),
-                opset_imports=[onnx.helper.make_opsetid("", 18)],
-            ),
-        ]
-        return models
-
-    def test_llama_p0_rule_set_identity(self):
-        for model_proto in self._identity_models():
-            ir_model = ir.serde.deserialize_model(model_proto)
-            rule_set = llama_rule_sets.llama_p0_rule_set()
-            rule_set.apply_to_model(ir_model)
-            rewritten_model = ir.serde.serialize_model(ir_model)
-
-            self.assertEqual(["Identity"], [n.op_type for n in rewritten_model.graph.node])
-            self._check_model(model_proto, rewritten_model)
-
-    @classmethod
-    def _transpose_transpose_models(cls):
-        models = [
-            onnx.helper.make_model(
-                onnx.helper.make_graph(
-                    [
-                        onnx.helper.make_node("Transpose", ["X"], ["xt"], perm=[1, 2, 0]),
-                        onnx.helper.make_node("Transpose", ["xt"], ["Y"], perm=[1, 2, 0]),
-                    ],
-                    "name",
-                    [onnx.helper.make_tensor_value_info("X", FLOAT, [None, None, None])],
-                    [onnx.helper.make_tensor_value_info("Y", FLOAT, [None, None, None])],
-                ),
-                opset_imports=[onnx.helper.make_opsetid("", 18)],
             ),
         ]
-        return models
+    )
+    def test_llama_p0_rule_set_identity(self, _: str, model: ir.Model):
+        rule_set = llama_rule_sets.llama_p0_rule_set()
+        model_proto = ir.serde.serialize_model(model)
+        rule_set.apply_to_model(model)
+        rewritten_model = ir.serde.serialize_model(model)
 
-    def test_llama_p0_rule_set_transpose_transpose(self):
-        for model_proto in self._transpose_transpose_models():
-            ir_model = ir.serde.deserialize_model(model_proto)
-            rule_set = llama_rule_sets.llama_p0_rule_set()
-            rule_set.apply_to_model(ir_model)
-            rewritten_model = ir.serde.serialize_model(ir_model)
+        self.assertEqual(["Identity"], [n.op_type for n in model.graph])
+        self._check_model(model_proto, rewritten_model)
 
-            self.assertEqual(["Transpose"], [n.op_type for n in rewritten_model.graph.node])
-            self._check_model(model_proto, rewritten_model)
-
-    @classmethod
-    def _cast_cast_models(cls):
-        models = [
-            onnx.helper.make_model(
-                onnx.helper.make_graph(
-                    [
-                        onnx.helper.make_node(
-                            "Cast", ["X"], ["Xc"], to=onnx.TensorProto.FLOAT16
-                        ),
-                        onnx.helper.make_node(
-                            "Cast", ["Xc"], ["Y"], to=onnx.TensorProto.DOUBLE
-                        ),
-                    ],
-                    "name",
-                    [onnx.helper.make_tensor_value_info("X", FLOAT, [None, None, None])],
-                    [
-                        onnx.helper.make_tensor_value_info(
-                            "Y", onnx.TensorProto.DOUBLE, [None, None, None]
-                        )
-                    ],
+    @parameterized.parameterized.expand(
+        [
+            (
+                "consecutive_transposes",
+                _make_model(
+                    onnx.helper.make_graph(
+                        [
+                            onnx.helper.make_node("Transpose", ["X"], ["xt"], perm=[1, 2, 0]),
+                            onnx.helper.make_node("Transpose", ["xt"], ["Y"], perm=[1, 2, 0]),
+                        ],
+                        "name",
+                        [onnx.helper.make_tensor_value_info("X", FLOAT, [None, None, None])],
+                        [onnx.helper.make_tensor_value_info("Y", FLOAT, [None, None, None])],
+                    ),
+                    opset_imports=[onnx.helper.make_opsetid("", 18)],
                 ),
-                opset_imports=[onnx.helper.make_opsetid("", 18)],
             ),
         ]
-        return models
+    )
+    def test_llama_p0_rule_set_transpose_transpose(self, _: str, model: ir.Model):
+        rule_set = llama_rule_sets.llama_p0_rule_set()
+        model_proto = ir.serde.serialize_model(model)
+        rule_set.apply_to_model(model)
+        rewritten_model = ir.serde.serialize_model(model)
+        self.assertEqual(["Transpose"], [n.op_type for n in model.graph])
+        self._check_model(model_proto, rewritten_model)
 
-    def test_llama_p0_rule_set_cast_cast(self):
-        for model_proto in self._cast_cast_models():
-            ir_model = ir.serde.deserialize_model(model_proto)
-            rule_set = llama_rule_sets.llama_p0_rule_set()
-            rule_set.apply_to_model(ir_model)
-            rewritten_model = ir.serde.serialize_model(ir_model)
+    @parameterized.parameterized.expand(
+        [
+            (
+                "double_casts",
+                _make_model(
+                    onnx.helper.make_graph(
+                        [
+                            onnx.helper.make_node(
+                                "Cast", ["X"], ["Xc"], to=onnx.TensorProto.FLOAT16
+                            ),
+                            onnx.helper.make_node(
+                                "Cast", ["Xc"], ["Y"], to=onnx.TensorProto.DOUBLE
+                            ),
+                        ],
+                        "name",
+                        [onnx.helper.make_tensor_value_info("X", FLOAT, [None, None, None])],
+                        [
+                            onnx.helper.make_tensor_value_info(
+                                "Y", onnx.TensorProto.DOUBLE, [None, None, None]
+                            )
+                        ],
+                    ),
+                    opset_imports=[onnx.helper.make_opsetid("", 18)],
+                ),
+            ),
+        ]
+    )
+    def test_llama_p0_rule_set_cast_cast(self, _: str, model: ir.Model):
+        rule_set = llama_rule_sets.llama_p0_rule_set()
+        model_proto = ir.serde.serialize_model(model)
+        rule_set.apply_to_model(model)
+        rewritten_model = ir.serde.serialize_model(model)
 
-            self.assertEqual(["Cast"], [n.op_type for n in rewritten_model.graph.node])
-            self._check_model(model_proto, rewritten_model, atol=1e-2)
+        self.assertEqual(["Cast"], [n.op_type for n in model.graph])
+        self._check_model(model_proto, rewritten_model, atol=1e-2)
 
-    @classmethod
-    def _cast_identity_models(cls):
-        @onnxscript.script()
-        def model(x: ot.FLOAT["a", "b", "c"]) -> ot.FLOAT["a", "b", "c"]:  # noqa: F821, UP037
-            y = opset18.Cast(x, to=onnx.TensorProto.FLOAT)
-            return y
+    @parameterized.parameterized.expand(
+        [
+            (
+                "cast_identity",
+                ir.serde.deserialize_model(cast_identity_model.to_model_proto()),
+            ),
+        ]
+    )
+    def test_llama_p0_rule_set_cast_identity(self, _: str, model: ir.Model):
+        rule_set = llama_rule_sets.llama_p0_rule_set()
+        model_proto = ir.serde.serialize_model(model)
+        rule_set.apply_to_model(model)
+        rewritten_model = ir.serde.serialize_model(model)
 
-        return [model.to_model_proto()]
-
-    def test_llama_p0_rule_set_cast_identity(self):
-        for model_proto in self._cast_identity_models():
-            ir_model = ir.serde.deserialize_model(model_proto)
-            rule_set = llama_rule_sets.llama_p0_rule_set()
-            rule_set.apply_to_model(ir_model)
-            rewritten_model = ir.serde.serialize_model(ir_model)
-
-            self.assertEqual(["Identity"], [n.op_type for n in rewritten_model.graph.node])
-            self._check_model(model_proto, rewritten_model)
+        self.assertEqual(["Identity"], [n.op_type for n in model.graph])
+        self._check_model(model_proto, rewritten_model)
 
     @parameterized.parameterized.expand(
         [
             (
                 "normal_case",
-                ir.serde.deserialize_model(
-                    onnx.helper.make_model(
-                        onnx.helper.make_graph(
-                            [
-                                onnx.helper.make_node("Expand", ["X", "shape"], ["Y"]),
-                            ],
-                            "name",
-                            [onnx.helper.make_tensor_value_info("X", FLOAT, [3, 4, 5])],
-                            [onnx.helper.make_tensor_value_info("Y", FLOAT, [3, 4, 5])],
-                            [
-                                onnx.numpy_helper.from_array(
-                                    np.array([3, 4, 5], dtype=np.int64), name="shape"
-                                )
-                            ],
-                        ),
-                        opset_imports=[onnx.helper.make_opsetid("", 18)],
-                    )
+                _make_model(
+                    onnx.helper.make_graph(
+                        [
+                            onnx.helper.make_node("Expand", ["X", "shape"], ["Y"]),
+                        ],
+                        "name",
+                        [onnx.helper.make_tensor_value_info("X", FLOAT, [3, 4, 5])],
+                        [onnx.helper.make_tensor_value_info("Y", FLOAT, [3, 4, 5])],
+                        [
+                            onnx.numpy_helper.from_array(
+                                np.array([3, 4, 5], dtype=np.int64), name="shape"
+                            )
+                        ],
+                    ),
+                    opset_imports=[onnx.helper.make_opsetid("", 18)],
                 ),
                 ("Identity",),
             ),
             (
                 "input_no_shape",
-                ir.serde.deserialize_model(
-                    onnx.helper.make_model(
-                        onnx.helper.make_graph(
-                            [
-                                onnx.helper.make_node("Identity", ["X"], ["Y"]),
-                                onnx.helper.make_node("Expand", ["Y", "shape"], ["Z"]),
-                            ],
-                            "name",
-                            [onnx.helper.make_tensor_value_info("X", FLOAT, [3, 4, 5])],
-                            [onnx.helper.make_tensor_value_info("Z", FLOAT, [3, 4, 5])],
-                            [
-                                onnx.numpy_helper.from_array(
-                                    np.array([3, 4, 5], dtype=np.int64), name="shape"
-                                )
-                            ],
-                        ),
-                        opset_imports=[onnx.helper.make_opsetid("", 18)],
-                    )
+                _make_model(
+                    onnx.helper.make_graph(
+                        [
+                            onnx.helper.make_node("Identity", ["X"], ["Y"]),
+                            onnx.helper.make_node("Expand", ["Y", "shape"], ["Z"]),
+                        ],
+                        "name",
+                        [onnx.helper.make_tensor_value_info("X", FLOAT, [3, 4, 5])],
+                        [onnx.helper.make_tensor_value_info("Z", FLOAT, [3, 4, 5])],
+                        [
+                            onnx.numpy_helper.from_array(
+                                np.array([3, 4, 5], dtype=np.int64), name="shape"
+                            )
+                        ],
+                    ),
+                    opset_imports=[onnx.helper.make_opsetid("", 18)],
                 ),
                 ("Identity", "Expand"),
             ),
@@ -245,131 +254,135 @@ class LlamaRuleSetsTest(unittest.TestCase):
         self, _: str, model: ir.Model, expected_nodes: tuple[str, ...]
     ):
         rule_set = llama_rule_sets.llama_p0_rule_set()
-        original_proto = ir.serde.serialize_model(model)
+        model_proto = ir.serde.serialize_model(model)
         rule_set.apply_to_model(model)
         rewritten_model = ir.serde.serialize_model(model)
 
         self.assertEqual(tuple(n.op_type for n in model.graph), expected_nodes)
-        self._check_model(original_proto, rewritten_model)
+        self._check_model(model_proto, rewritten_model)
 
-    @classmethod
-    def _unsqueeze_unsqueeze_models(cls):
-        models = [
-            onnx.helper.make_model(
-                onnx.helper.make_graph(
-                    [
-                        onnx.helper.make_node("Unsqueeze", ["X", "axes1"], ["Xu"]),
-                        onnx.helper.make_node("Unsqueeze", ["Xu", "axes2"], ["Y"]),
-                    ],
-                    "name",
-                    [onnx.helper.make_tensor_value_info("X", FLOAT, [3])],
-                    [onnx.helper.make_tensor_value_info("Y", FLOAT, [1, 3, 1])],
-                    [
-                        onnx.numpy_helper.from_array(
-                            np.array([1], dtype=np.int64), name="axes1"
-                        ),
-                        onnx.numpy_helper.from_array(
-                            np.array([0], dtype=np.int64), name="axes2"
-                        ),
-                    ],
+    @parameterized.parameterized.expand(
+        [
+            (
+                "double_unsqueezes_1",
+                _make_model(
+                    onnx.helper.make_graph(
+                        [
+                            onnx.helper.make_node("Unsqueeze", ["X", "axes1"], ["Xu"]),
+                            onnx.helper.make_node("Unsqueeze", ["Xu", "axes2"], ["Y"]),
+                        ],
+                        "name",
+                        [onnx.helper.make_tensor_value_info("X", FLOAT, [3])],
+                        [onnx.helper.make_tensor_value_info("Y", FLOAT, [1, 3, 1])],
+                        [
+                            onnx.numpy_helper.from_array(
+                                np.array([1], dtype=np.int64), name="axes1"
+                            ),
+                            onnx.numpy_helper.from_array(
+                                np.array([0], dtype=np.int64), name="axes2"
+                            ),
+                        ],
+                    ),
+                    opset_imports=[onnx.helper.make_opsetid("", 18)],
                 ),
-                opset_imports=[onnx.helper.make_opsetid("", 18)],
             ),
-            onnx.helper.make_model(
-                onnx.helper.make_graph(
-                    [
-                        onnx.helper.make_node("Unsqueeze", ["X", "axes1"], ["Xu"]),
-                        onnx.helper.make_node("Unsqueeze", ["Xu", "axes2"], ["Y"]),
-                    ],
-                    "name",
-                    [onnx.helper.make_tensor_value_info("X", FLOAT, [3])],
-                    [onnx.helper.make_tensor_value_info("Y", FLOAT, [1, 3, 1])],
-                    [
-                        onnx.numpy_helper.from_array(
-                            np.array([0], dtype=np.int64), name="axes1"
-                        ),
-                        onnx.numpy_helper.from_array(
-                            np.array([1], dtype=np.int64), name="axes2"
-                        ),
-                    ],
+            (
+                "double_unsqueezes_2",
+                _make_model(
+                    onnx.helper.make_graph(
+                        [
+                            onnx.helper.make_node("Unsqueeze", ["X", "axes1"], ["Xu"]),
+                            onnx.helper.make_node("Unsqueeze", ["Xu", "axes2"], ["Y"]),
+                        ],
+                        "name",
+                        [onnx.helper.make_tensor_value_info("X", FLOAT, [3])],
+                        [onnx.helper.make_tensor_value_info("Y", FLOAT, [1, 3, 1])],
+                        [
+                            onnx.numpy_helper.from_array(
+                                np.array([0], dtype=np.int64), name="axes1"
+                            ),
+                            onnx.numpy_helper.from_array(
+                                np.array([1], dtype=np.int64), name="axes2"
+                            ),
+                        ],
+                    ),
+                    opset_imports=[onnx.helper.make_opsetid("", 18)],
                 ),
-                opset_imports=[onnx.helper.make_opsetid("", 18)],
-            ),
-        ]
-        return models
-
-    def test_llama_p0_rule_set_unsqueeze_unsqueeze(self):
-        for model_proto in self._unsqueeze_unsqueeze_models():
-            ir_model = ir.serde.deserialize_model(model_proto)
-            rule_set = llama_rule_sets.llama_p0_rule_set()
-            rule_set.apply_to_model(ir_model)
-            rewritten_model = ir.serde.serialize_model(ir_model)
-
-            self.assertEqual(
-                ["Constant", "Unsqueeze"], [n.op_type for n in rewritten_model.graph.node]
-            )
-            self._check_model(model_proto, rewritten_model)
-
-    @classmethod
-    def _reshape_reshape_models(cls):
-        models = [
-            onnx.helper.make_model(
-                onnx.helper.make_graph(
-                    [
-                        onnx.helper.make_node("Reshape", ["X", "shape_"], ["Xu"]),
-                        onnx.helper.make_node("Reshape", ["Xu", "shape"], ["Y"]),
-                    ],
-                    "name",
-                    [onnx.helper.make_tensor_value_info("X", FLOAT, [3, 4, 5])],
-                    [onnx.helper.make_tensor_value_info("Y", FLOAT, [5, 4, 3])],
-                    [
-                        onnx.numpy_helper.from_array(
-                            np.array([4, 5, 3], dtype=np.int64), name="shape_"
-                        ),
-                        onnx.numpy_helper.from_array(
-                            np.array([5, 4, 3], dtype=np.int64), name="shape"
-                        ),
-                    ],
-                ),
-                opset_imports=[onnx.helper.make_opsetid("", 18)],
-            ),
-            onnx.helper.make_model(
-                onnx.helper.make_graph(
-                    [
-                        onnx.helper.make_node("Reshape", ["X", "shape_"], ["Xu"]),
-                        onnx.helper.make_node("Reshape", ["Xu", "shape"], ["Y"]),
-                    ],
-                    "name",
-                    [onnx.helper.make_tensor_value_info("X", FLOAT, [3, 4, 5])],
-                    [onnx.helper.make_tensor_value_info("Y", FLOAT, [5, 4, 3])],
-                    [
-                        onnx.numpy_helper.from_array(
-                            np.array([-1], dtype=np.int64), name="shape_"
-                        ),
-                        onnx.numpy_helper.from_array(
-                            np.array([5, 4, 3], dtype=np.int64), name="shape"
-                        ),
-                    ],
-                ),
-                opset_imports=[onnx.helper.make_opsetid("", 18)],
             ),
         ]
-        return models
+    )
+    def test_llama_p0_rule_set_unsqueeze_unsqueeze(self, _: str, model: ir.Model):
+        rule_set = llama_rule_sets.llama_p0_rule_set()
+        model_proto = ir.serde.serialize_model(model)
+        rule_set.apply_to_model(model)
+        rewritten_model = ir.serde.serialize_model(model)
 
-    def test_llama_p0_rule_set_reshape_reshape(self):
-        for model_proto in self._reshape_reshape_models():
-            ir_model = ir.serde.deserialize_model(model_proto)
-            rule_set = llama_rule_sets.llama_p0_rule_set()
-            rule_set.apply_to_model(ir_model)
-            rewritten_model = ir.serde.serialize_model(ir_model)
+        self.assertEqual(["Constant", "Unsqueeze"], [n.op_type for n in model.graph])
+        self._check_model(model_proto, rewritten_model)
 
-            self.assertEqual(["Reshape"], [n.op_type for n in rewritten_model.graph.node])
-            self._check_model(model_proto, rewritten_model)
+    @parameterized.parameterized.expand(
+        [
+            (
+                "double_reshape_1",
+                _make_model(
+                    onnx.helper.make_graph(
+                        [
+                            onnx.helper.make_node("Reshape", ["X", "shape_"], ["Xu"]),
+                            onnx.helper.make_node("Reshape", ["Xu", "shape"], ["Y"]),
+                        ],
+                        "name",
+                        [onnx.helper.make_tensor_value_info("X", FLOAT, [3, 4, 5])],
+                        [onnx.helper.make_tensor_value_info("Y", FLOAT, [5, 4, 3])],
+                        [
+                            onnx.numpy_helper.from_array(
+                                np.array([4, 5, 3], dtype=np.int64), name="shape_"
+                            ),
+                            onnx.numpy_helper.from_array(
+                                np.array([5, 4, 3], dtype=np.int64), name="shape"
+                            ),
+                        ],
+                    ),
+                    opset_imports=[onnx.helper.make_opsetid("", 18)],
+                ),
+            ),
+            (
+                "double_reshape_2",
+                _make_model(
+                    onnx.helper.make_graph(
+                        [
+                            onnx.helper.make_node("Reshape", ["X", "shape_"], ["Xu"]),
+                            onnx.helper.make_node("Reshape", ["Xu", "shape"], ["Y"]),
+                        ],
+                        "name",
+                        [onnx.helper.make_tensor_value_info("X", FLOAT, [3, 4, 5])],
+                        [onnx.helper.make_tensor_value_info("Y", FLOAT, [5, 4, 3])],
+                        [
+                            onnx.numpy_helper.from_array(
+                                np.array([-1], dtype=np.int64), name="shape_"
+                            ),
+                            onnx.numpy_helper.from_array(
+                                np.array([5, 4, 3], dtype=np.int64), name="shape"
+                            ),
+                        ],
+                    ),
+                    opset_imports=[onnx.helper.make_opsetid("", 18)],
+                ),
+            ),
+        ]
+    )
+    def test_llama_p0_rule_set_reshape_reshape(self, _: str, model: ir.Model):
+        rule_set = llama_rule_sets.llama_p0_rule_set()
+        model_proto = ir.serde.serialize_model(model)
+        rule_set.apply_to_model(model)
+        rewritten_model = ir.serde.serialize_model(model)
+
+        self.assertEqual(["Reshape"], [n.op_type for n in model.graph])
+        self._check_model(model_proto, rewritten_model)
 
     @classmethod
     def _slides_split_models(cls):
         models = [
-            onnx.helper.make_model(
+            _make_model(
                 onnx.helper.make_graph(
                     [
                         onnx.helper.make_node(


### PR DESCRIPTION
ExpandIdentity may fail if x_shape is None. This change fixes it.

- Also created parameterized tests