### PR TITLE
[torchlib] Squeeze sym_size

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -8085,7 +8085,7 @@ def aten_swapdims(self: TensorType, dim0: int, dim1: int) -> TensorType:
 @torch_op("aten::sym_size.int", trace_only=True)
 def aten_sym_size(self: TensorType, dim: int = 0) -> INT64:
     """sym_size.int(Tensor self, int dim) -> SymInt"""
-    return op.Shape(self, end=dim + 1, start=dim)
+    return op.Squeeze(op.Shape(self, end=dim + 1, start=dim))
 
 
 def aten_symeig(


### PR DESCRIPTION
Add Squeeze to aten_sym_size because the output is expected to be 0d.