### PR TITLE
Handle input initializers correctly in constant folding

### DIFF
--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -834,6 +834,8 @@ class ConstantFolder:
             self.replace_node(node, replacement, root)
 
     def visit_graph(self, graph: ir.Graph) -> None:
+        # Track inputs that have a const_value (which is really a default-value, and should not
+        # be used for constant-folding).
         self._state.push_initializer_inputs()
         for input in graph.inputs:
             if input.const_value is not None:

--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -768,7 +768,7 @@ class ConstantFolder:
         if any(x is None for x in input_values):
             return None
 
-        if any(self._state.is_initializer_input(x) for x in node.inputs):
+        if any(self._state.is_initializer_input(x) for x in node.inputs):  # type: ignore[arg-type]
             return None
 
         if any(input.nbytes > self._input_size_limit for input in input_values):  # type: ignore[union-attr]

--- a/onnxscript/optimizer/_constant_folding_test.py
+++ b/onnxscript/optimizer/_constant_folding_test.py
@@ -6,6 +6,7 @@ import onnx
 import parameterized
 import pytest
 
+import onnxscript.ir as ir
 import onnxscript.optimizer as optimizer
 from onnxscript.ir import serde
 from onnxscript.optimizer import _constant_folding
@@ -432,6 +433,29 @@ func (float[1,3] x) => (float[1,3] return_val) {
         optimized = self._fold(model)
         self.assertEqual(len(optimized.graph.node), 1)
         self.assertEqual(optimized.graph.node[0].op_type, "Identity")
+
+
+class FoldConstantsIrTest(unittest.TestCase):
+    def _fold(self, model_text: str, onnx_shape_inference=False) -> ir.Model:
+        model_proto = onnx.parser.parse_model(model_text)
+        model = serde.deserialize_model(model_proto)
+        _constant_folding.fold_constants(model, onnx_shape_inference=onnx_shape_inference)
+        optimizer.remove_unused_nodes(model)
+        return model
+
+    def test_initializer_input_not_folded(self):
+        model_text = """
+            <ir_version: 7, opset_import: [ "" : 18]>
+            agraph (float[N] x, float[1] c = {1.0} ) => (float[N] z)
+            {
+                # c is not a constant, and following should not be folded.
+                two_c = Add (c, c)
+                z = Mul (x, two_c)
+            }
+            """
+        optimized = self._fold(model_text)
+        self.assertEqual(len(optimized.graph), 2)
+        self.assertEqual(optimized.graph.node(0).op_type, "Add")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Values that are both inputs and initializers of a model/graph should not be treated as constants (and cannot be used for constant-folding). Unfortunately, the single `const_value` field is class Value is used both to indicate constant-values of proper constants as well as initializer values of initializers. Ideally, the IR should provide an easy way to distinguish this at the value level (with either an extra boolean flag to indicate the value is an input-value or by using distinct fields for "initializer_value" and "const_value".

Meanwhile, this PR introduces a workaround to handle the main issue.