### PR TITLE
Rotary embedding needs function extraction

### DIFF
--- a/onnxscript/rewriter/ort_fusions/rotary_embedding.py
+++ b/onnxscript/rewriter/ort_fusions/rotary_embedding.py
@@ -24,6 +24,9 @@ def _rotate_half_pattern(op, x, start1, end1, start2, end2):
 
 
 class RotaryEmbeddingFusion(pattern.RewriteRuleClassBase):
+    def __init__(self):
+        super().__init__(name="RotaryEmbedding", as_function=True)
+
     def pattern(self, op, x, cos, sin, start1, end1, start2, end2):
         return x * cos + _rotate_half_pattern(op, x, start1, end1, start2, end2) * sin
 


### PR DESCRIPTION
Rotary embedding fusion needs as_function=True.