### PR TITLE
Handle empty rewrite rules in rewrite function

### DIFF
--- a/onnxscript/optimizer/_inliner.py
+++ b/onnxscript/optimizer/_inliner.py
@@ -190,6 +190,7 @@ def _abbreviate(
 
 class InlinePass(ir.passes.InPlacePass):
     def __init__(self) -> None:
+        super().__init__()
         self._functions: dict[ir.OperatorIdentifier, ir.Function] = {}
         self._function_id_abbreviations: dict[ir.OperatorIdentifier, str] = {}
         self._opset_imports: dict[str, int] = {}

--- a/onnxscript/optimizer/_legacy/_optimizer.py
+++ b/onnxscript/optimizer/_legacy/_optimizer.py
@@ -15,7 +15,6 @@ from onnxscript.optimizer._legacy._simple_function_folding import (
     inline_simple_functions,
 )
 from onnxscript.optimizer._legacy.constant_folding import fold_constants
-from onnxscript.optimizer._optimizer import _DEFAULT_REWRITE_RULES
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +74,7 @@ def optimize(
         onnxscript.optimizer.remove_unused_functions(model)
         inline_functions_with_unused_outputs(model)
         # NOTE: This is general rewrite rules
-        model = rewriter.rewrite(model, pattern_rewrite_rules=_DEFAULT_REWRITE_RULES)
+        model = rewriter.rewrite(model)
         if stop_if_no_change and not modified:
             logger.debug("Stopping after %d iterations.", _)
             break

--- a/onnxscript/optimizer/_optimizer.py
+++ b/onnxscript/optimizer/_optimizer.py
@@ -5,28 +5,10 @@ from __future__ import annotations
 import logging
 
 import onnxscript.ir.passes.common.unused_removal
-import onnxscript.optimizer
 from onnxscript import ir, rewriter
 from onnxscript.optimizer import _constant_folding, _inliner
-from onnxscript.rewriter import (
-    broadcast_to_matmul,
-    cast_constant_of_shape,
-    collapse_slices,
-    gemm_to_matmul_add,
-    llama_rule_sets,
-    no_op,
-)
 
 logger = logging.getLogger(__name__)
-
-_DEFAULT_REWRITE_RULES: tuple[rewriter.pattern.RewriteRule, ...] = (
-    *no_op.rules.rules,  # TODO: merge this rule into constant folding?
-    *broadcast_to_matmul.rules.rules,
-    gemm_to_matmul_add.rule,  # type: ignore[has-type]
-    *cast_constant_of_shape.rules.rules,
-    *collapse_slices.rules.rules,
-    *llama_rule_sets.llama_p0_rule_set().rules,
-)
 
 
 def optimize_ir(
@@ -61,7 +43,7 @@ def optimize_ir(
                     input_size_limit=input_size_limit,
                     output_size_limit=output_size_limit,
                 ),
-                rewriter.RewritePass(_DEFAULT_REWRITE_RULES),
+                rewriter.RewritePass(rewriter._DEFAULT_REWRITE_RULES),
                 onnxscript.ir.passes.common.unused_removal.RemoveUnusedNodesPass(),
                 onnxscript.ir.passes.common.unused_removal.RemoveUnusedFunctionsPass(),
                 onnxscript.ir.passes.common.unused_removal.RemoveUnusedOpsetsPass(),

--- a/onnxscript/rewriter/__init__.py
+++ b/onnxscript/rewriter/__init__.py
@@ -38,8 +38,8 @@ _DEFAULT_REWRITE_RULES: tuple[pattern.RewriteRule, ...] = (
 class RewritePass(ir.passes.InPlacePass):
     def __init__(
         self,
-        /,
         rules: Sequence[pattern.RewriteRule] | pattern.RewriteRuleSet,
+        /,
     ) -> None:
         super().__init__()
         if isinstance(rules, Sequence):

--- a/onnxscript/rewriter/__init__.py
+++ b/onnxscript/rewriter/__init__.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 from typing import Sequence, TypeVar, Union
 
 __all__ = [
-    # Modules
     "pattern",
-    # Functions
     "rewrite",
+    "RewritePass",
 ]
 
 import onnx
@@ -17,18 +16,18 @@ from onnxscript import ir
 from onnxscript.ir.passes.common import unused_removal
 from onnxscript.rewriter import pattern
 
-PatternRewriteRule = pattern.RewriteRule
-
 ModelProtoOrIr = TypeVar("ModelProtoOrIr", onnx.ModelProto, ir.Model)
 
 
 class RewritePass(ir.passes.InPlacePass):
     def __init__(
         self,
-        pattern_rewrite_rules: Sequence[PatternRewriteRule] | pattern.RewriteRuleSet,
+        pattern_rewrite_rules: Sequence[pattern.RewriteRule] | pattern.RewriteRuleSet,
     ) -> None:
         super().__init__()
         if isinstance(pattern_rewrite_rules, Sequence):
+            if not pattern_rewrite_rules:
+                raise ValueError("pattern_rewrite_rules must not be empty")
             # Create a pattern rule-set using provided rules
             pattern_rewrite_rules = pattern.RewriteRuleSet(pattern_rewrite_rules)
         assert isinstance(pattern_rewrite_rules, pattern.RewriteRuleSet)
@@ -43,7 +42,7 @@ class RewritePass(ir.passes.InPlacePass):
 
 def rewrite(
     model: ModelProtoOrIr,
-    pattern_rewrite_rules: Union[Sequence[PatternRewriteRule], pattern.RewriteRuleSet] = (),
+    pattern_rewrite_rules: Union[Sequence[pattern.RewriteRule], pattern.RewriteRuleSet] = (),
 ) -> ModelProtoOrIr:
     """Rewrite the model using the provided pattern rewrite rules.
 

--- a/onnxscript/rewriter/__init__.py
+++ b/onnxscript/rewriter/__init__.py
@@ -69,20 +69,23 @@ def rewrite(
     Args:
         model: The model to be rewritten. Can be an ONNX ModelProto or an ir.Model.
         pattern_rewrite_rules: A sequence of pattern rewrite rules or a RewriteRuleSet.
-            If not provided or empty, default rules will be applied.
+            If not provided, default rules will be applied. If empty, no rules will be applied
+            and the original model will be returned.
 
     Returns:
-        The rewritten model, either as an ONNX ModelProto or an ir.Model.
+        The rewritten model as the same type as the input model.
     """
+    if pattern_rewrite_rules is None:
+        pattern_rewrite_rules = _DEFAULT_REWRITE_RULES
+    elif not pattern_rewrite_rules:
+        return model
+
     if isinstance(model, onnx.ModelProto):
         model_ir = ir.serde.deserialize_model(model)
         proto = True
     else:
         model_ir = model
         proto = False
-
-    if not pattern_rewrite_rules:
-        pattern_rewrite_rules = _DEFAULT_REWRITE_RULES
 
     rewrite_pass = ir.passes.PassManager(
         (

--- a/onnxscript/rewriter/__init__.py
+++ b/onnxscript/rewriter/__init__.py
@@ -38,19 +38,20 @@ _DEFAULT_REWRITE_RULES: tuple[pattern.RewriteRule, ...] = (
 class RewritePass(ir.passes.InPlacePass):
     def __init__(
         self,
-        pattern_rewrite_rules: Sequence[pattern.RewriteRule] | pattern.RewriteRuleSet,
+        /,
+        rules: Sequence[pattern.RewriteRule] | pattern.RewriteRuleSet,
     ) -> None:
         super().__init__()
-        if isinstance(pattern_rewrite_rules, Sequence):
-            if not pattern_rewrite_rules:
-                raise ValueError("pattern_rewrite_rules must not be empty")
+        if isinstance(rules, Sequence):
+            if not rules:
+                raise ValueError("rules must not be empty")
             # Create a pattern rule-set using provided rules
-            pattern_rewrite_rules = pattern.RewriteRuleSet(pattern_rewrite_rules)
-        assert isinstance(pattern_rewrite_rules, pattern.RewriteRuleSet)
-        self.pattern_rewrite_rules: pattern.RewriteRuleSet = pattern_rewrite_rules
+            rules = pattern.RewriteRuleSet(rules)
+        assert isinstance(rules, pattern.RewriteRuleSet)
+        self.rules: pattern.RewriteRuleSet = rules
 
     def call(self, model: ir.Model) -> ir.passes.PassResult:
-        count = self.pattern_rewrite_rules.apply_to_model(model)
+        count = self.rules.apply_to_model(model)
         if count:
             print(f"Applied {count} of general pattern rewrite rules.")
         return ir.passes.PassResult(model, bool(count))

--- a/onnxscript/rewriter/__init__.py
+++ b/onnxscript/rewriter/__init__.py
@@ -16,7 +16,7 @@ from onnxscript import ir
 from onnxscript.ir.passes.common import unused_removal
 from onnxscript.rewriter import pattern
 
-ModelProtoOrIr = TypeVar("ModelProtoOrIr", onnx.ModelProto, ir.Model)
+_ModelProtoOrIr = TypeVar("_ModelProtoOrIr", onnx.ModelProto, ir.Model)
 
 
 class RewritePass(ir.passes.InPlacePass):
@@ -41,9 +41,9 @@ class RewritePass(ir.passes.InPlacePass):
 
 
 def rewrite(
-    model: ModelProtoOrIr,
+    model: _ModelProtoOrIr,
     pattern_rewrite_rules: Union[Sequence[pattern.RewriteRule], pattern.RewriteRuleSet] = (),
-) -> ModelProtoOrIr:
+) -> _ModelProtoOrIr:
     """Rewrite the model using the provided pattern rewrite rules.
 
     Unused nodes, functions, and opsets will be removed after the rewrite.

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -1664,6 +1664,8 @@ def _get_new_overload(model: ir.Model, domain: str, name: str) -> str:
 
 class RewriteRuleSet:
     def __init__(self, rules: Sequence[RewriteRule], *, commute: bool = False) -> None:
+        if not rules:
+            raise ValueError("rules must contain at least one rule")
         if commute:
             rules = list(itertools.chain.from_iterable([rule.commute() for rule in rules]))
         self.rules = rules

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -1673,6 +1673,9 @@ class RewriteRuleSet:
         # NOT remove nodes (immediately when it is applied)
         self.remove_unused_nodes = any(not rule.remove_nodes for rule in rules)
 
+    def __repr__(self) -> str:
+        return f"RewriteRuleSet({self.rules})"
+
     def _apply_to_graph_or_function(
         self,
         model: ir.Model,

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -1674,7 +1674,7 @@ class RewriteRuleSet:
         self.remove_unused_nodes = any(not rule.remove_nodes for rule in rules)
 
     def __repr__(self) -> str:
-        return f"RewriteRuleSet({self.rules})"
+        return f"{self.__class__.__name__}({self.rules})"
 
     def _apply_to_graph_or_function(
         self,


### PR DESCRIPTION
In https://github.com/microsoft/onnxscript/pull/2149 the logic for skipping rewrite when no rules are provided was removed. This PR adds the logic back and hardens input checks. Now if no rules are provided to `rewrite()`, it will only run cleanup passes.