### PR TITLE
[IR] Improve pass infra

### DIFF
--- a/onnxscript/ir/passes/__init__.py
+++ b/onnxscript/ir/passes/__init__.py
@@ -5,6 +5,10 @@ __all__ = [
     "PassBase",
     "PassResult",
     "PassManager",
+    "Sequential",
+    "InPlacePass",
+    "OutOfPlacePass",
+    "DestructivePass",
     # Errors
     "InvariantError",
     "PreconditionError",
@@ -13,13 +17,17 @@ __all__ = [
 ]
 
 from onnxscript.ir.passes._pass_infra import (
+    DestructivePass,
+    InPlacePass,
     InvariantError,
+    OutOfPlacePass,
     PassBase,
     PassError,
     PassManager,
     PassResult,
     PostconditionError,
     PreconditionError,
+    Sequential,
 )
 
 

--- a/onnxscript/ir/passes/__init__.py
+++ b/onnxscript/ir/passes/__init__.py
@@ -7,7 +7,7 @@ __all__ = [
     "PassManager",
     "Sequential",
     "InPlacePass",
-    "OutOfPlacePass",
+    "FunctionalPass",
     # Errors
     "InvariantError",
     "PreconditionError",
@@ -16,9 +16,9 @@ __all__ = [
 ]
 
 from onnxscript.ir.passes._pass_infra import (
+    FunctionalPass,
     InPlacePass,
     InvariantError,
-    OutOfPlacePass,
     PassBase,
     PassError,
     PassManager,

--- a/onnxscript/ir/passes/__init__.py
+++ b/onnxscript/ir/passes/__init__.py
@@ -8,7 +8,6 @@ __all__ = [
     "Sequential",
     "InPlacePass",
     "OutOfPlacePass",
-    "DestructivePass",
     # Errors
     "InvariantError",
     "PreconditionError",
@@ -17,7 +16,6 @@ __all__ = [
 ]
 
 from onnxscript.ir.passes._pass_infra import (
-    DestructivePass,
     InPlacePass,
     InvariantError,
     OutOfPlacePass,

--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -225,13 +225,14 @@ class PassManager(Sequential):
     Attributes:
         passes: The passes to run.
         steps: The number of times to run the passes.
+        early_stop: Whether to stop running the passes if the graph stops changing.
     """
 
     def __init__(
         self,
         passes: Sequence[PassBase],
         steps: int = 1,
-        early_stop=True,
+        early_stop: bool = True,
     ):
         # TODO(justinchuby): Implement constraints
         super().__init__(*passes)

--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -176,14 +176,16 @@ class Sequential(PassBase):
         if not passes:
             raise ValueError("Sequential must take at least one pass")
         self.passes = passes
+        self._in_place = all(pass_.in_place for pass_ in passes)
+        self._changes_input = self.passes[0].changes_input or self.passes[0].in_place
 
     @property
     def in_place(self) -> bool:
-        return all(pass_.in_place for pass_ in self.passes)
+        return self._in_place
 
     @property
     def changes_input(self) -> bool:
-        return self.passes[0].changes_input or self.passes[0].in_place
+        return self._changes_input
 
     def call(self, model: ir.Model) -> PassResult:
         modified = False

--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -70,7 +70,11 @@ class PassBase(abc.ABC):
 
     @property
     def in_place(self) -> bool:
-        """Whether the pass modifies the model in place."""
+        """Whether the pass modifies the model in place.
+
+        If True, the pass will return the same model object that was passed in.
+        If False, the pass will return a new model object.
+        """
         return True
 
     @property

--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -23,7 +23,6 @@ __all__ = [
     "Sequential",
     "InPlacePass",
     "OutOfPlacePass",
-    "DestructivePass",
     "PassManager",
     "PassResult",
     # Errors
@@ -168,18 +167,6 @@ class OutOfPlacePass(PassBase):
     @property
     def changes_input(self) -> bool:
         return False
-
-
-class DestructivePass(PassBase):
-    """A pass that modifies the input model and returns a new model."""
-
-    @property
-    def in_place(self) -> bool:
-        return False
-
-    @property
-    def changes_input(self) -> bool:
-        return True
 
 
 class Sequential(PassBase):

--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -186,11 +186,6 @@ class PassManager(PassBase):
                     f"An error occurred when running the '{pass_}' pass after the "
                     f"following passes: {prev_pass_names} during step {step}"
                 ) from e
-            if not isinstance(pass_result, PassResult):
-                raise TypeError(
-                    f"The result of the pass {pass_} should be type PassResult."
-                    "Please create one with ir.passes.PassResult()."
-                )
 
             model = pass_result.model
             modified = modified or pass_result.modified

--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -95,7 +95,7 @@ class PassBase(abc.ABC):
         except PostconditionError:
             raise
         except Exception as e:
-            raise PostconditionError("Post-condition failed") from e
+            raise PostconditionError(f"Post-condition failed: {e.__class__.__name__}: {e}") from e
         return result
 
     @abc.abstractmethod

--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -92,13 +92,13 @@ class PassBase(abc.ABC):
         If True, the pass will return the same model object that was passed in.
         If False, the pass will return a new model object.
         """
-        return True
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
     def changes_input(self) -> bool:
         """Whether the pass modifies input model."""
-        return True
+        raise NotImplementedError
 
     @property
     def destructive(self) -> bool:

--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -85,7 +85,9 @@ class PassBase(abc.ABC):
         except PreconditionError:
             raise
         except Exception as e:
-            raise PreconditionError(f"Pre-condition failed: {e.__class__.__name__}") from e
+            raise PreconditionError(
+                f"Pre-condition for pass '{self.__class__.__name__}' failed"
+            ) from e
 
         result = self.call(model)
 
@@ -95,7 +97,9 @@ class PassBase(abc.ABC):
         except PostconditionError:
             raise
         except Exception as e:
-            raise PostconditionError(f"Post-condition failed: {e.__class__.__name__}") from e
+            raise PostconditionError(
+                f"Post-condition for pass '{self.__class__.__name__}' failed"
+            ) from e
         return result
 
     @abc.abstractmethod

--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -22,7 +22,7 @@ __all__ = [
     "PassBase",
     "Sequential",
     "InPlacePass",
-    "OutOfPlacePass",
+    "FunctionalPass",
     "PassManager",
     "PassResult",
     # Errors
@@ -157,7 +157,7 @@ class InPlacePass(PassBase):
         return True
 
 
-class OutOfPlacePass(PassBase):
+class FunctionalPass(PassBase):
     """A pass that returns a new model but does not modify the input model."""
 
     @property

--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -177,6 +177,9 @@ class Sequential(PassBase):
             raise ValueError("Sequential must take at least one pass")
         self.passes = passes
         self._in_place = all(pass_.in_place for pass_ in passes)
+        # The reason changes_inputs is decided by the first pass is that if the first pass is either in-place,
+        # or if it is not designed to be in-place but somehow changes the input (destructive),
+        # this pass sequence will change inputs.
         self._changes_input = self.passes[0].changes_input or self.passes[0].in_place
 
     @property

--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -103,7 +103,7 @@ class PassBase(abc.ABC):
 
         if not isinstance(result, PassResult):
             raise TypeError(
-                f"The result of the pass '{self.__class__.__name__}' should be type PassResult."
+                f"The result of the pass '{self.__class__.__name__}' should be type PassResult. "
                 "Please create one with ir.passes.PassResult()."
             )
         return result

--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -85,7 +85,7 @@ class PassBase(abc.ABC):
         except PreconditionError:
             raise
         except Exception as e:
-            raise PreconditionError("Pre-condition failed") from e
+            raise PreconditionError(f"Pre-condition failed: {e.__class__.__name__}") from e
 
         result = self.call(model)
 
@@ -95,7 +95,7 @@ class PassBase(abc.ABC):
         except PostconditionError:
             raise
         except Exception as e:
-            raise PostconditionError(f"Post-condition failed: {e.__class__.__name__}: {e}") from e
+            raise PostconditionError(f"Post-condition failed: {e.__class__.__name__}") from e
         return result
 
     @abc.abstractmethod

--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -100,6 +100,12 @@ class PassBase(abc.ABC):
             raise PostconditionError(
                 f"Post-condition for pass '{self.__class__.__name__}' failed"
             ) from e
+
+        if not isinstance(result, PassResult):
+            raise TypeError(
+                f"The result of the pass '{self.__class__.__name__}' should be type PassResult."
+                "Please create one with ir.passes.PassResult()."
+            )
         return result
 
     @abc.abstractmethod

--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -69,7 +69,20 @@ class PassResult:
 
 
 class PassBase(abc.ABC):
-    """Base class for all passes."""
+    """Base class for all passes.
+
+
+    ``in_place`` and ``changes_input`` properties and what they mean:
+
+    +------------+------------------+----------------------------+
+    |            | changes_inputs   | not changes_inputs         |
+    +------------+------------------+----------------------------+
+    | in_place   | in place         | Side-effect-only pass      |
+    +------------+------------------+----------------------------+
+    | not        | destructive      | functional                 |
+    | in_place   |                  |                            |
+    +------------+------------------+----------------------------+
+    """
 
     @property
     @abc.abstractmethod

--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -70,12 +70,31 @@ class PassBase(abc.ABC):
 
     Class attributes:
         in_place: Whether the pass modifies the model in place.
+        destructive: Whether the pass will destroy the input model when ``in_place=False``.
     """
 
     in_place: bool = True
+    destructive: bool = False
 
     def __call__(self, model: ir.Model) -> PassResult:
-        return self.call(model)
+        # Check preconditions
+        try:
+            self.requires(model)
+        except PreconditionError:
+            raise
+        except Exception as e:
+            raise PreconditionError("Pre-condition failed") from e
+
+        result = self.call(model)
+
+        # Check postconditions
+        try:
+            self.ensures(model)
+        except PostconditionError:
+            raise
+        except Exception as e:
+            raise PostconditionError("Post-condition failed") from e
+        return result
 
     @abc.abstractmethod
     def call(self, model: ir.Model) -> PassResult:
@@ -97,26 +116,23 @@ class PassBase(abc.ABC):
         del model  # Unused
 
 
-class PassManager:
+class PassManager(PassBase):
     """Pass manager for the IR.
 
-    The PassManager is a callable that runs a sequence of passes on a model.
+    The PassManager is a Pass that runs a sequence of passes on a model.
 
     Attributes:
         passes: The passes to run.
-        check_invariants: Whether to check invariants before and after each pass.
         steps: The number of times to run the passes.
     """
 
     def __init__(
         self,
         passes: Sequence[PassBase],
-        check_invariants: bool = False,
         steps: int = 1,
     ):
         # TODO(justinchuby): Implement constraints
         self.passes = list(passes)
-        self.check_invariants = check_invariants
         self.steps = steps
 
     def __call__(self, model: ir.Model) -> PassResult:
@@ -137,17 +153,10 @@ class PassManager:
         modified = False
         for i, pass_ in enumerate(self.passes):
             logger.debug("Running the %s-th pass '%s', (step %s)", i, pass_, step)
-
-            # 1. Check preconditions
-            if self.check_invariants:
-                try:
-                    pass_.requires(model)
-                except Exception as e:
-                    raise PreconditionError(f"Pre-condition failed for {pass_}") from e
-
-            # 2. Run the pass
             try:
                 pass_result = pass_(model)
+            except (PreconditionError, PostconditionError):
+                raise
             except Exception as e:
                 prev_pass_names = [str(p) for p in self.passes[:i]]
                 raise PassError(
@@ -163,10 +172,4 @@ class PassManager:
             model = pass_result.model
             modified = modified or pass_result.modified
 
-            # 3. Check postconditions
-            if self.check_invariants:
-                try:
-                    pass_.ensures(model)
-                except Exception as e:
-                    raise PostconditionError(f"Post-condition failed for {pass_}") from e
         return PassResult(model, modified)

--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -186,6 +186,8 @@ class Sequential(PassBase):
     """Run a sequence of passes in order."""
 
     def __init__(self, *passes: PassBase):
+        if not passes:
+            raise ValueError("Sequential must take at least one pass")
         self.passes = passes
 
     @property

--- a/onnxscript/ir/passes/common/shape_inference.py
+++ b/onnxscript/ir/passes/common/shape_inference.py
@@ -22,11 +22,8 @@ logger = logging.getLogger(__name__)
 _BIG_TENSOR_SIZE_LIMIT = 1000  # 1KB
 
 
-class ShapeInferencePass(ir.passes.PassBase):
+class ShapeInferencePass(ir.passes.OutOfPlacePass):
     """This pass performs shape inference on the graph."""
-
-    # This pass does not modify the model in place.
-    in_place = False
 
     def __init__(
         self, check_type: bool = True, strict_mode: bool = True, data_prop: bool = True

--- a/onnxscript/ir/passes/common/shape_inference.py
+++ b/onnxscript/ir/passes/common/shape_inference.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 _BIG_TENSOR_SIZE_LIMIT = 1000  # 1KB
 
 
-class ShapeInferencePass(ir.passes.OutOfPlacePass):
+class ShapeInferencePass(ir.passes.FunctionalPass):
     """This pass performs shape inference on the graph."""
 
     def __init__(

--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -797,7 +797,7 @@ def _merge_shapes(shape1: ir.Shape | None, shape2: ir.Shape | None) -> ir.Shape 
     return ir.Shape([merge_dims(dim1, dim2) for dim1, dim2 in zip(shape1, shape2)])
 
 
-class FoldConstantsPass(ir.passes.PassBase):
+class FoldConstantsPass(ir.passes.InPlacePass):
     def __init__(
         self,
         *,

--- a/onnxscript/optimizer/_remove_unused.py
+++ b/onnxscript/optimizer/_remove_unused.py
@@ -82,7 +82,7 @@ def _process_function_or_graph(function_or_graph: ir.Function | ir.Graph) -> int
     return count
 
 
-class RemoveUnusedNodesPass(ir.passes.PassBase):
+class RemoveUnusedNodesPass(ir.passes.InPlacePass):
     def call(self, model: ir.Model) -> ir.passes.PassResult:
         count = _process_function_or_graph(model.graph)
         graph_outputs = frozenset(model.graph.outputs)

--- a/onnxscript/optimizer/_remove_unused_function.py
+++ b/onnxscript/optimizer/_remove_unused_function.py
@@ -25,7 +25,7 @@ def _clean_up_unused_functions(model: ir.Model, unused: set[ir.OperatorIdentifie
     logger.debug("Functions removed: %s", unused)
 
 
-class RemoveUnusedFunctionPass(ir.passes.PassBase):
+class RemoveUnusedFunctionPass(ir.passes.InPlacePass):
     def __init__(self):
         super().__init__()
         self.used: set[ir.OperatorIdentifier] | None = None


### PR DESCRIPTION
1. Run invariant functions `requires` and `ensures` by default at Pass `__call__` to match pytorch's pass behavior. This means the invariants cannot be too expensive because they are always checked.
2. Make PassManager a `Pass` so that it can be composed.
3. Add `changes_input` attribute to indicate if the input is changed. Turn two class attributes into properties for them to be dynamic. Combining the two attributes we can tell if a pass is destructive. For now the properties are unused but they will become useful when we want to have a better guard on pass usage etc.
4. Create `Sequential`, `InPlacePass`, `FunctionalPass` to help users create passes.