### PR TITLE
[IR] Add torch tensor support for `ir.tensor`

### DIFF
--- a/onnxscript/ir/_convenience.py
+++ b/onnxscript/ir/_convenience.py
@@ -360,7 +360,7 @@ def tensor(
     elif str(type(value)) == "<class 'torch.Tensor'>":
         # NOTE: We use str(type(...)) and do not import torch for type checking
         # as it creates overhead during import
-        return tensor_adapters.TorchTensor(value, name=name, doc_string=doc_string)
+        return tensor_adapters.TorchTensor(value, name=name, doc_string=doc_string)  # type: ignore[arg-type]
     elif isinstance(value, (_protocols.DLPackCompatible, _protocols.ArrayCompatible)):
         return _core.Tensor(value, dtype=dtype, name=name, doc_string=name)
 

--- a/onnxscript/ir/_convenience_test.py
+++ b/onnxscript/ir/_convenience_test.py
@@ -1,0 +1,22 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Unit tests for the _convenience module."""
+
+import unittest
+
+import numpy as np
+
+from onnxscript.ir import _convenience
+
+
+class ConvenienceTest(unittest.TestCase):
+    def test_tensor_accepts_torch_tensor(self):
+        import torch as some_random_name
+
+        torch_tensor = some_random_name.tensor([1, 2, 3])
+        tensor = _convenience.tensor(torch_tensor)
+        np.testing.assert_array_equal(tensor, torch_tensor.numpy())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnxscript/ir/_convenience_test.py
+++ b/onnxscript/ir/_convenience_test.py
@@ -11,7 +11,7 @@ from onnxscript.ir import _convenience
 
 class ConvenienceTest(unittest.TestCase):
     def test_tensor_accepts_torch_tensor(self):
-        import torch as some_random_name
+        import torch as some_random_name  # pylint: disable=import-outside-toplevel
 
         torch_tensor = some_random_name.tensor([1, 2, 3])
         tensor = _convenience.tensor(torch_tensor)

--- a/onnxscript/ir/tensor_adapters.py
+++ b/onnxscript/ir/tensor_adapters.py
@@ -38,13 +38,16 @@ from typing import TYPE_CHECKING, Any
 import numpy.typing as npt
 
 from onnxscript import ir
+from onnxscript.ir import _core
 
 if TYPE_CHECKING:
     import torch
 
 
-class TorchTensor(ir.Tensor):
-    def __init__(self, tensor: torch.Tensor, name: str | None = None):
+class TorchTensor(_core.Tensor):
+    def __init__(
+        self, tensor: torch.Tensor, name: str | None = None, doc_string: str | None = None
+    ):
         # Pass the tensor as the raw data to ir.Tensor's constructor
         import torch
 
@@ -69,7 +72,9 @@ class TorchTensor(ir.Tensor):
             torch.uint32: ir.DataType.UINT32,
             torch.uint64: ir.DataType.UINT64,
         }
-        super().__init__(tensor, dtype=_TORCH_DTYPE_TO_ONNX[tensor.dtype], name=name)
+        super().__init__(
+            tensor, dtype=_TORCH_DTYPE_TO_ONNX[tensor.dtype], name=name, doc_string=doc_string
+        )
 
     def numpy(self) -> npt.NDArray:
         import torch


### PR DESCRIPTION
Users can now do

```python
import torch
torch_tensor = torch.tensor([1, 2, 3])
tensor = ir.tensor(torch_tensor)
np.testing.assert_array_equal(tensor, torch_tensor.numpy())
```
