### PR TITLE
Add missing close parenthesis in conversion to script

### DIFF
--- a/onnxscript/backend/onnx_export.py
+++ b/onnxscript/backend/onnx_export.py
@@ -389,6 +389,7 @@ class Exporter:
                     text += f", offset={metadata.offset!r}"
                 if metadata.length:
                     text += f", length={metadata.length!r}"
+                text += ")"
                 attributes.append((at.name, text))
                 continue
             attributes.append((at.name, repr(value)))


### PR DESCRIPTION
The tool for converting onnx model to onnxscript code has a missing parenthesis when generating external data tensor descriptor.