### PR TITLE
[IR] Create getters for the Attr class

### DIFF
--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -2715,6 +2715,87 @@ class Attr(_protocols.AttributeProtocol, _display.PrettyPrintable):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.name!r}, {self.type!r}, {self.value!r})"
 
+    # Well typed getters
+    def as_float(self) -> float:
+        """Get the attribute value as a float."""
+        if not isinstance(self.value, (int, float)):
+            raise TypeError(f"Value of attribute '{self!r}' is not a float.")
+        return float(self.value)
+
+    def as_int(self) -> int:
+        """Get the attribute value as an int."""
+        if not isinstance(self.value, int):
+            raise TypeError(f"Value of attribute '{self!r}' is not an int.")
+        return self.value
+
+    def as_string(self) -> str:
+        """Get the attribute value as a string."""
+        if not isinstance(self.value, str):
+            raise TypeError(f"Value of attribute '{self!r}' is not a string.")
+        return self.value
+
+    def as_tensor(self) -> _protocols.TensorProtocol:
+        """Get the attribute value as a tensor."""
+        if not isinstance(self.value, _protocols.TensorProtocol):
+            raise TypeError(f"Value of attribute '{self!r}' is not a tensor.")
+        return self.value
+
+    def as_graph(self) -> Graph:
+        """Get the attribute value as a graph."""
+        if not isinstance(self.value, Graph):
+            raise TypeError(f"Value of attribute '{self!r}' is not a graph.")
+        return self.value
+
+    def as_floats(self) -> Sequence[float]:
+        """Get the attribute value as a sequence of floats."""
+        if not isinstance(self.value, Sequence):
+            raise TypeError(f"Value of attribute '{self!r}' is not a Sequence.")
+        if onnxscript.DEBUG:
+            if not all(isinstance(x, (int, float)) for x in self.value):
+                raise TypeError(f"Value of attribute '{self!r}' is not a Sequence of floats.")
+        # Create a copy of the list to prevent mutation
+        return list(self.value)
+
+    def as_ints(self) -> Sequence[int]:
+        """Get the attribute value as a sequence of ints."""
+        if not isinstance(self.value, Sequence):
+            raise TypeError(f"Value of attribute '{self!r}' is not a Sequence.")
+        if onnxscript.DEBUG:
+            if not all(isinstance(x, int) for x in self.value):
+                raise TypeError(f"Value of attribute '{self!r}' is not a Sequence of ints.")
+        # Create a copy of the list to prevent mutation
+        return list(self.value)
+
+    def as_strings(self) -> Sequence[str]:
+        """Get the attribute value as a sequence of strings."""
+        if not isinstance(self.value, Sequence):
+            raise TypeError(f"Value of attribute '{self!r}' is not a Sequence.")
+        if onnxscript.DEBUG:
+            if not all(isinstance(x, str) for x in self.value):
+                raise TypeError(f"Value of attribute '{self!r}' is not a Sequence of strings.")
+        # Create a copy of the list to prevent mutation
+        return list(self.value)
+
+    def as_tensors(self) -> Sequence[_protocols.TensorProtocol]:
+        """Get the attribute value as a sequence of tensors."""
+        if not isinstance(self.value, Sequence):
+            raise TypeError(f"Value of attribute '{self!r}' is not a Sequence.")
+        if onnxscript.DEBUG:
+            if not all(isinstance(x, _protocols.TensorProtocol) for x in self.value):
+                raise TypeError(f"Value of attribute '{self!r}' is not a Sequence of tensors.")
+        # Create a copy of the list to prevent mutation
+        return list(self.value)
+
+    def as_graphs(self) -> Sequence[Graph]:
+        """Get the attribute value as a sequence of graphs."""
+        if not isinstance(self.value, Sequence):
+            raise TypeError(f"Value of attribute '{self!r}' is not a Sequence.")
+        if onnxscript.DEBUG:
+            if not all(isinstance(x, Graph) for x in self.value):
+                raise TypeError(f"Value of attribute '{self!r}' is not a Sequence of graphs.")
+        # Create a copy of the list to prevent mutation
+        return list(self.value)
+
 
 # NOTE: The following functions are just for convenience
 def AttrFloat32(name: str, value: float, doc_string: str | None = None) -> Attr:

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -2718,15 +2718,13 @@ class Attr(_protocols.AttributeProtocol, _display.PrettyPrintable):
     # Well typed getters
     def as_float(self) -> float:
         """Get the attribute value as a float."""
