### PR TITLE
[rewriter] Remove redundant op.Slice and op.ScatterND

### DIFF
--- a/onnxscript/optimizer/_optimizer.py
+++ b/onnxscript/optimizer/_optimizer.py
@@ -10,6 +10,7 @@ from onnxscript.optimizer._remove_unused import remove_unused_nodes
 from onnxscript.rewriter import (
     broadcast_to_matmul,
     cast_constant_of_shape,
+    collapse_slices,
     gemm_to_matmul_add,
     no_op,
 )
@@ -21,6 +22,7 @@ _DEFAULT_REWRITE_RULES = [
     *broadcast_to_matmul.rules.rules,
     gemm_to_matmul_add.rule,
     *cast_constant_of_shape.rules.rules,
+    *collapse_slices.rules.rules,
 ]
 
 

--- a/onnxscript/rewriter/collapse_slices.py
+++ b/onnxscript/rewriter/collapse_slices.py
@@ -11,7 +11,7 @@ from onnxscript.rewriter import pattern
 logger = logging.getLogger(__name__)
 
 
-def check_if_redundant_slice(
+def _check_if_redundant_slice(
     context,
     data: ir.Value,
     starts: ir.Value,
@@ -23,112 +23,92 @@ def check_if_redundant_slice(
     """If the starts is 0, and the ends is equal to or grater than the shape of the specified axis, then the slice is redundant."""
     del context  # Reserved for future extensions
 
-    starts = starts.const_value
-    ends = ends.const_value
-    axes = axes.const_value
-    steps = steps.const_value
+    starts_const = starts.const_value
+    ends_const = ends.const_value
+    axes_const = axes.const_value
+    steps_const = steps.const_value
 
-    if starts is None or ends is None or axes is None or steps is None:
+    if starts_const is None or ends_const is None or axes_const is None or steps_const is None:
         logger.info("The value 'start', 'end', 'axis', 'step' is not statically known.")
         return False
-
-    if steps.numpy().item() != 1:
+    if steps_const.numpy().item() != 1:
         return False
-
-    if starts.numpy().item() != 0:
+    # starts is 0
+    if starts_const.numpy().item() != 0:
         return False
-
-    if ends.numpy().item() == sys.maxsize:
+    # In case data.shape is not statically known, we still can tell the slice is redundant if ends is sys.maxsize
+    if ends_const.numpy().item() == sys.maxsize:
         return True
-
     if data.shape is None:
         logger.info("The value 'data' shape is not statically known.")
         return False
-
-    if ends.numpy().item() < data.shape[axes.numpy().item()]:
+    if ends_const.numpy().item() < data.shape[axes_const.numpy().item()]:
         return False
 
     return True
 
 
-def _identity(op, data, **_):
+def _identity_to_itself(op, data, **_):
     return op.Identity(data)
+
+
+def _identity_to_updates(op, data, indices, updates, **_):
+    return op.Identity(updates)
 
 
 def _potential_redundant_slice(op, data, starts, ends, axes, steps):
     return op.Slice(data, starts, ends, axes, steps)
 
 
-def _slice(op, data_a, starts_a, ends_a, axes_a, steps_a, starts_b, ends_b, axes_b, steps_b):
-    new_axes = op.Concat(axes_a, axes_b, axis=0)
-    return op.Slice(data_a, starts_a, ends_a, new_axes, steps_a)
+def _potential_redundant_scatternd(op, data, indices, updates):
+    return op.ScatterND(data, indices, updates)
 
 
-def _two_consecutive_slices_pattern(
-    op, data_a, starts_a, ends_a, axes_a, steps_a, starts_b, ends_b, axes_b, steps_b
-):
-    intermediate = op.Slice(data_a, starts_a, ends_a, axes_a, steps_a)
-    return op.Slice(intermediate, starts_b, ends_b, axes_b, steps_b)
-
-
-def check_if_slices_are_collpasable(
+def _check_if_redundant_scatternd(
     context,
-    starts_a: ir.Value,
-    ends_a: ir.Value,
-    steps_a: ir.Value,
-    starts_b: ir.Value,
-    ends_b: ir.Value,
-    steps_b: ir.Value,
+    data: ir.Value,
+    indices: ir.Value,
+    updates: ir.Value,
     **_,
 ):
-    """
-
-    In PyTorch axes (dim) is only allowed to be scalar, but in ONNX, op.Slice accpets a list of axes.
-    Therefore, we collapse the axesof two op.Slices into a single list, when we find start, end,
-    and step are the same.
-
-    """
+    """If the indices is the same length as the first dim of data, and the shape of updates is equal to data, we can simply swap the whole value."""
     del context  # Reserved for future extensions
 
-    # cehck starts, ends, and steps are constants
-    starts_a = starts_a.const_value
-    ends_a = ends_a.const_value
-    steps_a = steps_a.const_value
-    starts_b = starts_b.const_value
-    ends_b = ends_b.const_value
-    steps_b = steps_b.const_value
-
-    if starts_a is None or ends_a is None or steps_a is None:
-        logger.info("The value 'start', 'end', 'step' is not statically known.")
+    # To validate data can be replaced directly by updates, we need to check the following:
+    # 1. they have the same shape
+    if data.shape is None:
+        logger.info("The value 'data' shape is not statically known.")
         return False
-    if starts_b is None or ends_b is None or steps_b is None:
-        logger.info("The value 'start', 'end', 'step' is not statically known.")
+    if updates.shape is None:
+        logger.info("The value 'updates' shape is not statically known.")
+        return False
+    if data.shape != updates.shape:
+        logger.info("The shape of 'data' and 'updates' are different.")
         return False
 
-    # check starts, ends, and steps are the same
-    if starts_a.numpy() != starts_b.numpy():
+    # 2. the indices is referring to the whole data, which is from 0 to data.shape[0]
+    if indices.const_value is None:
+        logger.info("The value 'indices' is not statically known.")
         return False
-    if ends_a.numpy() != ends_b.numpy():
+    if indices.const_value.numpy().tolist() != [[i] for i in range(data.shape[0])]:  # type: ignore[arg-type]
+        logger.info("The 'indices' is not referring to the whole data.")
         return False
-    if steps_a.numpy() != steps_b.numpy():
-        return False
+
     return True
 
 
 # Register the rewrite rules
 remove_redundant_slice = pattern.RewriteRule(
     _potential_redundant_slice,
-    _identity,
-    check_if_redundant_slice,
+    _identity_to_itself,
+    _check_if_redundant_slice,
 )
 
-collapse_slices_rule = pattern.RewriteRule(
-    _two_consecutive_slices_pattern,
-    _slice,
-    # We can use the same check_if_not_need_reshape function for both the rules,
-    # as one_reshape_matmul_reshape_pattern is a subset of _two_reshapes_matmul_reshape_pattern.
-    check_if_slices_are_collpasable,
+remove_redundant_scatternd = pattern.RewriteRule(
+    _potential_redundant_scatternd,
+    _identity_to_updates,
+    _check_if_redundant_scatternd,
 )
 
 # NOTE: The order of the rules is important. Larger pattern should be checked first.
-rules = pattern.RewriteRuleSet([remove_redundant_slice])
+rules = pattern.RewriteRuleSet([remove_redundant_slice, remove_redundant_scatternd])

--- a/onnxscript/rewriter/collapse_slices.py
+++ b/onnxscript/rewriter/collapse_slices.py
@@ -1,0 +1,134 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+from __future__ import annotations
+
+import logging
+import sys
+
+from onnxscript import ir
+from onnxscript.rewriter import pattern
+
+logger = logging.getLogger(__name__)
+
+
+def check_if_redundant_slice(
+    context,
+    data: ir.Value,
+    starts: ir.Value,
+    ends: ir.Value,
+    axes: ir.Value,
+    steps: ir.Value,
+    **_,
+):
+    """If the starts is 0, and the ends is equal to or grater than the shape of the specified axis, then the slice is redundant."""
+    del context  # Reserved for future extensions
+
+    starts = starts.const_value
+    ends = ends.const_value
+    axes = axes.const_value
+    steps = steps.const_value
+
+    if starts is None or ends is None or axes is None or steps is None:
+        logger.info("The value 'start', 'end', 'axis', 'step' is not statically known.")
+        return False
+
+    if steps.numpy().item() != 1:
+        return False
+
+    if starts.numpy().item() != 0:
+        return False
+
+    if ends.numpy().item() == sys.maxsize:
+        return True
+
+    if data.shape is None:
+        logger.info("The value 'data' shape is not statically known.")
+        return False
+
+    if ends.numpy().item() < data.shape[axes.numpy().item()]:
+        return False
+
+    return True
+
+
+def _identity(op, data, **_):
+    return op.Identity(data)
+
+
+def _potential_redundant_slice(op, data, starts, ends, axes, steps):
+    return op.Slice(data, starts, ends, axes, steps)
+
+
+def _slice(op, data_a, starts_a, ends_a, axes_a, steps_a, starts_b, ends_b, axes_b, steps_b):
+    new_axes = op.Concat(axes_a, axes_b, axis=0)
+    return op.Slice(data_a, starts_a, ends_a, new_axes, steps_a)
+
+
+def _two_consecutive_slices_pattern(
+    op, data_a, starts_a, ends_a, axes_a, steps_a, starts_b, ends_b, axes_b, steps_b
+):
+    intermediate = op.Slice(data_a, starts_a, ends_a, axes_a, steps_a)
+    return op.Slice(intermediate, starts_b, ends_b, axes_b, steps_b)
+
+
+def check_if_slices_are_collpasable(
+    context,
+    starts_a: ir.Value,
+    ends_a: ir.Value,
+    steps_a: ir.Value,
+    starts_b: ir.Value,
+    ends_b: ir.Value,
+    steps_b: ir.Value,
+    **_,
+):
+    """
+
+    In PyTorch axes (dim) is only allowed to be scalar, but in ONNX, op.Slice accpets a list of axes.
+    Therefore, we collapse the axesof two op.Slices into a single list, when we find start, end,
+    and step are the same.
+
+    """
+    del context  # Reserved for future extensions
+
+    # cehck starts, ends, and steps are constants
+    starts_a = starts_a.const_value
+    ends_a = ends_a.const_value
+    steps_a = steps_a.const_value
+    starts_b = starts_b.const_value
+    ends_b = ends_b.const_value
+    steps_b = steps_b.const_value
+
+    if starts_a is None or ends_a is None or steps_a is None:
+        logger.info("The value 'start', 'end', 'step' is not statically known.")
+        return False
+    if starts_b is None or ends_b is None or steps_b is None:
+        logger.info("The value 'start', 'end', 'step' is not statically known.")
+        return False
+
+    # check starts, ends, and steps are the same
+    if starts_a.numpy() != starts_b.numpy():
+        return False
+    if ends_a.numpy() != ends_b.numpy():
+        return False
+    if steps_a.numpy() != steps_b.numpy():
+        return False
+    return True
+
+
+# Register the rewrite rules
+remove_redundant_slice = pattern.RewriteRule(
+    _potential_redundant_slice,
+    _identity,
+    check_if_redundant_slice,
+)
+
+collapse_slices_rule = pattern.RewriteRule(
+    _two_consecutive_slices_pattern,
+    _slice,
+    # We can use the same check_if_not_need_reshape function for both the rules,
+    # as one_reshape_matmul_reshape_pattern is a subset of _two_reshapes_matmul_reshape_pattern.
+    check_if_slices_are_collpasable,
+)
+
+# NOTE: The order of the rules is important. Larger pattern should be checked first.
+rules = pattern.RewriteRuleSet([remove_redundant_slice])

--- a/onnxscript/rewriter/collapse_slices.py
+++ b/onnxscript/rewriter/collapse_slices.py
@@ -19,7 +19,7 @@ def _check_if_redundant_slice(
     axes: ir.Value,
     steps: ir.Value,
     **_,
-):
+) -> bool:
     """If the starts is 0, and the ends is equal to or grater than the shape of the specified axis, then the slice is redundant."""
     del context  # Reserved for future extensions
 

--- a/onnxscript/rewriter/collapse_slices.py
+++ b/onnxscript/rewriter/collapse_slices.py
@@ -29,16 +29,16 @@ def _check_if_redundant_slice(
     steps_const = steps.const_value
 
     # Check if the values are scalar
-    if starts_const.numpy().size != 1:
+    if starts_const.numpy().size != 1:  # type: ignore[union-attr]
         logger.info("The value 'start' is not a scalar.")
         return False
-    if ends_const.numpy().size != 1:
+    if ends_const.numpy().size != 1:  # type: ignore[union-attr]
         logger.info("The value 'end' is not a scalar.")
         return False
-    if axes_const.numpy().size != 1:
+    if axes_const.numpy().size != 1:  # type: ignore[union-attr]
         logger.info("The value 'axis' is not a scalar.")
         return False
-    if steps_const.numpy().size != 1:
+    if steps_const.numpy().size != 1:  # type: ignore[union-attr]
         logger.info("The value 'step' is not a scalar.")
         return False
 

--- a/onnxscript/rewriter/collapse_slices_test.py
+++ b/onnxscript/rewriter/collapse_slices_test.py
@@ -4,73 +4,75 @@ from __future__ import annotations
 
 import unittest
 
+import numpy as np
 import onnx.parser
 import onnx.shape_inference
 
 from onnxscript import ir
 from onnxscript.rewriter import collapse_slices
 
-
-def _infer_shapes(model: ir.Model) -> ir.Model:
-    """Run shape inference on the IR model."""
-    # TODO: Update when shape inference is supported on the IR
-    return ir.serde.deserialize_model(
-        onnx.shape_inference.infer_shapes(ir.serde.serialize_model(model))
-    )
+_INT64_MAX = 9223372036854775807
 
 
 class TwoReshapesMatMulReshapeTest(unittest.TestCase):
-    def test_two_consecutive_slices_with_only_axes_difference_should_be_collpased_to_one(self):
+    def test_slice_is_redundant_when_ends_is_greater_than_input_shape(self):
         model_proto = onnx.parser.parse_model(
             """
             <ir_version: 7, opset_import: [ "" : 17]>
-            agraph (float[512, 16, 112, 112] data_a) => (float[512, 16, 112, 112] output)
+            agraph (float[512, 16, 112, 112] data) => (float[512, 16, 112, 112] output)
             {
-                starts_a = Constant<value: tensor = int64[1] {0}>()
-                starts_b = Constant<value: tensor = int64[1] {0}>()
-                ends_a = Constant<value: tensor = int64[1] {999}>()
-                ends_b = Constant<value: tensor = int64[1] {999}>()
-                axes_a = Constant<value: tensor = int64[1] {0}>()
-                axes_b = Constant<value: tensor = int64[1] {2}>()
-                steps_a = Constant<value: tensor = int64[1] {1}>()
-                steps_b = Constant<value: tensor = int64[1] {1}>()
-                intermediate = Slice (data_a, starts_a, ends_a, axes_a, steps_a)
-                output = Slice (intermediate, starts_b, ends_b, axes_b, steps_b)
+                starts = Constant<value: tensor = int64[1] {0}>()
+                ends = Constant<value: tensor = int64[1] {9999}>()
+                axes = Constant<value: tensor = int64[1] {0}>()
+                steps = Constant<value: tensor = int64[1] {1}>()
+                output = Slice (data, starts, ends, axes, steps)
             }
         """
         )
         model = ir.serde.deserialize_model(model_proto)
         count = collapse_slices.rules.apply_to_model(model)
         self.assertEqual(count, 1)
-        _infer_shapes(model)
 
-    def test_three_consecutive_slices_with_only_axes_difference_should_be_collpased_to_one(
-        self,
-    ):
+    def test_slice_is_redundant_when_ends_reaches_int64_max(self):
         model_proto = onnx.parser.parse_model(
-            """
+            f"""
             <ir_version: 7, opset_import: [ "" : 17]>
-            agraph (float[512, 16, 112, 112] data_a) => (float[512, 16, 112, 112] output)
-            {
-                starts_a = Constant<value: tensor = int64[1] {0}>()
-                starts_b = Constant<value: tensor = int64[1] {0}>()
-                starts_c = Constant<value: tensor = int64[1] {0}>()
-                ends_a = Constant<value: tensor = int64[1] {999}>()
-                ends_b = Constant<value: tensor = int64[1] {999}>()
-                ends_c = Constant<value: tensor = int64[1] {999}>()
-                axes_a = Constant<value: tensor = int64[1] {0}>()
-                axes_b = Constant<value: tensor = int64[1] {2}>()
-                axes_c = Constant<value: tensor = int64[1] {3}>()
-                steps_a = Constant<value: tensor = int64[1] {1}>()
-                steps_b = Constant<value: tensor = int64[1] {1}>()
-                steps_c = Constant<value: tensor = int64[1] {1}>()
-                intermediate_1 = Slice (data_a, starts_a, ends_a, axes_a, steps_a)
-                intermediate_2 = Slice (intermediate_1, starts_b, ends_b, axes_b, steps_b)
-                output = Slice (intermediate_2, starts_c, ends_c, axes_c, steps_c)
-            }
+            agraph (float[512, 16, 112, 112] data) => (float[512, 16, 112, 112] output)
+            {{
+                starts = Constant<value: tensor = int64[1] {{0}}>()
+                ends = Constant<value: tensor = int64[1] {{{_INT64_MAX}}}>()
+                axes = Constant<value: tensor = int64[1] {{0}}>()
+                steps = Constant<value: tensor = int64[1] {{1}}>()
+                output = Slice (data, starts, ends, axes, steps)
+            }}
         """
         )
         model = ir.serde.deserialize_model(model_proto)
         count = collapse_slices.rules.apply_to_model(model)
-        self.assertEqual(count, 2)
-        _infer_shapes(model)
+        self.assertEqual(count, 1)
+
+    def test_scatternd_is_redundant_when_it_is_updating_the_whole_input_in_order(self):
+        model_proto = onnx.parser.parse_model(
+            """
+            <ir_version: 7, opset_import: [ "" : 17]>
+            agraph (float[112, 16, 112, 512] data, float[112, 16, 112, 512] updates) => (float[112, 16, 112, 512] output)
+            {
+                output = ScatterND (data, indices, updates)
+            }
+        """
+        )
+        # Use inserted initializers to avoid manually coding the large constants
+        indices = np.arange(112).reshape(112, 1)
+        model_proto.graph.initializer.extend(
+            [
+                onnx.helper.make_tensor(
+                    "indices",
+                    onnx.TensorProto.FLOAT16,
+                    indices.shape,
+                    indices,
+                ),
+            ]
+        )
+        model = ir.serde.deserialize_model(model_proto)
+        count = collapse_slices.rules.apply_to_model(model)
+        self.assertEqual(count, 1)

--- a/onnxscript/rewriter/collapse_slices_test.py
+++ b/onnxscript/rewriter/collapse_slices_test.py
@@ -1,0 +1,76 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+from __future__ import annotations
+
+import unittest
+
+import onnx.parser
+import onnx.shape_inference
+
+from onnxscript import ir
+from onnxscript.rewriter import collapse_slices
+
+
+def _infer_shapes(model: ir.Model) -> ir.Model:
+    """Run shape inference on the IR model."""
+    # TODO: Update when shape inference is supported on the IR
+    return ir.serde.deserialize_model(
+        onnx.shape_inference.infer_shapes(ir.serde.serialize_model(model))
+    )
+
+
+class TwoReshapesMatMulReshapeTest(unittest.TestCase):
+    def test_two_consecutive_slices_with_only_axes_difference_should_be_collpased_to_one(self):
+        model_proto = onnx.parser.parse_model(
+            """
+            <ir_version: 7, opset_import: [ "" : 17]>
+            agraph (float[512, 16, 112, 112] data_a) => (float[512, 16, 112, 112] output)
+            {
+                starts_a = Constant<value: tensor = int64[1] {0}>()
+                starts_b = Constant<value: tensor = int64[1] {0}>()
+                ends_a = Constant<value: tensor = int64[1] {999}>()
+                ends_b = Constant<value: tensor = int64[1] {999}>()
+                axes_a = Constant<value: tensor = int64[1] {0}>()
+                axes_b = Constant<value: tensor = int64[1] {2}>()
+                steps_a = Constant<value: tensor = int64[1] {1}>()
+                steps_b = Constant<value: tensor = int64[1] {1}>()
+                intermediate = Slice (data_a, starts_a, ends_a, axes_a, steps_a)
+                output = Slice (intermediate, starts_b, ends_b, axes_b, steps_b)
+            }
+        """
+        )
+        model = ir.serde.deserialize_model(model_proto)
+        count = collapse_slices.rules.apply_to_model(model)
+        self.assertEqual(count, 1)
+        _infer_shapes(model)
+
+    def test_three_consecutive_slices_with_only_axes_difference_should_be_collpased_to_one(
+        self,
+    ):
+        model_proto = onnx.parser.parse_model(
+            """
+            <ir_version: 7, opset_import: [ "" : 17]>
+            agraph (float[512, 16, 112, 112] data_a) => (float[512, 16, 112, 112] output)
+            {
+                starts_a = Constant<value: tensor = int64[1] {0}>()
+                starts_b = Constant<value: tensor = int64[1] {0}>()
+                starts_c = Constant<value: tensor = int64[1] {0}>()
+                ends_a = Constant<value: tensor = int64[1] {999}>()
+                ends_b = Constant<value: tensor = int64[1] {999}>()
+                ends_c = Constant<value: tensor = int64[1] {999}>()
+                axes_a = Constant<value: tensor = int64[1] {0}>()
+                axes_b = Constant<value: tensor = int64[1] {2}>()
+                axes_c = Constant<value: tensor = int64[1] {3}>()
+                steps_a = Constant<value: tensor = int64[1] {1}>()
+                steps_b = Constant<value: tensor = int64[1] {1}>()
+                steps_c = Constant<value: tensor = int64[1] {1}>()
+                intermediate_1 = Slice (data_a, starts_a, ends_a, axes_a, steps_a)
+                intermediate_2 = Slice (intermediate_1, starts_b, ends_b, axes_b, steps_b)
+                output = Slice (intermediate_2, starts_c, ends_c, axes_c, steps_c)
+            }
+        """
+        )
+        model = ir.serde.deserialize_model(model_proto)
+        count = collapse_slices.rules.apply_to_model(model)
+        self.assertEqual(count, 2)
+        _infer_shapes(model)

--- a/onnxscript/rewriter/collapse_slices_test.py
+++ b/onnxscript/rewriter/collapse_slices_test.py
@@ -36,7 +36,7 @@ class TwoReshapesMatMulReshapeTest(unittest.TestCase):
         self.assertIn("Identity", [node.op_type for node in model.graph])
         testing.assert_numerically_equal(
             model_proto,
-            ir.serde.serialize_model(model),
+            model,
             (np.random.rand(512, 16, 112).astype(np.float32),),
         )
 
@@ -61,7 +61,7 @@ class TwoReshapesMatMulReshapeTest(unittest.TestCase):
         self.assertIn("Identity", [node.op_type for node in model.graph])
         testing.assert_numerically_equal(
             model_proto,
-            ir.serde.serialize_model(model),
+            model,
             (np.random.rand(512, 16, 112).astype(np.float32),),
         )
 
@@ -95,6 +95,4 @@ class TwoReshapesMatMulReshapeTest(unittest.TestCase):
         self.assertIn("Identity", [node.op_type for node in model.graph])
 
         input = np.random.rand(112, 16, 512).astype(np.float32)
-        testing.assert_numerically_equal(
-            original_model_proto, ir.serde.serialize_model(model), (input, input)
-        )
+        testing.assert_numerically_equal(original_model_proto, model, (input, input))

--- a/onnxscript/rewriter/no_op.py
+++ b/onnxscript/rewriter/no_op.py
@@ -32,7 +32,7 @@ def dropout_inference(op, x):
 
 
 # Replacement
-def identity(op, x):
+def identity(op, x, **_):
     return op.Identity(x)
 
 

--- a/onnxscript/rewriter/testing.py
+++ b/onnxscript/rewriter/testing.py
@@ -1,0 +1,52 @@
+import onnxruntime as ort
+import numpy as np
+import onnx
+from typing import Any
+
+def assert_numerically_equal(original_model_proto: onnx.ModelProto, the_rewritten_model_proto: onnx.ModelProto,
+    args: tuple[Any, ...],
+    rtol: float = 1,
+    atol: float = 1e-3,
+    ):
+    """Assert that the two models are numerically equal.
+
+    Args:
+        original_model_proto (onnx.ModelProto): The original model proto.
+        the_rewritten_model_proto (onnx.ModelProto): The rewritten by the rules model proto.
+        rtol: Relative tolerance.
+        atol: Absolute tolerance.
+        args: The positional arguments to pass to the model.
+    """
+    original_proto_ort_inputs = {
+        k.name: v for k, v in zip(original_model_proto.graph.input, args)
+    }
+    original_proto_ort_inference_session = _ort_session_initializer(original_model_proto.SerializeToString())
+    run_options = ort.RunOptions()
+    run_options.log_severity_level = 3  # 3: Error
+    original_outputs = original_proto_ort_inference_session.run(None, original_proto_ort_inputs, run_options=run_options)
+
+    the_rewritten_proto_ort_inputs = {
+        k.name: v for k, v in zip(the_rewritten_model_proto.graph.input, args)
+    }
+    the_rewritten_proto_ort_inference_session = _ort_session_initializer(the_rewritten_model_proto.SerializeToString())
+    the_rewritten_outputs = the_rewritten_proto_ort_inference_session.run(None, the_rewritten_proto_ort_inputs, run_options=run_options)
+
+    np.testing.assert_allclose(original_outputs, the_rewritten_outputs, rtol=rtol, atol=atol, equal_nan=True)
+
+def _ort_session_initializer(model: str | bytes) -> ort.InferenceSession:
+    """Initialize an ONNX Runtime inference session with the specified model."""
+    import onnxruntime as ort
+
+    session_options = ort.SessionOptions()
+    session_options.log_severity_level = 3  # 3: Error
+    possible_providers = (
+        "CUDAExecutionProvider",
+        "CPUExecutionProvider",
+    )
+    available_providers = set(ort.get_available_providers())
+    providers = [
+        provider for provider in possible_providers if provider in available_providers
+    ]
+    return ort.InferenceSession(
+        model, providers=providers, sess_options=session_options
+    )

--- a/onnxscript/rewriter/testing.py
+++ b/onnxscript/rewriter/testing.py
@@ -1,13 +1,20 @@
-import onnxruntime as ort
-import numpy as np
-import onnx
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 from typing import Any
 
-def assert_numerically_equal(original_model_proto: onnx.ModelProto, the_rewritten_model_proto: onnx.ModelProto,
+import numpy as np
+import onnx
+import onnxruntime as ort
+
+
+def assert_numerically_equal(
+    original_model_proto: onnx.ModelProto,
+    the_rewritten_model_proto: onnx.ModelProto,
     args: tuple[Any, ...],
     rtol: float = 1,
     atol: float = 1e-3,
-    ):
+):
     """Assert that the two models are numerically equal.
 
     Args:
@@ -20,18 +27,29 @@ def assert_numerically_equal(original_model_proto: onnx.ModelProto, the_rewritte
     original_proto_ort_inputs = {
         k.name: v for k, v in zip(original_model_proto.graph.input, args)
     }
-    original_proto_ort_inference_session = _ort_session_initializer(original_model_proto.SerializeToString())
+    original_proto_ort_inference_session = _ort_session_initializer(
+        original_model_proto.SerializeToString()
+    )
     run_options = ort.RunOptions()
     run_options.log_severity_level = 3  # 3: Error
-    original_outputs = original_proto_ort_inference_session.run(None, original_proto_ort_inputs, run_options=run_options)
+    original_outputs = original_proto_ort_inference_session.run(
+        None, original_proto_ort_inputs, run_options=run_options
+    )
 
     the_rewritten_proto_ort_inputs = {
         k.name: v for k, v in zip(the_rewritten_model_proto.graph.input, args)
     }
-    the_rewritten_proto_ort_inference_session = _ort_session_initializer(the_rewritten_model_proto.SerializeToString())
-    the_rewritten_outputs = the_rewritten_proto_ort_inference_session.run(None, the_rewritten_proto_ort_inputs, run_options=run_options)
+    the_rewritten_proto_ort_inference_session = _ort_session_initializer(
+        the_rewritten_model_proto.SerializeToString()
+    )
+    the_rewritten_outputs = the_rewritten_proto_ort_inference_session.run(
+        None, the_rewritten_proto_ort_inputs, run_options=run_options
+    )
 
-    np.testing.assert_allclose(original_outputs, the_rewritten_outputs, rtol=rtol, atol=atol, equal_nan=True)
+    np.testing.assert_allclose(
+        original_outputs, the_rewritten_outputs, rtol=rtol, atol=atol, equal_nan=True
+    )
+
 
 def _ort_session_initializer(model: str | bytes) -> ort.InferenceSession:
     """Initialize an ONNX Runtime inference session with the specified model."""
@@ -47,6 +65,4 @@ def _ort_session_initializer(model: str | bytes) -> ort.InferenceSession:
     providers = [
         provider for provider in possible_providers if provider in available_providers
     ]
-    return ort.InferenceSession(
-        model, providers=providers, sess_options=session_options
-    )
+    return ort.InferenceSession(model, providers=providers, sess_options=session_options)


### PR DESCRIPTION
Fixes https://github.com/microsoft/onnx-converters-private/issues/270

It is observed that ExportedProgram could generates aten::slice.Tensor and aten::slice_scatter.default that slice nothing:

![Screenshot 2024-10-29 112157](https://github.com/user-attachments/assets/6274e71c-f5a8-4fdc-b885-ff1365b4c245)

The slices would result in redundant op.Slice ops in ONNX graph that does nothing, and op.ScatterND that basically replaces the whole input to updates, which takes a lot of time in inference.

This rule set recognizes the redundant slices by checking if the following requirements are met:
(1) starts = 0
(2) ends >= inputs[dim].shape or ends == _INT64_MAX 
(3) steps == 1

This rule set recognizes the redundant scatterND by checking if the following requirements are met:
(1) indices has the same length as the first dim of input
(2) indices is from 0 to input.shape[0]
(3)input has the same shape as updates


Benchmark on ghostnet_100 (the original speed up was 0.0256):
|| Stat       | Speedup | Increase  | Med    |
|-------|---------------|------------|-----------|-----------|
|      Suite  | Model Name  | onnx_dynamo | onnx_dynamo | onnx_dynamo |
| Timm  | ghostnet_100  | 1.1599     | 15.986%   | 1.1580    |
