### PR TITLE
[torchlib] Fix index_put: handle None cases

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -4329,7 +4329,7 @@ def aten_index_put(
     for i in range(self_rank):
         if indices[i] is None:
             # For a full slice along dim i, create a range index [0, self.shape[i]).
-            idx = op.Range(0, op.Shape(self, start=i, end=i + 1), 1)
+            idx = op.Range(0, self.shape[i], 1)
             reshape_update = self.shape[i]
         else:
             idx = indices[i]

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 import math
 from typing import Any, Optional, Sequence, Tuple, Union
 
-import numpy as np
-
 from onnxscript import (
     BFLOAT16,
     BOOL,
@@ -4305,10 +4303,6 @@ def aten_index_put(
         while len(reshape_list) > len(values_shape) and 1 in reshape_list:
             reshape_list.remove(1)
 
-        # Or add ones until the rank of reshape_list matches values_shape.
-        while len(reshape_list) < len(values_shape):
-            reshape_list.append(1)
-
         # Now ensure each dimension is broadcastable:
         # This is mandatory when mixing basic and advanced indexing
         # Example: data((10, 3, 4)), indices([[0, 1], :, [0, 1]]) values(2, 3)
@@ -4335,11 +4329,11 @@ def aten_index_put(
     for i in range(self_rank):
         if indices[i] is None:
             # For a full slice along dim i, create a range index [0, self.shape[i]).
-            idx = op.Range(start=0, limit=self.shape[i], delta=1)
+            idx = op.Range(0, op.Shape(self, start=i, end=i + 1), 1)
             reshape_update = self.shape[i]
         else:
             idx = indices[i]
-            reshape_update = np.prod(idx.shape).item()
+            reshape_update = math.prod(idx.shape)
             # when Index is more than 1D, flatten it and also the values shape
             # Example: self shape: (10, 3), indices[i] shape: (2, 4), values shape: (2, 4, 3)
             # Indices -> (2*4,) and values shape (2*4, 32)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -4298,14 +4298,70 @@ def aten_index_put(
     <https://github.com/pytorch/pytorch/blob/main/torch/onnx/symbolic_opset11.py#L212>`_.
     """
 
-    # TODO(justinchuby): Handle when indicies has more than one element
-    index = indices[0]
-    new_index = op.Unsqueeze(index, [-1])
+    def _make_reshape_list_broadcastable(reshape_list, values_shape):
+        # Remove ones until the rank of reshape_list matches values_shape.
+        while len(reshape_list) > len(values_shape) and 1 in reshape_list:
+            reshape_list.remove(1)
+
+        # Now ensure each dimension is broadcastable:
+        # This is mandatory when mixing basic and advanced indexing
+        # Example: data((10, 3, 4)), indices([[0, 1], :, [0, 1]]) values(2, 3)
+        # the reshape list should be : [[2, 1], [1, 3], [2, 1]]
+        for i, r in enumerate(reshape_list):
+            if r != 1 and r != values_shape[i]:
+                one_index = reshape_list.index(1)
+                # Swap elements
+                # For the example above the current reshape list is [1, 2] for last dim,
+                # to make it broadcastable, we swap the elements
+                reshape_list[one_index], reshape_list[i] = reshape_list[i], 1
+
+        return reshape_list
+
+    # Ensure the number of indices matches the tensor rank.
+    self_rank = len(self.shape)
+    if len(indices) < self_rank:
+        indices = list(indices) + [None] * (self_rank - len(indices))
+
+    # Get values shape (we use .numpy to make it hashable)
+    values_shape = values.shape.numpy()
+
+    index_vectors = []
+    for i in range(self_rank):
+        if indices[i] is None:
+            # For a full slice along dim i, create a range index [0, self.shape[i]).
+            idx = op.Range(start=0, limit=self.shape[i], delta=1)
+            reshape_update = self.shape[i]
+        else:
+            idx = indices[i]
+            reshape_update = indices[i].shape[0]
+
+        # Create a reshape pattern: one value per index dimension,
+        # with the current dimension set to the update size.
+        reshape_list = [1] * len(indices)
+        reshape_list[i] = reshape_update
+
+        # Adjust the reshape list to match the values shape.
+        reshape_list = _make_reshape_list_broadcastable(reshape_list, values_shape)
+
+        # Reshape and expand the index.
+        idx = op.Reshape(idx, reshape_list)
+        idx = op.Expand(idx, values_shape)
+
+        # Flatten the index to 1D and unsqueeze to form a column vector.
+        idx = op.Reshape(idx, [-1])
+        idx = op.Unsqueeze(idx, axes=[1])
+        index_vectors.append(idx)
+
+    # Concatenate the index vectors along axis=1 to form the final indices.
+    new_index = op.Concat(*index_vectors, axis=1)
+
+    # Flatten values to match the indices
+    flat_values = op.Reshape(values, [-1])
 
     if accumulate:
-        result = op.ScatterND(self, new_index, values, reduction="add")
+        result = op.ScatterND(self, new_index, flat_values, reduction="add")
     else:
-        result = op.ScatterND(self, new_index, values)
+        result = op.ScatterND(self, new_index, flat_values)
 
     return result
 

--- a/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/tests/function_libs/torch_lib/extra_opinfo.py
@@ -834,6 +834,12 @@ def sample_inputs_index_put(op_info, device, dtype, requires_grad, **kwargs):
             ],
             (1,),
         ),
+        # Cases: Multidimensional index
+        (
+            (10, 3),
+            [torch.arange(8, dtype=torch.int64, device=device).reshape((-1, 4))],
+            (2, 4, 3),
+        ),
     ]
 
     for data_shape, indices, values_shape in cases:  # type: ignore[misc]


### PR DESCRIPTION
This PR introduces support for `None` indices in the `index_put` function. If an index is None, it acts as a full slice (`:`).
### index_put Logic:
1. Construct index grid that contains all the indices to be updated
2. Reshapes the update values to match the computed indices.
