### PR TITLE
A couple of optimizer and rewriter extensions

### DIFF
--- a/onnxscript/optimizer/_constant_folding_test.py
+++ b/onnxscript/optimizer/_constant_folding_test.py
@@ -394,6 +394,45 @@ func (float[1,3] x) => (float[1,3] return_val) {
         self.assertEqual(optimized.graph.node[6].op_type, "Concat")
         onnx.checker.check_model(optimized)
 
+    @parameterized.parameterized.expand(
+        [
+            ("output = Dropout(input)",),
+            ("output = Dropout(input, zero, true)",),
+            ("output = Dropout(input, half)",),
+            ("output = Dropout(input, half, false)",),
+        ]
+    )
+    def test_dropout_identity(self, dropout_node: str):
+        if not self.using_ir:
+            return
+        model = onnx.parser.parse_model(f"""
+            <ir_version: 7, opset_import: [ "" : 17]>
+            agraph (float[N] input) => (float[N] output)
+            <float zero = {{0.0}}, float half = {{0.5}}, bool true = {{1}}, bool false = {{0}}>
+            {{
+                {dropout_node}
+            }}
+        """)
+        optimized = self._fold(model)
+        self.assertEqual(len(optimized.graph.node), 1)
+        self.assertEqual(optimized.graph.node[0].op_type, "Identity")
+
+    def test_concat_identity(self):
+        if not self.using_ir:
+            return
+        model = onnx.parser.parse_model(
+            """
+            <ir_version: 7, opset_import: [ "" : 17]>
+            agraph (float[N] x) => (float[N] z)
+            {
+                z = Concat <axis=-1> (x)
+            }
+        """
+        )
+        optimized = self._fold(model)
+        self.assertEqual(len(optimized.graph.node), 1)
+        self.assertEqual(optimized.graph.node[0].op_type, "Identity")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/onnxscript/optimizer/_constant_folding_test.py
+++ b/onnxscript/optimizer/_constant_folding_test.py
@@ -404,7 +404,7 @@ func (float[1,3] x) => (float[1,3] return_val) {
     )
     def test_dropout_identity(self, dropout_node: str):
         if not self.using_ir:
-            return
+            self.skipTest("New optimizations not supported for legacy optimizer")
         model = onnx.parser.parse_model(f"""
             <ir_version: 7, opset_import: [ "" : 17]>
             agraph (float[N] input) => (float[N] output)
@@ -419,7 +419,7 @@ func (float[1,3] x) => (float[1,3] return_val) {
 
     def test_concat_identity(self):
         if not self.using_ir:
-            return
+            self.skipTest("New optimizations not supported for legacy optimizer")
         model = onnx.parser.parse_model(
             """
             <ir_version: 7, opset_import: [ "" : 17]>

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -255,8 +255,8 @@ class OpPatternBuilder:
             inputs,
             attributes,
             _outputs,
-            _allow_other_attributes,
-            _allow_other_inputs,
+            allow_other_attributes=_allow_other_attributes,
+            allow_other_inputs=_allow_other_inputs,
         )
         self.pattern_builder.add_node(node_pattern)
         output_values = node_pattern.outputs
@@ -478,21 +478,22 @@ class NodePattern:
         inputs: Sequence[int | float | ValuePattern | None],
         attributes: dict[str, AttrPattern],
         outputs: Sequence[str | None],
+        *,
         allow_other_attributes: bool | None,
-        _allow_other_inputs: bool | None,
+        allow_other_inputs: bool | None,
     ):
         if allow_other_attributes is None:
             # Default behavior: allow other unmatched attributes in the node.
             allow_other_attributes = True
-        if _allow_other_inputs is None:
+        if allow_other_inputs is None:
             # TODO(rama): Should we default to True? For now, we preserve the current behavior.
-            _allow_other_inputs = False
+            allow_other_inputs = False
         self.domain = domain
         self.op = StringConstantPattern(op) if isinstance(op, str) else op
         self.inputs = [_to_value_pattern(x) for x in inputs]
         self.attributes = attributes
         self.allow_other_attributes = allow_other_attributes
-        self.allow_other_inputs = _allow_other_inputs
+        self.allow_other_inputs = allow_other_inputs
         # In the common case, domain and op are constants, which can be used to optimize matching.
         if isinstance(op, str) and isinstance(domain, StringConstantPattern):
             # TODO(rama): support overloaded operators.
@@ -574,8 +575,8 @@ class NodePattern:
             inputs,
             self.attributes,
             outputs,
