### PR TITLE
[torch] Fix _operator::{truediv/floordiv}

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -2761,6 +2761,20 @@ def aten_div(self: TFloat, other: TFloat) -> TFloat:
 
 @torch_op(
     (
+        "aten::true_divide.Tensor",
+        "aten::true_divide.Scalar",
+        "_operator::truediv",
+    )
+)
+def aten_div_int(self: TInt, other: TInt) -> TFloat:
+    """div.Tensor(Tensor self, Tensor other) -> Tensor"""
+
+    # Int inputs will be promoted to float by PyTorch
+    return op.Div(op.Cast(self, to=FLOAT.dtype), op.Cast(other, to=FLOAT.dtype))
+
+
+@torch_op(
+    (
         "aten::div.Tensor",
         "aten::div.Scalar",
         "aten::divide.Tensor",
@@ -3605,12 +3619,12 @@ def aten_floor_divide(self: TFloat, other: TFloat) -> TFloat:
 
 
 @torch_op(("aten::floor_divide", "_operator::floordiv"), traceable=True)
-def aten_floor_divide_int(self: TInt, other: TInt) -> TInt:
+def aten_floor_divide_int(self: TInt, other: TInt) -> FLOAT:
     """floor_divide(Tensor self, Tensor other) -> Tensor"""
 
     # We implement floor_divide only for positive inputs (using integer division)
     # because that is the usual intended case and is the most efficient.
-    return op.Div(self, other)
+    return op.Div(op.Cast(self, to=FLOAT.dtype), op.Cast(other, to=FLOAT.dtype))
 
 
 def aten_fmax(self: TensorType, other: TensorType) -> TensorType:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -2760,8 +2760,6 @@ def aten_div(self: TFloat, other: TFloat) -> TFloat:
 
 @torch_op("_operator::truediv", traceable=True)
 def operator_truediv(self: TensorType, other: TensorType) -> FLOAT:
-    """div.Tensor(Tensor self, Tensor other) -> Tensor"""
-
     return op.Div(op.Cast(self, to=FLOAT.dtype), op.Cast(other, to=FLOAT.dtype))
 
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -170,7 +170,7 @@ def aten_add(self: TReal, other: TReal, alpha: float = 1.0) -> TReal:
 
 
 @torch_op(
-    ("aten::add.Tensor", "aten::add.Scalar", "_operator::add"), trace_only=True, complex=True
+    ("aten::add.Tensor", "aten::add.Scalar"), trace_only=True, complex=True
 )
 def aten_add_complex(self: TReal, other: TReal, alpha: float = 1.0) -> TReal:
     """add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"""
@@ -2749,7 +2749,6 @@ def aten_dist(self: TensorType, other: TensorType, p: float = 2.0) -> TensorType
         "aten::divide.Scalar",
         "aten::true_divide.Tensor",
         "aten::true_divide.Scalar",
-        "_operator::truediv",
     )
 )
 def aten_div(self: TFloat, other: TFloat) -> TFloat:
@@ -2760,7 +2759,7 @@ def aten_div(self: TFloat, other: TFloat) -> TFloat:
 
 
 @torch_op("_operator::truediv", traceable=True)
-def operator_truediv_int(self: TInt, other: TInt) -> TFloat:
+def operator_truediv(self: TensorType, other: TensorType) -> FLOAT:
     """div.Tensor(Tensor self, Tensor other) -> Tensor"""
 
     return op.Div(op.Cast(self, to=FLOAT.dtype), op.Cast(other, to=FLOAT.dtype))
@@ -3611,7 +3610,7 @@ def aten_floor_divide(self: TFloat, other: TFloat) -> TFloat:
 
 
 @torch_op("_operator::floordiv", traceable=True)
-def operator_floordiv(self: TInt, other: TInt) -> TInt:
+def operator_floordiv(self: INT64, other: INT64) -> INT64:
     # We implement floor_divide only for positive inputs (using integer division)
     # because that is the usual intended case and is the most efficient.
     return op.Div(self, other)
@@ -4944,7 +4943,6 @@ def aten_logical_not(self: BOOL) -> BOOL:
         "aten::bitwise_or.Scalar_Tensor",
         "aten::add.Tensor",
         "aten::add.Scalar",
-        "_operator::add",
     ),
     traceable=True,
 )
@@ -5662,7 +5660,7 @@ def aten_mul(self: TReal, other: TReal) -> TReal:
 
 
 @torch_op(
-    ("aten::mul", "aten::mul.Tensor", "_operator::mul", "aten::multiply.Tensor"),
+    ("aten::mul", "aten::mul.Tensor", "aten::multiply.Tensor"),
     traceable=True,
 )
 def aten_mul_bool(self: BOOL, other: BOOL) -> BOOL:
@@ -5675,7 +5673,7 @@ def aten_mul_bool(self: BOOL, other: BOOL) -> BOOL:
 
 
 @torch_op(
-    ("aten::mul", "aten::mul.Tensor", "_operator::mul", "aten::multiply.Tensor"),
+    ("aten::mul", "aten::mul.Tensor", "aten::multiply.Tensor"),
     traceable=True,
     complex=True,
 )
@@ -8048,7 +8046,6 @@ def aten_sub(self: TReal, other: TReal, alpha: float = 1.0) -> TReal:
         "aten::sub.Scalar",
         "aten::subtract.Tensor",
         "aten::subtract.Scalar",
