### PR TITLE
Squeeze Reshape Identity optimization

### DIFF
--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -1627,6 +1627,9 @@ class RewriteRuleSet:
         if commute:
             rules = list(itertools.chain.from_iterable([rule.commute() for rule in rules]))
         self.rules = rules
+        # We call remove_unused_nodes at end of rewriting if there is any rule that does
+        # NOT remove nodes (immediately when it is applied)
+        self.remove_unused_nodes = any(not rule.remove_nodes for rule in rules)
 
     def _apply_to_graph_or_function(
         self,
@@ -1759,6 +1762,8 @@ class RewriteRuleSet:
             count += self._apply_to_graph_or_function(
                 model, function, verbose=verbose, tracer=tracer
             )
+        if self.remove_unused_nodes:
+            onnxscript.optimizer.remove_unused_nodes(model)
         if tracer:
             tracer.report()
         return count


### PR DESCRIPTION
A recent fix to the translation of pytorch symints introduces a Squeeze=>Reshape pattern that can be optimized away. This PR introduces a rewrite-rule to do this optimization.

TODO (in a separate PR): for now, this optimization needs to be explicitly invoked. This should be done by default. (But there are several other such optimizations that need to be collected and included in the default-rule list.)