### PR TITLE
[IR] Expose the Tape module

### DIFF
--- a/onnxscript/ir/__init__.py
+++ b/onnxscript/ir/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "traversal",
     "convenience",
     "external_data",
+    "tape",
     # IR classes
     "Tensor",
     "ExternalTensor",
@@ -79,7 +80,7 @@ __all__ = [
     "save",
 ]
 
-from onnxscript.ir import convenience, external_data, passes, serde, traversal
+from onnxscript.ir import convenience, external_data, passes, serde, tape, traversal
 from onnxscript.ir._convenience import tensor
 from onnxscript.ir._core import (
     Attr,

--- a/onnxscript/ir/_tape.py
+++ b/onnxscript/ir/_tape.py
@@ -2,9 +2,6 @@
 # Licensed under the MIT License.
 """Convenience methods for constructing the IR."""
 
-# NOTE: This is a temporary solution for constructing the IR. It should be replaced
-# with a more permanent solution in the future.
-
 from __future__ import annotations
 
 from typing import Any, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple
@@ -14,7 +11,32 @@ from onnxscript.ir import _convenience
 
 
 class Tape(Iterable[ir.Node]):
-    """A tape for recording nodes that are created."""
+    """Tape class.
+
+    A tape is a recorder that collects nodes and initializers that are created so
+    that they can be used for creating a graph.
+
+    Example::
+        from onnxscript import ir
+
+        tape = Tape()
+        a = tape.initializer(ir.tensor([1, 2, 3], name="a"))
+        b: ir.Value = ...
+        c: ir.Value = ...
+        x = tape.op("Add", [a, b], attributes={"alpha": 1.0})
+        y = tape.op("Mul", [x, c], attributes={"beta": 2.0})
+        model = ir.Model(
+            graph := ir.Graph(
+                inputs=[b, c],
+                outputs=[y],
+                nodes=tape.nodes,
+                opset_imports={"": 20},
+            ),
+            ir_version=10,
+        )
+        for initializer in tape.initializers:
+            graph.register_initializer(initializer)
+    """
 
     def __init__(self) -> None:
         self._nodes: list[ir.Node] = []

--- a/onnxscript/ir/_tape.py
+++ b/onnxscript/ir/_tape.py
@@ -36,7 +36,14 @@ class Tape(Iterable[ir.Node]):
         op_type: str,
         inputs: Sequence[ir.Value | None],
         attributes: Mapping[str, _convenience.SupportedAttrTypes] | None = None,
-        domain: str = "",
+        *,
+        domain: str  = "",
+        overload: str = "",
+        version: int | None = None,
+        graph: ir.Graph | None = None,
+        name: str | None = None,
+        doc_string: str | None = None,
+        metadata_props: dict[str, str] | None = None,
     ) -> ir.Value:
         if attributes is None:
             attrs: Sequence[ir.Attr | ir.RefAttr] = ()
@@ -53,8 +60,14 @@ class Tape(Iterable[ir.Node]):
         inputs: Sequence[ir.Value | None],
         attributes: Mapping[str, _convenience.SupportedAttrTypes] | None = None,
         *,
-        num_outputs: int,
-        domain: str = "",
+        domain: str  = "",
+        overload: str = "",
+        num_outputs: int | None = None,
+        version: int | None = None,
+        graph: ir.Graph | None = None,
+        name: str | None = None,
+        doc_string: str | None = None,
+        metadata_props: dict[str, str] | None = None,
     ) -> Sequence[ir.Value]:
         if attributes is None:
             attrs: Sequence[ir.Attr | ir.RefAttr] = ()

--- a/onnxscript/ir/_tape.py
+++ b/onnxscript/ir/_tape.py
@@ -37,7 +37,7 @@ class Tape(Iterable[ir.Node]):
         inputs: Sequence[ir.Value | None],
         attributes: Mapping[str, _convenience.SupportedAttrTypes] | None = None,
         *,
-        domain: str  = "",
+        domain: str = "",
         overload: str = "",
         version: int | None = None,
         graph: ir.Graph | None = None,
@@ -49,7 +49,19 @@ class Tape(Iterable[ir.Node]):
             attrs: Sequence[ir.Attr | ir.RefAttr] = ()
         else:
             attrs = _convenience.convert_attributes(attributes)
-        node = ir.Node(domain, op_type, inputs, attributes=attrs, num_outputs=1)
+        node = ir.Node(
+            domain,
+            op_type,
+            inputs,
+            attributes=attrs,
+            num_outputs=1,
+            overload=overload,
+            version=version,
+            graph=graph,
+            name=name,
+            doc_string=doc_string,
+            metadata_props=metadata_props,
+        )
         self._nodes.append(node)
 
         return node.outputs[0]
@@ -60,7 +72,7 @@ class Tape(Iterable[ir.Node]):
         inputs: Sequence[ir.Value | None],
         attributes: Mapping[str, _convenience.SupportedAttrTypes] | None = None,
         *,
-        domain: str  = "",
+        domain: str = "",
         overload: str = "",
         num_outputs: int | None = None,
         version: int | None = None,
@@ -73,7 +85,19 @@ class Tape(Iterable[ir.Node]):
             attrs: Sequence[ir.Attr | ir.RefAttr] = ()
         else:
             attrs = _convenience.convert_attributes(attributes)
-        node = ir.Node(domain, op_type, inputs, attributes=attrs, num_outputs=num_outputs)
+        node = ir.Node(
+            domain,
+            op_type,
+            inputs,
+            attributes=attrs,
+            num_outputs=num_outputs,
+            overload=overload,
+            version=version,
+            graph=graph,
+            name=name,
+            doc_string=doc_string,
+            metadata_props=metadata_props,
+        )
         self._nodes.append(node)
 
         return node.outputs

--- a/onnxscript/ir/passes/common/shape_inference_test.py
+++ b/onnxscript/ir/passes/common/shape_inference_test.py
@@ -7,7 +7,6 @@ import unittest
 import numpy as np
 
 from onnxscript import ir
-from onnxscript.ir import building
 from onnxscript.ir.passes.common import shape_inference
 
 
@@ -24,7 +23,7 @@ class TestShapeInferencePass(unittest.TestCase):
             ),
         ]
 
-        tape = building.Tape()
+        tape = ir.tape.Tape()
 
         output = tape.op("Add", inputs=inputs)
 
@@ -65,7 +64,7 @@ class TestShapeInferencePass(unittest.TestCase):
             ),
         ]
 
-        tape = building.Tape()
+        tape = ir.tape.Tape()
 
         # Shape and type are not explicitly set for the initializer but it should still work
         initializer = tape.initializer(

--- a/onnxscript/ir/tape.py
+++ b/onnxscript/ir/tape.py
@@ -1,0 +1,15 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Taping module to facilitate building IR graphs."""
+
+# NOTE: Be *selective* about what this module exports because it is part of the public API.
+
+from __future__ import annotations
+
+__all__ = [
+    "Tape",
+]
+
+from onnxscript.ir._tape import Tape
+
+Tape.__module__ = __name__


### PR DESCRIPTION
Expose the `Tape` class under `ir.tape` for simplifying graph construction in the IR. This is a secondary API for convenience. I updated `onnxscript/ir/passes/common/shape_inference_test.py` to demonstrate usage.