-        if not isinstance(self.value, (int, float)):
-            raise TypeError(f"Value of attribute '{self!r}' is not a float.")
+        # Do not use isinstance check because it may prevent np.float32 etc. from being used
         return float(self.value)
 
     def as_int(self) -> int:
         """Get the attribute value as an int."""
-        if not isinstance(self.value, int):
-            raise TypeError(f"Value of attribute '{self!r}' is not an int.")
-        return self.value
+        # Do not use isinstance check because it may prevent np.int32 etc. from being used
+        return int(self.value)
 
     def as_string(self) -> str:
         """Get the attribute value as a string."""
@@ -2750,19 +2748,15 @@ class Attr(_protocols.AttributeProtocol, _display.PrettyPrintable):
         """Get the attribute value as a sequence of floats."""
         if not isinstance(self.value, Sequence):
             raise TypeError(f"Value of attribute '{self!r}' is not a Sequence.")
-        if onnxscript.DEBUG:
-            if not all(isinstance(x, (int, float)) for x in self.value):
-                raise TypeError(f"Value of attribute '{self!r}' is not a Sequence of floats.")
+        # Do not use isinstance check on elements because it may prevent np.int32 etc. from being used
         # Create a copy of the list to prevent mutation
-        return list(self.value)
+        return [float(v) for v in self.value]
 
     def as_ints(self) -> Sequence[int]:
         """Get the attribute value as a sequence of ints."""
         if not isinstance(self.value, Sequence):
             raise TypeError(f"Value of attribute '{self!r}' is not a Sequence.")
-        if onnxscript.DEBUG:
-            if not all(isinstance(x, int) for x in self.value):
-                raise TypeError(f"Value of attribute '{self!r}' is not a Sequence of ints.")
+        # Do not use isinstance check on elements because it may prevent np.int32 etc. from being used
         # Create a copy of the list to prevent mutation
         return list(self.value)
 

--- a/onnxscript/ir/_core_test.py
+++ b/onnxscript/ir/_core_test.py
@@ -1061,5 +1061,59 @@ class TypeTest(unittest.TestCase):
         self.assertEqual(type_, copy.deepcopy(type_))
 
 
+class AttrTest(unittest.TestCase):
+    """Test the Attr class."""
+
+    def test_init(self):
+        attr = _core.Attr("test", ir.AttributeType.INT, 42, doc_string="test string")
+        self.assertEqual(attr.name, "test")
+        self.assertEqual(attr.value, 42)
+        self.assertEqual(attr.type, ir.AttributeType.INT)
+        self.assertEqual(attr.doc_string, "test string")
+
+    def test_as_float(self):
+        attr = _core.Attr("test", ir.AttributeType.FLOAT, 42.0)
+        self.assertEqual(attr.as_float(), 42.0)
+
+        attr_int_value = _core.Attr("test", ir.AttributeType.FLOAT, 42)
+        self.assertEqual(attr_int_value.as_float(), 42.0)
+
+    def test_as_int(self):
+        attr = _core.Attr("test", ir.AttributeType.INT, 0)
+        self.assertEqual(attr.as_int(), 0)
+
+    def test_as_string(self):
+        attr = _core.Attr("test", ir.AttributeType.STRING, "test string")
+        self.assertEqual(attr.as_string(), "test string")
+
+    def test_as_tensor(self):
+        attr = _core.Attr("test", ir.AttributeType.TENSOR, ir.tensor([42.0]))
+        np.testing.assert_equal(attr.as_tensor().numpy(), np.array([42.0]))
+
+    def test_as_graph(self):
+        attr = _core.Attr("test", ir.AttributeType.GRAPH, _core.Graph((), (), nodes=()))
+        self.assertIsInstance(attr.as_graph(), _core.Graph)
+
+    def test_as_floats(self):
+        attr = _core.Attr("test", ir.AttributeType.FLOATS, [42.0])
+        self.assertEqual(attr.as_floats(), [42.0])
+
+    def test_as_ints(self):
+        attr = _core.Attr("test", ir.AttributeType.INTS, [42])
+        self.assertEqual(attr.as_ints(), [42])
+
+    def test_as_strings(self):
+        attr = _core.Attr("test", ir.AttributeType.STRINGS, ["test string", ""])
+        self.assertEqual(attr.as_strings(), ["test string", ""])
+
+    def test_as_tensors(self):
+        attr = _core.Attr("test", ir.AttributeType.TENSORS, [ir.tensor([42.0])])
+        np.testing.assert_equal(attr.as_tensors()[0].numpy(), np.array([42.0]))
+
+    def test_as_graphs(self):
+        attr = _core.Attr("test", ir.AttributeType.GRAPHS, [_core.Graph((), (), nodes=())])
+        self.assertIsInstance(attr.as_graphs()[0], _core.Graph)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -376,7 +376,7 @@ def if_op(node: ir.Node, op, state: OptimizerState) -> ReturnValue:
         if graph_attr.type != ir.AttributeType.GRAPH:
             return None
         assert isinstance(graph_attr, ir.Attr)