-        "_operator::sub",
     ),
     trace_only=True,
     complex=True,

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -2759,9 +2759,7 @@ def aten_div(self: TFloat, other: TFloat) -> TFloat:
     return op.Div(self, other)
 
 
-@torch_op(
-    "_operator::truediv"
-)
+@torch_op("_operator::truediv", traceable=True)
 def operator_truediv_int(self: TInt, other: TInt) -> TFloat:
     """div.Tensor(Tensor self, Tensor other) -> Tensor"""
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -2760,11 +2760,7 @@ def aten_div(self: TFloat, other: TFloat) -> TFloat:
 
 
 @torch_op(
-    (
-        "aten::true_divide.Tensor",
-        "aten::true_divide.Scalar",
-        "_operator::truediv",
-    )
+    "_operator::truediv"
 )
 def operator_truediv_int(self: TInt, other: TInt) -> TFloat:
     """div.Tensor(Tensor self, Tensor other) -> Tensor"""

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -2763,7 +2763,6 @@ def aten_div(self: TFloat, other: TFloat) -> TFloat:
 def operator_truediv_int(self: TInt, other: TInt) -> TFloat:
     """div.Tensor(Tensor self, Tensor other) -> Tensor"""
 
-    # Int inputs will be promoted to float by PyTorch
     return op.Div(op.Cast(self, to=FLOAT.dtype), op.Cast(other, to=FLOAT.dtype))
 
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -3611,7 +3611,7 @@ def aten_floor_divide(self: TFloat, other: TFloat) -> TFloat:
 
 
 @torch_op("_operator::floordiv", traceable=True)
-def operator_floordiv(self: TInt, other: TInt) -> FLOAT:
+def operator_floordiv(self: TInt, other: TInt) -> TInt:
     # We implement floor_divide only for positive inputs (using integer division)
     # because that is the usual intended case and is the most efficient.
     return op.Div(self, other)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -169,9 +169,7 @@ def aten_add(self: TReal, other: TReal, alpha: float = 1.0) -> TReal:
     return op.Add(self, other)
 
 
-@torch_op(
-    ("aten::add.Tensor", "aten::add.Scalar"), trace_only=True, complex=True
-)
+@torch_op(("aten::add.Tensor", "aten::add.Scalar"), trace_only=True, complex=True)
 def aten_add_complex(self: TReal, other: TReal, alpha: float = 1.0) -> TReal:
     """add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"""
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -2774,7 +2774,6 @@ def operator_truediv_int(self: TInt, other: TInt) -> TFloat:
         "aten::divide.Scalar",
         "aten::true_divide.Tensor",
         "aten::true_divide.Scalar",
-        "_operator::truediv",
     ),
     complex=True,
 )
@@ -3604,20 +3603,18 @@ def python_math_floor(self: TFloat) -> TInt:
     return op.Cast(floor, to=INT64.dtype)
 
 
-@torch_op(("aten::floor_divide", "_operator::floordiv"), traceable=True)
+@torch_op("aten::floor_divide", traceable=True)
 def aten_floor_divide(self: TFloat, other: TFloat) -> TFloat:
     """floor_divide(Tensor self, Tensor other) -> Tensor"""
 
     return op.Floor(op.Div(self, other))
 
 
-@torch_op(("aten::floor_divide", "_operator::floordiv"), traceable=True)
-def aten_floor_divide_int(self: TInt, other: TInt) -> FLOAT:
-    """floor_divide(Tensor self, Tensor other) -> Tensor"""
-
+@torch_op("_operator::floordiv", traceable=True)
+def operator_floordiv(self: TInt, other: TInt) -> FLOAT:
     # We implement floor_divide only for positive inputs (using integer division)
     # because that is the usual intended case and is the most efficient.
-    return op.Div(op.Cast(self, to=FLOAT.dtype), op.Cast(other, to=FLOAT.dtype))
+    return op.Div(self, other)
 
 
 def aten_fmax(self: TensorType, other: TensorType) -> TensorType:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -2766,7 +2766,7 @@ def aten_div(self: TFloat, other: TFloat) -> TFloat:
         "_operator::truediv",
     )
 )
-def aten_div_int(self: TInt, other: TInt) -> TFloat:
+def operator_truediv_int(self: TInt, other: TInt) -> TFloat:
     """div.Tensor(Tensor self, Tensor other) -> Tensor"""
 
     # Int inputs will be promoted to float by PyTorch

--- a/tests/function_libs/torch_lib/ops_test_data.py
+++ b/tests/function_libs/torch_lib/ops_test_data.py
@@ -829,7 +829,6 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         test_class_name="TestOutputConsistencyEager",
         reason="fixme: off-by-one issue due to numerical precision. https://github.com/microsoft/onnxscript/issues/989",
     ),
-    TorchLibOpInfo("ops.aten.floor_divide.int", core_ops.aten_floor_divide_int),
     TorchLibOpInfo("fmod", core_ops.aten_fmod),
     TorchLibOpInfo("frac", core_ops.aten_frac),
     TorchLibOpInfo("full", core_ops.aten_full),


### PR DESCRIPTION
Create separate implementations for `_operator::{truediv/floordiv}` to handle SymInts