### PR TITLE
Improve handling of trailing optional inputs in pattern matching

### DIFF
--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -1040,19 +1040,14 @@ class SimplePatternMatcher(PatternMatcher):
 
         self._matched[pattern_node] = node
 
-        # TODO: Revisit this to handle optional trailing inputs better.
-        if pattern_node.allow_other_inputs:
-            if len(node.inputs) < len(pattern_node.inputs):
-                return self.fail(
-                    f"Number of inputs ({len(node.inputs)}) is less than expected ({len(pattern_node.inputs)})"
-                )
-        else:
-            if len(node.inputs) != len(pattern_node.inputs):
-                return self.fail(
-                    f"Input nums mismatch. {len(node.inputs)} vs {len(pattern_node.inputs)}"
-                )
+        if len(node.inputs) > len(pattern_node.inputs) and not pattern_node.allow_other_inputs:
+            return self.fail(
+                f"Number of inputs ({len(node.inputs)}) is more than expected ({len(pattern_node.inputs)})"
+            )
 
-        for arg_value, arg_pattern in zip(node.inputs, pattern_node.inputs):
+        for arg_value, arg_pattern in itertools.zip_longest(
+            node.inputs, pattern_node.inputs, fillvalue=None
+        ):
             # arg_pattern could be a Var, if it's the original arg.
             if arg_pattern is None:
                 if arg_value is None:

--- a/onnxscript/rewriter/pattern_test.py
+++ b/onnxscript/rewriter/pattern_test.py
@@ -493,9 +493,9 @@ class RewriteRuleTest(unittest.TestCase):
             # Pattern should match following call (with optional_input == None)
             t1 = op.Original(x, None)
             # as well as this one (with optional_input != None)
-            z = op.Original(x, t1)
+            t2 = op.Original(x, t1)
             # as well as this one (with optional_input == None)
-            z = op.Original(x)
+            z = op.Original(t2)
             return z
 
         model_proto = test_model.to_model_proto()


### PR DESCRIPTION
Pattern-variables are allowed in places where an optional input is expected. If the input is present, the pattern-variable will be bound to the corresponding ir.Value. Otherwise, the pattern-variable will be bound to None.

This PR extends this convention to handle trailing optional inputs better: specifically, `SomeOp(x)` and `SomeOp(x, None)` are treated equivalently during the pattern-match. If the pattern is `SomeOp(pattern_x, pattern_y)`, then `pattern_y` will be bound to None in both cases, and the pattern-match will succeed.

Side note: A consequence of allowing pattern-variables to be bound to None is that the corresponding guard/rewrite function will have to handle the case where the pattern-variable is None correctly. This is not an issue for correctly-typed models (where we can assume that a non-optional input will never be None). However, to protect against incorrectly-typed models, we may end up having to add tedious `x is not None` checks before accessing x's fields/attributes. It may be useful to perhaps allow the user to flip the convention for a given rule (as to whether pattern-variables are allowed to be bound to None). Or, ensure a model is type-valid before applying optimizations. (Or, a quick hack might be to catch these exceptions in the rewrite-engine and skip that particular rewrite, which is probably a good idea anyway.)