-        graph: ir.Graph = graph_attr.value
+        graph = graph_attr.as_graph()
         formal_outs = graph.outputs
         actual_outs = node.outputs
         renamings = {
@@ -801,10 +801,10 @@ class ConstantFolder:
     def visit_attribute(self, attr: ir.Attr | ir.RefAttr) -> None:
         if isinstance(attr, ir.Attr):
             if attr.type == ir.AttributeType.GRAPH:
-                self.visit_graph(attr.value)  # type: ignore[arg-type]
+                self.visit_graph(attr.as_graph())
             elif attr.type == ir.AttributeType.GRAPHS:
-                for graph in attr.value:
-                    self.visit_graph(graph)  # type: ignore[arg-type]
+                for graph in attr.as_graphs():
+                    self.visit_graph(graph)
 
     def visit_node(self, node: ir.Node, root: ir.Graph | ir.Function):
         replacement = self.process_node(node)

--- a/onnxscript/optimizer/_inliner.py
+++ b/onnxscript/optimizer/_inliner.py
@@ -81,10 +81,10 @@ class _CopyReplace:
     def clone_attr(self, key: str, attr: ir.Attr | ir.RefAttr) -> ir.Attr | ir.RefAttr | None:
         if isinstance(attr, ir.Attr):
             if attr.type == ir.AttributeType.GRAPH:
-                graph = self.clone_graph(attr.value)
+                graph = self.clone_graph(attr.as_graph())
                 return ir.Attr(key, ir.AttributeType.GRAPH, graph, doc_string=attr.doc_string)
             elif attr.type == ir.AttributeType.GRAPHS:
-                graphs = [self.clone_graph(graph) for graph in attr.value]
+                graphs = [self.clone_graph(graph) for graph in attr.as_graphs()]
                 return ir.Attr(
                     key, ir.AttributeType.GRAPHS, graphs, doc_string=attr.doc_string
                 )
@@ -297,9 +297,9 @@ class _Inliner:
                     if not isinstance(attr, ir.Attr):
                         continue
                     if attr.type == ir.AttributeType.GRAPH:
-                        self.inline_calls_in(attr.value)
+                        self.inline_calls_in(attr.as_graph())
                     elif attr.type == ir.AttributeType.GRAPHS:
-                        for graph in attr.value:
+                        for graph in attr.as_graphs():
                             self.inline_calls_in(graph)
 
 

--- a/onnxscript/optimizer/_remove_unused.py
+++ b/onnxscript/optimizer/_remove_unused.py
@@ -75,9 +75,9 @@ def process_function_or_graph(function_or_graph: ir.Function | ir.Graph) -> int:
                 if not isinstance(attr, ir.Attr):
                     continue
                 if attr.type == ir.AttributeType.GRAPH:
-                    count += process_function_or_graph(attr.value)
+                    count += process_function_or_graph(attr.as_graph())
                 elif attr.type == ir.AttributeType.GRAPHS:
-                    for graph in attr.value:
+                    for graph in attr.as_graphs():
                         count += process_function_or_graph(graph)
     return count
 


### PR DESCRIPTION
Create well typed getters for the Attr class

Previously, users need to self assert the values to be the correct type. From this PR on they can do

```py
a = attr.as_int()
b = a + 1
```

etc. with a being a well typed object