### PR TITLE
Rama/new init

### DIFF
--- a/onnxscript/ir/_tape.py
+++ b/onnxscript/ir/_tape.py
@@ -18,6 +18,7 @@ class Tape(Iterable[ir.Node]):
 
     def __init__(self) -> None:
         self._nodes: list[ir.Node] = []
+        self._initializers: list[ir.Value] = []
 
     def __iter__(self) -> Iterator[ir.Node]:
         return iter(self._nodes)
@@ -25,6 +26,10 @@ class Tape(Iterable[ir.Node]):
     @property
     def nodes(self) -> Sequence[ir.Node]:
         return tuple(self._nodes)
+
+    @property
+    def initializers(self) -> Sequence[ir.Value]:
+        return tuple(self._initializers)
 
     def op(
         self,
@@ -60,6 +65,10 @@ class Tape(Iterable[ir.Node]):
 
         return node.outputs
 
+    def initializer(self, name: str, tensor: ir.TensorProtocol) -> ir.Value:
+        value = ir.Value(name=name, shape=tensor.shape, type=ir.TensorType(tensor.dtype), const_value=tensor)
+        self._initializers.append(value)
+        return value
 
 # A type representing the domains/versions used in creating nodes in IR.
 UsedOpsets = List[Tuple[str, Optional[int]]]

--- a/onnxscript/ir/_tape.py
+++ b/onnxscript/ir/_tape.py
@@ -65,7 +65,10 @@ class Tape(Iterable[ir.Node]):
 
         return node.outputs
 
-    def initializer(self, name: str, tensor: ir.TensorProtocol) -> ir.Value:
+    def initializer(self, tensor: ir.TensorProtocol, name: str | None = None) -> ir.Value:
+        name = name or tensor.name
+        if name is None:
+            raise ValueError("Name must be provided for initializer.")
         value = ir.Value(name=name, shape=tensor.shape, type=ir.TensorType(tensor.dtype), const_value=tensor)
         self._initializers.append(value)
         return value

--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -119,7 +119,11 @@ class ReferenceEvaluator:
         evaluator = self.get_evaluator(domain, op, version)
         if evaluator is None:
             return None
-        return evaluator(*args, **kwargs)
+        try:
+            return evaluator(*args, **kwargs)
+        except Exception as e:
+            logger.debug("Evaluation failed: %s", e)
+            return None
 
 
 _reference_evaluator = ReferenceEvaluator()

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -900,6 +900,7 @@ class ReplacementSubgraph:
     match: MatchResult
     new_outputs: Sequence[ir.Value]
     new_nodes: Sequence[ir.Node]
+    new_initializers: Sequence[ir.Value]
     used_opsets: _tape.UsedOpsets
 
 
@@ -928,7 +929,7 @@ class ReplacementPatternFunction:
             return None  # Failed to create replacement subgraph
         if not isinstance(new_outputs, Sequence):
             new_outputs = [new_outputs]
-        return ReplacementSubgraph(match, new_outputs, context.nodes, context.used_opsets)
+        return ReplacementSubgraph(match, new_outputs, context.nodes, context.initializers, context.used_opsets)
 
 
 def _update_opset_imports(
@@ -1566,6 +1567,12 @@ class RewriteRuleSet:
                 if delta is None or tracer is not None:
                     continue
                 assert isinstance(delta, ReplacementSubgraph)
+                if delta.new_initializers and isinstance(graph_or_function, ir.Function):
+                    # TODO(rama): Can't add initializers to functions. But currently this is not
+                    # an issue, as we apply inlining before applying rewrite rules.
+                    continue
+                for initializer in delta.new_initializers:
+                    graph_or_function.initializers[initializer.name] = initializer
                 # TODO: This does not yet handle the problem of determining the correct insertion point
                 # for inserted nodes in the case of patterns with multiple output-nodes. The following
                 # is sufficient for patterns with a single output-node "node", which can serve as the

--- a/onnxscript/rewriter/pattern_test.py
+++ b/onnxscript/rewriter/pattern_test.py
@@ -3,6 +3,7 @@
 import contextlib
 import io
 import logging
+import numpy as np
 import unittest
 
 import onnx.checker
@@ -542,6 +543,38 @@ class RewriteRuleTest(unittest.TestCase):
         self.assertEqual(count, 0)
         # Not a robust test. But test serves to ensure that debug mode is producing something.
         self.assertIn("OpType mismatch: expected Abs, got Neg", captured_output)
+
+    def test_new_initializer(self):
+        def source_pattern(op, x, y):
+            return op.Gemm(x, op.Transpose(y))
+        
+        def check(context, x, y):
+            return y.const_value is not None
+
+        def replacement(op, x, y):
+            tensor = y.const_value
+            name = y.name + "_transposed"
+            transposed = ir.tensor(tensor.numpy().T, name=name)
+            initializer = op.initializer(transposed)
+            return op.Gemm(x, initializer)
+        
+        rule = pattern.RewriteRule(source_pattern, replacement, check)
+
+        y_value = np.random.rand(8, 4).astype(np.float32)
+        @script()
+        def test_model(x: FLOAT[16, 8]) -> FLOAT[16, 4]:
+            y = op.Constant(value=y_value)
+            return op.Gemm(x, op.Transpose(y))
+        
+        model_proto = test_model.to_model_proto()
+        model = ir.serde.deserialize_model(model_proto)
+        rule.apply_to_model(model)
+        self.assertEqual(len(model.graph.initializers), 1)
+        last_node = model.graph[-1]
+        self.assertEqual(len(last_node.inputs), 2)
+        init_name = last_node.inputs[1].name
+        self.assertIn(init_name, model.graph.initializers)
+        self.assertIs(last_node.inputs[1], model.graph.initializers[init_name])
 
 
 class PatternBuilderTest(unittest.TestCase):


### PR DESCRIPTION
Add support for creating new initializers in rewrite rules. The same can serve as the basis for creating new initializers in onnxscript (eager mode), but that is a separate issue to be tackled separately.

Addresses https://github.com/microsoft/onnxscript/issues/2016

