### PR TITLE
Update opgen for it to be runnable

### DIFF
--- a/opgen/README.md
+++ b/opgen/README.md
@@ -1,0 +1,17 @@
+# Generator for onnx_opset
+
+Use this module the generate onnx_opset implementations when new opsets are introduced with new ONNX versions.
+
+## Generate
+
+```sh
+python opgen
+```
+
+Run
+
+```sh
+python opgen -h
+```
+
+for more information.

--- a/opgen/__main__.py
+++ b/opgen/__main__.py
@@ -9,7 +9,7 @@ import subprocess
 import textwrap
 from pathlib import Path
 
-from opgen.onnx_opset_builder import (
+from onnx_opset_builder import (
     OpsetId,
     OpsetsBuilder,
     format_opsetid,

--- a/opgen/onnx_opset_builder.py
+++ b/opgen/onnx_opset_builder.py
@@ -17,7 +17,7 @@ from onnx.defs import (
 )
 from onnx.helper import get_attribute_value
 
-import opgen.pygen as cg
+import pygen as cg
 
 __all__ = [
     "OpsetId",

--- a/opgen/onnx_opset_builder.py
+++ b/opgen/onnx_opset_builder.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Annotated, Any, Iterable, Optional, Set, TextIO
 
+import pygen as cg
 from onnx.defs import (
     AttributeProto,
     OpSchema,
@@ -16,8 +17,6 @@ from onnx.defs import (
     onnx_opset_version,
 )
 from onnx.helper import get_attribute_value
-
-import pygen as cg
 
 __all__ = [
     "OpsetId",


### PR DESCRIPTION
Previously the opgen module assumes that it is installed as a package and can be found at script import. Since we are now just running it as a standalone script, I updated to imports so that it can be run directly. Added a README.