### PR TITLE
Turn inliner into a pass and use it in rewriter & optimizer

### DIFF
--- a/onnxscript/optimizer/_inliner.py
+++ b/onnxscript/optimizer/_inliner.py
@@ -190,9 +190,9 @@ def _abbreviate(
 
 class InlinePass(ir.passes.InPlacePass):
     def __init__(self) -> None:
-        self._functions = {}
-        self._function_id_abbreviations = {}
-        self._opset_imports = {}
+        self._functions: dict[ir.OperatorIdentifier, ir.Function] = {}
+        self._function_id_abbreviations: dict[ir.OperatorIdentifier, str] = {}
+        self._opset_imports: dict[str, int] = {}
         self.used_value_names: set[str] = set()
         self.used_node_names: set[str] = set()
         self.node_context: dict[ir.Node, CallStack] = {}

--- a/onnxscript/optimizer/_optimizer.py
+++ b/onnxscript/optimizer/_optimizer.py
@@ -72,4 +72,5 @@ def optimize_ir(
         onnxscript.ir.passes.common.unused_removal.RemoveUnusedNodesPass(),
     )
     assert optimizer_pass.in_place
-    optimizer_pass(model)
+    result = optimizer_pass(model)
+    assert result.model is model

--- a/onnxscript/optimizer/_optimizer.py
+++ b/onnxscript/optimizer/_optimizer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 
+import onnxscript.ir.passes.common.unused_removal
 import onnxscript.optimizer
 from onnxscript import ir, rewriter
 from onnxscript.optimizer import _constant_folding, _inliner
@@ -50,15 +51,25 @@ def optimize_ir(
         stop_if_no_change: Not supported currently (has no effect). Meant to stop the
             outer optimization loop if no change is detected in one iteration.
     """
-    del stop_if_no_change  # Looks like rewriter doesn't support this yet.
-    # TODO(justinchuby): Update this to use a pass manager
-    _inliner.inline(model)
-    for _ in range(num_iterations):
-        _constant_folding.fold_constants(
-            model,
-            onnx_shape_inference=onnx_shape_inference,
-            input_size_limit=input_size_limit,
-            output_size_limit=output_size_limit,
-        )
-        rewriter.rewrite(model, pattern_rewrite_rules=_DEFAULT_REWRITE_RULES)
-    onnxscript.optimizer.remove_unused_nodes(model)
+    optimizer_pass = ir.passes.Sequential(
+        _inliner.InlinePass(),
+        ir.passes.PassManager(
+            [
+                _constant_folding.FoldConstantsPass(
+                    external_data_folder="",
+                    shape_inference=onnx_shape_inference,
+                    input_size_limit=input_size_limit,
+                    output_size_limit=output_size_limit,
+                ),
+                rewriter.RewritePass(_DEFAULT_REWRITE_RULES),
+                onnxscript.ir.passes.common.unused_removal.RemoveUnusedNodesPass(),
+                onnxscript.ir.passes.common.unused_removal.RemoveUnusedFunctionsPass(),
+                onnxscript.ir.passes.common.unused_removal.RemoveUnusedOpsetsPass(),
+            ],
+            steps=num_iterations,
+            early_stop=stop_if_no_change,
+        ),
+        onnxscript.ir.passes.common.unused_removal.RemoveUnusedNodesPass(),
+    )
+    assert optimizer_pass.in_place
+    optimizer_pass(model)

--- a/onnxscript/rewriter/__init__.py
+++ b/onnxscript/rewriter/__init__.py
@@ -17,15 +17,34 @@ from onnxscript import ir
 from onnxscript.ir.passes.common import unused_removal
 from onnxscript.rewriter import pattern
 
-RewriteRuleSet = pattern.RewriteRuleSet
 PatternRewriteRule = pattern.RewriteRule
 
 ModelProtoOrIr = TypeVar("ModelProtoOrIr", onnx.ModelProto, ir.Model)
 
 
+class RewritePass(ir.passes.InPlacePass):
+    def __init__(
+        self,
+        pattern_rewrite_rules: Union[
+            Sequence[PatternRewriteRule], pattern.RewriteRuleSet
+        ] = (),
+    ) -> None:
+        if pattern_rewrite_rules:
+            if not isinstance(pattern_rewrite_rules, pattern.RewriteRuleSet):
+                # Create a pattern rule-set using provided rules
+                pattern_rewrite_rules = pattern.RewriteRuleSet(pattern_rewrite_rules)
+        self.pattern_rewrite_rules: pattern.RewriteRuleSet = pattern_rewrite_rules
+
+    def call(self, model: ir.Model) -> ir.passes.PassResult:
+        count = self.pattern_rewrite_rules.apply_to_model(model)
+        if count:
+            print(f"Applied {count} of general pattern rewrite rules.")
+        return ir.passes.PassResult(model, bool(count))
+
+
 def rewrite(
     model: ModelProtoOrIr,
-    pattern_rewrite_rules: Union[Sequence[PatternRewriteRule], RewriteRuleSet] = (),
+    pattern_rewrite_rules: Union[Sequence[PatternRewriteRule], pattern.RewriteRuleSet] = (),
 ) -> ModelProtoOrIr:
     if isinstance(model, onnx.ModelProto):
         model_ir = ir.serde.deserialize_model(model)
@@ -33,21 +52,16 @@ def rewrite(
     else:
         model_ir = model
         proto = False
-    if pattern_rewrite_rules:
-        if not isinstance(pattern_rewrite_rules, RewriteRuleSet):
-            # Create a pattern rule-set using provided rules
-            pattern_rewrite_rules = pattern.RewriteRuleSet(pattern_rewrite_rules)
-        count = pattern_rewrite_rules.apply_to_model(model_ir)
-        if count:
-            print(f"Applied {count} of general pattern rewrite rules.")
-    unused_remover = ir.passes.PassManager(
+
+    rewrite_pass = ir.passes.PassManager(
         (
+            RewritePass(pattern_rewrite_rules),
             unused_removal.RemoveUnusedNodesPass(),
             unused_removal.RemoveUnusedFunctionsPass(),
             unused_removal.RemoveUnusedOpsetsPass(),
         )
     )
-    model_ir = unused_remover(model_ir).model
+    model_ir = rewrite_pass(model_ir).model
     if proto:
         return ir.serde.serialize_model(model_ir)
     return model_ir  # type: ignore[return-value]

--- a/onnxscript/rewriter/__init__.py
+++ b/onnxscript/rewriter/__init__.py
@@ -25,14 +25,13 @@ ModelProtoOrIr = TypeVar("ModelProtoOrIr", onnx.ModelProto, ir.Model)
 class RewritePass(ir.passes.InPlacePass):
     def __init__(
         self,
-        pattern_rewrite_rules: Union[
-            Sequence[PatternRewriteRule], pattern.RewriteRuleSet
-        ] = (),
+        pattern_rewrite_rules: Sequence[PatternRewriteRule] | pattern.RewriteRuleSet = (),
     ) -> None:
         if pattern_rewrite_rules:
             if not isinstance(pattern_rewrite_rules, pattern.RewriteRuleSet):
                 # Create a pattern rule-set using provided rules
                 pattern_rewrite_rules = pattern.RewriteRuleSet(pattern_rewrite_rules)
+        assert isinstance(pattern_rewrite_rules, pattern.RewriteRuleSet)
         self.pattern_rewrite_rules: pattern.RewriteRuleSet = pattern_rewrite_rules
 
     def call(self, model: ir.Model) -> ir.passes.PassResult:


### PR DESCRIPTION
Use passes in optimizer and rewriter.

1. By opting into using the pass infra early, we get the benefit of getting the additional features in pass infra w/o having to pay higher refactoring cost in the future. We will be able to add more sophisticated debug utilities/snapshot capabilities etc. to the passes.
2. Since we are offering the pass infra to users, we can start validating it internally by using it here. If order altering becomes a valid use case we can expect users may need that and we can create appropriate facilities to support the usage.