### PR TITLE
Extend onnx to script converter

### DIFF
--- a/onnxscript/backend/onnx_export.py
+++ b/onnxscript/backend/onnx_export.py
@@ -730,21 +730,21 @@ class Exporter:
         indented_initializers_as_params = "\n".join(
            f"{_SINGLE_INDENT}{_SINGLE_INDENT}{x}," for x in init_names
         )
-        return """
+        return f"""
 def make_model(
-{initializers_as_params}):
+{initializers_as_params}
 ):
-    {script}
+{script}
 
-    model = {script_function_name}.to_model_proto()
-    return model
+{_SINGLE_INDENT}model = {script_function_name}.to_model_proto()
+{_SINGLE_INDENT}return model
 
 def make_model_with_random_weights():
 {random_initializer_values}
-   model = make_model(
+{_SINGLE_INDENT}model = make_model(
 {indented_initializers_as_params}
-   )
-   return model 
+{_SINGLE_INDENT})
+{_SINGLE_INDENT}return model 
 """
 
     def _import_onnx_types(
@@ -869,5 +869,5 @@ def export2python(
     if not isinstance(model_onnx, (ModelProto, FunctionProto)):
         raise TypeError(f"The function expects a ModelProto not {type(model_onnx)!r}.")
 
-    exporter = Exporter(rename, use_operators, inline_const)
+    exporter = Exporter(rename, use_operators, inline_const, skip_initializers)
     return exporter.export(model_onnx, function_name)

--- a/onnxscript/backend/onnx_export.py
+++ b/onnxscript/backend/onnx_export.py
@@ -747,7 +747,7 @@ def make_model_with_random_weights():
 {__}model = make_model(
 {indented_initializers_as_params}
 {__})
-{__}return model 
+{__}return model
 """
 
     def _import_onnx_types(

--- a/tools/onnx2external.py
+++ b/tools/onnx2external.py
@@ -10,7 +10,7 @@ import onnx.external_data_helper
 
 def convert2external(input_file_name: str) -> None:
     dir_name = os.path.dirname(input_file_name)
-    base_name, suffix = os.path.splitext(os.path.basename(input_file_name))
+    base_name, _suffix = os.path.splitext(os.path.basename(input_file_name))
     model = onnx.load(input_file_name)
     os.makedirs(os.path.join(dir_name, base_name), exist_ok=True)
     onnx.external_data_helper.convert_model_to_external_data(

--- a/tools/onnx2external.py
+++ b/tools/onnx2external.py
@@ -1,7 +1,5 @@
-# -------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# --------------------------------------------------------------------------
 
 import argparse
 import os

--- a/tools/onnx2external.py
+++ b/tools/onnx2external.py
@@ -1,0 +1,31 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+import argparse
+import os
+
+import onnx
+import onnx.external_data_helper
+
+
+def convert2external(input_file_name: str) -> None:
+    dir_name = os.path.dirname(input_file_name)
+    base_name, suffix = os.path.splitext(os.path.basename(input_file_name))
+    model = onnx.load(input_file_name)
+    os.makedirs(os.path.join(dir_name, base_name), exist_ok=True)
+    onnx.external_data_helper.convert_model_to_external_data(
+        model, location="external_data.onnx", size_threshold=128
+    )
+    onnx.save(model, os.path.join(dir_name, base_name, "model.onnx"))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Convert ONNX model file to external data format"
+    )
+    parser.add_argument("input", help="ONNX model file to convert")
+    args = parser.parse_args()
+
+    convert2external(args.input)

--- a/tools/onnx2script.py
+++ b/tools/onnx2script.py
@@ -32,7 +32,10 @@ def convert2script(
 ) -> None:
     model = onnx.load(input_file_name, load_external_data=False)
     python_code = onnxscript.proto2python(
-        model, use_operators=not verbose, inline_const=not verbose, skip_initializers=not initializers
+        model,
+        use_operators=not verbose,
+        inline_const=not verbose,
+        skip_initializers=not initializers,
     )
 
     # If output file name is not provided, use the input file name with .py extension
@@ -60,7 +63,7 @@ if __name__ == "__main__":
         "--initializers",
         action="store_true",
         help="Include initializers in the generated script",
-        default=False
+        default=False,
     )
 
     args = parser.parse_args()

--- a/tools/onnx2script.py
+++ b/tools/onnx2script.py
@@ -28,11 +28,11 @@ import onnxscript
 
 
 def convert2script(
-    input_file_name: str, output_file_name: Optional[str], verbose: bool
+    input_file_name: str, output_file_name: Optional[str], verbose: bool, initializers: bool
 ) -> None:
     model = onnx.load(input_file_name, load_external_data=False)
     python_code = onnxscript.proto2python(
-        model, use_operators=not verbose, inline_const=not verbose
+        model, use_operators=not verbose, inline_const=not verbose, skip_initializers=not initializers
     )
 
     # If output file name is not provided, use the input file name with .py extension
@@ -55,6 +55,13 @@ if __name__ == "__main__":
         help="Verbose mode, suppresses use of overloaded operators and inline constants",
         default=False,
     )
+    parser.add_argument(
+        "-i",
+        "--initializers",
+        action="store_true",
+        help="Include initializers in the generated script",
+        default=False
+    )
 
     args = parser.parse_args()
-    convert2script(args.input, args.output, args.verbose)
+    convert2script(args.input, args.output, args.verbose, args.initializers)


### PR DESCRIPTION
Extend onnx to script converter to suppress initializers in generated script, and replace them with randomly generated weights. This allows a compact onnxscript representation of models with large initializers, especially when we don't care about the exact weights. This is useful for generating source-based test-cases from models.

Eg., this allows us to generate test-cases such as the one [here](https://github.com/microsoft/onnxscript/blob/ca11a20625fb3b170c23798e03b4366d17d6bc1c/onnxscript/rewriter/onnxruntime/xformers/_smollm_1layer.py#L18).