### PR TITLE
[Stable APIs] Create torchlib_opset for torch 2.6

### DIFF
--- a/onnxscript/_framework_apis/torch_2_6.py
+++ b/onnxscript/_framework_apis/torch_2_6.py
@@ -23,7 +23,7 @@ from onnxscript._framework_apis.torch_2_5 import (
 )
 
 if TYPE_CHECKING:
-    from onnxscript.values import Opset
+    from onnxscript.onnx_opset._impl.opset18 import Opset18
 
 
 def optimize(model: ir.Model) -> ir.Model:
@@ -32,8 +32,14 @@ def optimize(model: ir.Model) -> ir.Model:
     return model
 
 
-def torchlib_opset() -> Opset:
+def torchlib_opset() -> Opset18:
     """Return the default opset for torchlib."""
-    from onnxscript import opset18  # pylint: disable=import-outside-toplevel
+    import onnxscript  # pylint: disable=import-outside-toplevel
 
-    return opset18
+    return onnxscript.opset18  # type: ignore
+
+
+def torchlib_opset_version() -> int:
+    """Return the default opset version for torchlib."""
+
+    return torchlib_opset().version

--- a/onnxscript/_framework_apis/torch_2_6.py
+++ b/onnxscript/_framework_apis/torch_2_6.py
@@ -34,6 +34,6 @@ def optimize(model: ir.Model) -> ir.Model:
 
 def torchlib_opset() -> Opset:
     """Return the default opset for torchlib."""
-    from onnxscript import opset18
+    from onnxscript import opset18  # pylint: disable=import-outside-toplevel
 
     return opset18

--- a/onnxscript/_framework_apis/torch_2_6.py
+++ b/onnxscript/_framework_apis/torch_2_6.py
@@ -10,7 +10,10 @@ __all__ = [
     "get_torchlib_ops",
     "optimize",
     "save_model_with_external_data",
+    "torchlib_opset",
 ]
+from typing import TYPE_CHECKING
+
 from onnxscript import ir, optimizer
 from onnxscript._framework_apis.torch_2_5 import (
     check_model,
@@ -19,8 +22,18 @@ from onnxscript._framework_apis.torch_2_5 import (
     save_model_with_external_data,
 )
 
+if TYPE_CHECKING:
+    from onnxscript.values import Opset
+
 
 def optimize(model: ir.Model) -> ir.Model:
     """Optimize the model."""
     optimizer.optimize_ir(model)
     return model
+
+
+def torchlib_opset() -> Opset:
+    """Return the default opset for torchlib."""
+    from onnxscript import opset18
+
+    return opset18


### PR DESCRIPTION
Create torchlib_opset for torch 2.6. This will be used for creating the model opset import as well as in `_building` for creating constant/concat nodes etc.