### PR TITLE
feat: update typing_extensions requirement

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ COMMON_TEST_DEPENDENCIES = (
     "pytest!=7.1.0",
     "pyyaml",
     "types-PyYAML",
-    "typing_extensions",
+    "typing_extensions>=4.10",
     "ml-dtypes",
 )
 ONNX = "onnx==1.17"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "License :: OSI Approved :: MIT License",
 ]
-dependencies = ["numpy", "onnx>=1.16", "typing_extensions", "ml_dtypes", "packaging"]
+dependencies = ["numpy", "onnx>=1.16", "typing_extensions>=4.10", "ml_dtypes", "packaging"]
 
 [tool.setuptools.packages.find]
 include = ["onnxscript*"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ setuptools>=61.0.0
 numpy
 onnx-weekly>=1.17.0.dev20240325
 onnxruntime>=1.17.0
-typing_extensions
+typing_extensions>=4.10
 rich>=13.7.1
 
 # Docs site


### PR DESCRIPTION
'TypeIs' is available from `typing_extensions` v4.10.
Close #1996 