### PR TITLE
Improve Op(unfold)

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -8477,38 +8477,29 @@ def aten_unfold(self: TTensor, dimension: int, size: int, step: int) -> TTensor:
         if dimension < 0:
             dimension = dimension + self_rank
         dim_size = self.shape[dimension]
-        target_end = (dim_size - size) // step + 1
-        if target_end >= 1:  # the rank of final reuslt will be self_rank + 1
-            self_rank = self_rank + 1
+
+        low_indices = range(0, dim_size, step)
+        hi_indices = range(size, dim_size + 1, step)
+        stack = [
+            op.Slice(
+                self,
+                op.Constant(value_ints=[low]),
+                op.Constant(value_ints=[hi]),
+                op.Constant(value_ints=[dimension]),
+            )
+            for low, hi in zip(low_indices, hi_indices)
+        ]
+
         # perm need to be list[int], so have to be generated in trace_only mode
         perm = list(range(self_rank))
         # from [0,1,2,3,4] -> [0,1,3,4,2] when dimension=1
-        perm.append(perm.pop(dimension + 1))
-        result = _aten_unfold_onnx(self, dimension, size, step, target_end, perm)
+        perm.append(perm.pop(dimension))
+        unsqueeze = [
+            op.Unsqueeze(op.Transpose(t, perm=perm), op.Constant(value_ints=[dimension]))
+            for t in stack
+        ]
+        result = op.Concat(*unsqueeze, axis=dimension)
     return result
-
-
-@torch_op("aten::unfold", private=True)
-def _aten_unfold_onnx(
-    self: TTensor, dim: int, size: int, step: int, target_end: int, perm: Sequence[int]
-) -> TTensor:
-    dims = op.Reshape(op.Constant(value_int=dim), op.Constant(value_ints=[-1]))
-    # FIXME(justinchuby): obtain the dtype for SequenceEmpty, currently it assumes float
-    seq_result = op.SequenceEmpty()
-    i = op.Constant(value_int=0)
-    cond = i < target_end
-    while cond:  # because for loop cannot work here, so use while loop
-        starts = op.Reshape(i * step, [-1])  # starts is [0, step, step*2, step*3, ...]
-        ends = starts + size  # ends is [0+size, step+size, step*2+size, step*3+size, ...]
-        slice_result = op.Slice(self, starts, ends, dims)
-        # sequence only support float32
-        slice_result_float32 = op.Cast(slice_result, to=FLOAT.dtype)
-        seq_result = op.SequenceInsert(seq_result, slice_result_float32)
-        i = i + 1
-        cond = i < target_end
-    concat_result = op.ConcatFromSequence(seq_result, axis=dim, new_axis=1)
-    result = op.Transpose(concat_result, perm=perm)
-    return op.CastLike(result, self)
 
 
 def aten_unfold_backward(


### PR DESCRIPTION
Fix #1998 

Basically, just follow the logic from symbolic_opset9.py: https://github.com/pytorch/pytorch/blob/fdb1305ace9cd875611931983eada640ab837c4c/torch/onnx/symbolic_opset9.py#L2878.

The implementation from symbolic_opset12.py claims it fixes static shapes issue, but I see no difference because dimension, size, step are all int. I also tested https://github.com/pytorch/pytorch/blob/fdb1305ace9cd875611931983eada640ab837c4c/test/onnx/test_pytorch_onnx_onnxruntime.py#L7300 with opset9 and it still works. So we don't need to capture the loop in dynamic I think.