### PR TITLE
[IR] Create tensor adapters

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -32,8 +32,8 @@ COMMON_TEST_DEPENDENCIES = (
 )
 ONNX = "onnx==1.16"
 ONNX_RUNTIME = "onnxruntime==1.17.1"
-PYTORCH = "torch==2.2.2"
-TORCHVISON = "torchvision==0.17.2"
+PYTORCH = "torch==2.3.1"
+TORCHVISON = "torchvision==0.18.1"
 TRANSFORMERS = "transformers==4.37.2"
 ONNX_RUNTIME_NIGHTLY_DEPENDENCIES = (
     "flatbuffers",

--- a/onnxscript/ir/tensor_adapters.py
+++ b/onnxscript/ir/tensor_adapters.py
@@ -1,0 +1,87 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Compatible adapters implementing the TensorProtocol interface for various framework tensor types."""
+
+# NOTE: DO NOT import any framework-specific modules here in the global namespace.
+
+from __future__ import annotations
+
+import ctypes
+from typing import TYPE_CHECKING, Any
+
+import numpy.typing as npt
+
+from onnxscript import ir
+
+if TYPE_CHECKING:
+    import torch
+
+
+class TorchTensor(ir.Tensor):
+    def __init__(self, tensor: torch.Tensor, name: str | None = None):
+        # Pass the tensor as the raw data to ir.Tensor's constructor
+        import torch
+
+        _TORCH_DTYPE_TO_ONNX: dict[torch.dtype, ir.DataType] = {
+            torch.bfloat16: ir.DataType.BFLOAT16,
+            torch.bool: ir.DataType.BOOL,
+            torch.complex128: ir.DataType.COMPLEX128,
+            torch.complex64: ir.DataType.COMPLEX64,
+            torch.float16: ir.DataType.FLOAT16,
+            torch.float32: ir.DataType.FLOAT,
+            torch.float64: ir.DataType.DOUBLE,
+            torch.float8_e4m3fn: ir.DataType.FLOAT8E4M3FN,
+            torch.float8_e4m3fnuz: ir.DataType.FLOAT8E4M3FNUZ,
+            torch.float8_e5m2: ir.DataType.FLOAT8E5M2,
+            torch.float8_e5m2fnuz: ir.DataType.FLOAT8E5M2FNUZ,
+            torch.int16: ir.DataType.INT16,
+            torch.int32: ir.DataType.INT32,
+            torch.int64: ir.DataType.INT64,
+            torch.int8: ir.DataType.INT8,
+            torch.uint8: ir.DataType.UINT8,
+            torch.uint16: ir.DataType.UINT16,
+            torch.uint32: ir.DataType.UINT32,
+            torch.uint64: ir.DataType.UINT64,
+        }
+        super().__init__(tensor, dtype=_TORCH_DTYPE_TO_ONNX[tensor.dtype], name=name)
+
+    def numpy(self) -> npt.NDArray:
+        import torch
+
+        self.raw: torch.Tensor
+        if self.dtype == ir.DataType.BFLOAT16:
+            return self.raw.view(torch.uint16).numpy(force=True)
+        if self.dtype in {
+            ir.DataType.FLOAT8E4M3FN,
+            ir.DataType.FLOAT8E4M3FNUZ,
+            ir.DataType.FLOAT8E5M2,
+            ir.DataType.FLOAT8E5M2FNUZ,
+        }:
+            # TODO: Use ml_dtypes
+            return self.raw.view(torch.uint8).numpy(force=True)
+        return self.raw.numpy(force=True)
+
+    def __array__(self, dtype: Any = None, copy: bool | None = None) -> npt.NDArray:
+        del copy  # Unused, but needed for the signature
+        if dtype is None:
+            return self.numpy()
+        return self.numpy().__array__(dtype)
+
+    def tobytes(self) -> bytes:
+        # Implement tobytes to support native PyTorch types so we can use types like bloat16
+        # Reading from memory directly is also more efficient because
+        # it avoids copying to a NumPy array
+        import torch._subclasses.fake_tensor
+
+        if isinstance(self.raw, torch._subclasses.fake_tensor.FakeTensor):
+            raise TypeError(
+                f"Cannot take content out from the FakeTensor ('{self.name}'). Please replace the tensor "
+                "with a tensor backed by real data using ONNXProgram.apply_weights() "
+                "or save the model without initializers by setting include_initializers=False."
+            )
+        tensor = self.raw.detach().cpu().contiguous()
+        return bytes(
+            (ctypes.c_ubyte * tensor.element_size() * tensor.numel()).from_address(
+                tensor.data_ptr()
+            )
+        )

--- a/onnxscript/ir/tensor_adapters.py
+++ b/onnxscript/ir/tensor_adapters.py
@@ -1,6 +1,26 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-"""Compatible adapters implementing the TensorProtocol interface for various framework tensor types."""
+"""Compatible adapters implementing the TensorProtocol interface for various framework tensor types.
+
+This module provides public classes that implement the :class:`onnxscript.ir.TensorProtocol`
+interface for various tensor types from popular deep learning frameworks.
+
+You can use these classes to create tensors and use them in the IR graph like any other tensor.
+
+Example::
+    import torch
+    from onnxscript import ir
+
+    # Create a PyTorch tensor
+    torch_tensor = torch.tensor([1, 2, 3])
+
+    # Wrap the PyTorch tensor in a TorchTensor object
+    ir_tensor = ir.tensor_adapters.TorchTensor(torch_tensor)
+
+    # Use the IR tensor in the graph
+    attr = ir.AttrTensor("x", ir_tensor)
+    print(attr)
+"""
 
 # NOTE: DO NOT import any framework-specific modules here in the global namespace.
 
@@ -73,13 +93,17 @@ class TorchTensor(ir.Tensor):
         # it avoids copying to a NumPy array
         import torch._subclasses.fake_tensor
 
-        if isinstance(self.raw, torch._subclasses.fake_tensor.FakeTensor):
+        with torch._subclasses.fake_tensor.unset_fake_temporarily():
+            # Disable any fake mode so calling detach() etc. will return a real tensor
+            tensor = self.raw.detach().cpu().contiguous()
+
+        if isinstance(tensor, torch._subclasses.fake_tensor.FakeTensor):
             raise TypeError(
                 f"Cannot take content out from the FakeTensor ('{self.name}'). Please replace the tensor "
                 "with a tensor backed by real data using ONNXProgram.apply_weights() "
                 "or save the model without initializers by setting include_initializers=False."
             )
-        tensor = self.raw.detach().cpu().contiguous()
+
         return bytes(
             (ctypes.c_ubyte * tensor.element_size() * tensor.numel()).from_address(
                 tensor.data_ptr()

--- a/onnxscript/ir/tensor_adapters.py
+++ b/onnxscript/ir/tensor_adapters.py
@@ -22,6 +22,8 @@ Example::
     print(attr)
 """
 
+# pylint: disable=import-outside-toplevel
+
 # NOTE: DO NOT import any framework-specific modules here in the global namespace.
 
 from __future__ import annotations
@@ -93,11 +95,11 @@ class TorchTensor(ir.Tensor):
         # it avoids copying to a NumPy array
         import torch._subclasses.fake_tensor
 
-        with torch._subclasses.fake_tensor.unset_fake_temporarily():
+        with torch._subclasses.fake_tensor.unset_fake_temporarily():  # pylint: disable=protected-access
             # Disable any fake mode so calling detach() etc. will return a real tensor
             tensor = self.raw.detach().cpu().contiguous()
 
-        if isinstance(tensor, torch._subclasses.fake_tensor.FakeTensor):
+        if isinstance(tensor, torch._subclasses.fake_tensor.FakeTensor):  # pylint: disable=protected-access
             raise TypeError(
                 f"Cannot take content out from the FakeTensor ('{self.name}'). Please replace the tensor "
                 "with a tensor backed by real data using ONNXProgram.apply_weights() "

--- a/onnxscript/ir/tensor_adapters.py
+++ b/onnxscript/ir/tensor_adapters.py
@@ -28,6 +28,10 @@ Example::
 
 from __future__ import annotations
 
+__all__ = [
+    "TorchTensor",
+]
+
 import ctypes
 from typing import TYPE_CHECKING, Any
 

--- a/onnxscript/ir/tensor_adapters_test.py
+++ b/onnxscript/ir/tensor_adapters_test.py
@@ -1,0 +1,72 @@
+"""Unit tests for the tensor_adapters module."""
+
+from __future__ import annotations
+
+import unittest
+import numpy as np
+
+import torch
+from onnxscript.ir import tensor_adapters
+import parameterized
+
+
+class TorchTensorTest(unittest.TestCase):
+    @parameterized.parameterized.expand(
+        [
+            (torch.bfloat16, np.uint16),
+            (torch.bool, np.bool_),
+            (torch.complex128, np.complex128),
+            (torch.complex64, np.complex64),
+            (torch.float16, np.float16),
+            (torch.float32, np.float32),
+            (torch.float64, np.float64),
+            (torch.float8_e4m3fn, np.uint8),
+            (torch.float8_e4m3fnuz, np.uint8),
+            (torch.float8_e5m2, np.uint8),
+            (torch.float8_e5m2fnuz, np.uint8),
+            (torch.int16, np.int16),
+            (torch.int32, np.int32),
+            (torch.int64, np.int64),
+            (torch.int8, np.int8),
+            (torch.uint16, np.uint16),
+            (torch.uint32, np.uint32),
+            (torch.uint64, np.uint64),
+            (torch.uint8, np.uint8),
+        ],
+    )
+    def test_numpy_returns_correct_dtype(self, dtype: torch.dtype, np_dtype):
+        tensor = tensor_adapters.TorchTensor(torch.tensor([1], dtype=dtype))
+        self.assertEqual(tensor.numpy().dtype, np_dtype)
+        self.assertEqual(tensor.__array__().dtype, np_dtype)
+        self.assertEqual(np.array(tensor).dtype, np_dtype)
+
+    @parameterized.parameterized.expand(
+        [
+            (torch.bfloat16),
+            (torch.bool),
+            (torch.complex128),
+            (torch.complex64),
+            (torch.float16),
+            (torch.float32),
+            (torch.float64),
+            (torch.float8_e4m3fn),
+            (torch.float8_e4m3fnuz),
+            (torch.float8_e5m2),
+            (torch.float8_e5m2fnuz),
+            (torch.int16),
+            (torch.int32),
+            (torch.int64),
+            (torch.int8),
+            (torch.uint16),
+            (torch.uint32),
+            (torch.uint64),
+            (torch.uint8),
+        ],
+    )
+    def test_tobytes(self, dtype: torch.dtype):
+        tensor = tensor_adapters.TorchTensor(torch.tensor([1], dtype=dtype))
+        self.assertEqual(tensor.tobytes(), tensor.numpy().tobytes())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnxscript/ir/tensor_adapters_test.py
+++ b/onnxscript/ir/tensor_adapters_test.py
@@ -1,7 +1,10 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Unit tests for the tensor_adapters module."""
 
 from __future__ import annotations
 
+import importlib.util
 import unittest
 
 import numpy as np
@@ -11,6 +14,14 @@ import torch
 from onnxscript.ir import tensor_adapters
 
 
+def skip_if_no(module_name: str):
+    """Decorator to skip a test if a module is not installed."""
+    if importlib.util.find_spec(module_name) is None:
+        return unittest.skip(f"{module_name} not installed")
+    return lambda func: func
+
+
+@skip_if_no("torch")
 class TorchTensorTest(unittest.TestCase):
     @parameterized.parameterized.expand(
         [

--- a/onnxscript/ir/tensor_adapters_test.py
+++ b/onnxscript/ir/tensor_adapters_test.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import unittest
-import numpy as np
 
-import torch
-from onnxscript.ir import tensor_adapters
+import numpy as np
 import parameterized
+import torch
+
+from onnxscript.ir import tensor_adapters
 
 
 class TorchTensorTest(unittest.TestCase):

--- a/pyproject_pylint.toml
+++ b/pyproject_pylint.toml
@@ -18,6 +18,7 @@ disable = [
   "no-name-in-module",
   "redefined-builtin",              # TODO: should we avoid redefined-builtin?
   "too-few-public-methods",
+  "too-many-ancestors",
   "too-many-arguments",
   "too-many-branches",
   "too-many-instance-attributes",


### PR DESCRIPTION
Create the new public module `ir.tensor_adapters` to implement `ir.TensorProtocol` for popular frameworks so users do not have to do that again.

Next PRs will include safetensors support.

#1499