-            self.allow_other_attributes,
-            self.allow_other_inputs,
+            allow_other_attributes=self.allow_other_attributes,
+            allow_other_inputs=self.allow_other_inputs,
         )
         node_map[self] = copied
         return copied

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -225,6 +225,7 @@ class OpPatternBuilder:
         _version: int | None = None,
         _outputs: int | list[str | None] = 1,
         _allow_other_attributes: bool | None = None,
+        _allow_other_inputs: bool | None = None,
         **kwargs,
     ):
         if _version is not None:
@@ -249,7 +250,13 @@ class OpPatternBuilder:
         inputs = [_to_value_pattern(x) for x in args]
         attributes = {name: _to_attr_pattern(value) for (name, value) in kwargs.items()}
         node_pattern = NodePattern(
-            opset_pattern, self.op_name, inputs, attributes, _outputs, _allow_other_attributes
+            opset_pattern,
+            self.op_name,
+            inputs,
+            attributes,
+            _outputs,
+            _allow_other_attributes,
+            _allow_other_inputs,
         )
         self.pattern_builder.add_node(node_pattern)
         output_values = node_pattern.outputs
@@ -472,15 +479,20 @@ class NodePattern:
         attributes: dict[str, AttrPattern],
         outputs: Sequence[str | None],
         allow_other_attributes: bool | None,
+        _allow_other_inputs: bool | None,
     ):
         if allow_other_attributes is None:
             # Default behavior: allow other unmatched attributes in the node.
             allow_other_attributes = True
+        if _allow_other_inputs is None:
+            # TODO(rama): Should we default to True? For now, we preserve the current behavior.
+            _allow_other_inputs = False
         self.domain = domain
         self.op = StringConstantPattern(op) if isinstance(op, str) else op
         self.inputs = [_to_value_pattern(x) for x in inputs]
         self.attributes = attributes
         self.allow_other_attributes = allow_other_attributes
+        self.allow_other_inputs = _allow_other_inputs
         # In the common case, domain and op are constants, which can be used to optimize matching.
         if isinstance(op, str) and isinstance(domain, StringConstantPattern):
             # TODO(rama): support overloaded operators.
@@ -557,7 +569,13 @@ class NodePattern:
             inputs = [inputs[1], inputs[0]]
         outputs = [value.name for value in self.outputs]
         copied = NodePattern(
-            self.domain, self.op, inputs, self.attributes, outputs, self.allow_other_attributes
+            self.domain,
+            self.op,
+            inputs,
+            self.attributes,
+            outputs,
+            self.allow_other_attributes,
+            self.allow_other_inputs,
         )
         node_map[self] = copied
         return copied
@@ -1022,10 +1040,16 @@ class SimplePatternMatcher(PatternMatcher):
         self._matched[pattern_node] = node
 
         # TODO: Revisit this to handle optional trailing inputs better.
-        if len(node.inputs) != len(pattern_node.inputs):
-            return self.fail(
-                "Input nums mismatch. {len(node.inputs)} vs {len(pattern_node.inputs)}"
-            )
+        if pattern_node.allow_other_inputs:
+            if len(node.inputs) < len(pattern_node.inputs):
+                return self.fail(
+                    f"Number of inputs ({len(node.inputs)}) is less than expected ({len(pattern_node.inputs)})"
+                )
+        else:
+            if len(node.inputs) != len(pattern_node.inputs):
+                return self.fail(
+                    f"Input nums mismatch. {len(node.inputs)} vs {len(pattern_node.inputs)}"
+                )
 
         for arg_value, arg_pattern in zip(node.inputs, pattern_node.inputs):
             # arg_pattern could be a Var, if it's the original arg.


### PR DESCRIPTION
A few extensions motivated by ongoing transformer fusion optimizations:

Pattern matching:
* Extend pattern-matching pattern to allow specifying that extra-inputs are allowed.

Optimizations:
* Concat (x) can be replaced by Identity(x)
* Redundant cast optimization was missing in core optimizer (though present as a llama rewrite rule).
* Dropout optimizations moved into core optimizer (from rewrite rule; rewrite rule has an issue, use of attribute instead of input, and it seemed better to move it into core optimizer).

In general, for optimizations involving a single node, the core optimizer is a better place (at least, as long as they are generic, and not backend-specific) than rewrite rules. It is more efficient.

* Fix input/output size limit of constant-folding to be number of bytes. (It is currently inconsistent, as number of bytes for one and number of elements for another).