### PR TITLE
[IR] Fix deserialize_node

### DIFF
--- a/onnxscript/ir/serde.py
+++ b/onnxscript/ir/serde.py
@@ -958,7 +958,7 @@ def _deserialize_attribute(
 
 def deserialize_node(proto: onnx.NodeProto) -> _core.Node:
     return _deserialize_node(
-        proto, scoped_values=[], value_info={}, quantization_annotations={}
+        proto, scoped_values=[{}], value_info={}, quantization_annotations={}
     )
 
 

--- a/onnxscript/ir/serde_test.py
+++ b/onnxscript/ir/serde_test.py
@@ -18,7 +18,7 @@ class ConvenienceFunctionsTest(unittest.TestCase):
         [
             ("model", onnx.ModelProto()),
             ("graph", onnx.GraphProto()),
-            ("node", onnx.NodeProto()),
+            ("node", onnx.NodeProto(input=["X"], output=["Y"])),
             (
                 "tensor",
                 onnx.helper.make_tensor("test_tensor", onnx.TensorProto.FLOAT, [1], [1.0]),


### PR DESCRIPTION
`ir.from_proto` raises an exception for `NodeProto` input type. Here this error is fixed.

Close #2093