### PR TITLE
[torchlib] Update operator:pow implementation

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6652,7 +6652,7 @@ def aten_positive(self: TensorType) -> TensorType:
 
 
 @torch_op(
-    ("aten::pow.Tensor_Tensor", "aten::pow.Tensor_Scalar"),
+    ("aten::pow.Tensor_Tensor", "aten::pow.Tensor_Scalar", "_operator::pow"),
     trace_only=True,
 )
 def aten_pow(self: TReal, exponent: TTensor) -> TReal:
@@ -6660,10 +6660,7 @@ def aten_pow(self: TReal, exponent: TTensor) -> TReal:
     return op.Pow(self, exponent)
 
 
-@torch_op(
-    ("_operator::pow", "aten::pow.Scalar"),
-    trace_only=True,
-)
+@torch_op("aten::pow.Scalar", trace_only=True)
 def aten_pow_scalar(self: float, exponent: TTensor) -> TTensor:
     """pow.Scalar(Scalar self, Tensor exponent) -> Tensor"""
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6651,19 +6651,21 @@ def aten_positive(self: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
-@torch_op(
-    ("aten::pow.Tensor_Tensor", "aten::pow.Tensor_Scalar", "_operator::pow"),
-    trace_only=True,
-)
+@torch_op(("aten::pow.Tensor_Tensor", "_operator::pow"), trace_only=True)
 def aten_pow(self: TReal, exponent: TTensor) -> TReal:
     """pow(Tensor self, Tensor exponent) -> Tensor"""
+    return op.Pow(self, exponent)
+
+
+@torch_op("aten::pow.Tensor_Scalar", trace_only=True)
+def aten_pow_tensor_scalar(self: TReal, exponent: float) -> TReal:
+    """pow(Tensor self, Scalar exponent) -> Tensor"""
     return op.Pow(self, exponent)
 
 
 @torch_op("aten::pow.Scalar", trace_only=True)
 def aten_pow_scalar(self: float, exponent: TTensor) -> TTensor:
     """pow.Scalar(Scalar self, Tensor exponent) -> Tensor"""
-
     return op.Pow(op.Cast(self, to=exponent.dtype), exponent)
 
 


### PR DESCRIPTION
Register it to aten_pow instead because exponent may not be a tensor when self is SymInt.

Fixes https://github.com/pytorch/pytorch/issues/147606