### PR TITLE
Bump upload-artifact version in CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,7 +79,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload torchlib error reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Error reports (${{ matrix.name }}-${{ matrix.os }})
           path: error_reports


### PR DESCRIPTION
upload-artifact fails because the version is deprecated. Otherwise everything fails