### PR TITLE
Avoid using fixed value for max_pos_ids in cos_sin_cache fusion

### DIFF
--- a/onnxscript/rewriter/ort_fusions/_smollm_2.py
+++ b/onnxscript/rewriter/ort_fusions/_smollm_2.py
@@ -459,7 +459,7 @@ class _SmollmTest2:
         if not hasattr(self, "_ort_inputs"):
             inputs = {
                 "input_ids": numpy.random.randint(0, 49152, (1, 30)).astype(numpy.int64),
-                "position_ids": numpy.ones((1, 30), dtype=numpy.int64),
+                "position_ids": numpy.arange(30).reshape(1, 30).astype(numpy.int64),
                 "past_key_values_0_0": numpy.random.rand(1, 32, 16, 64).astype(numpy.float32),
                 "past_key_values_0_1": numpy.random.rand(1, 32, 16, 64).astype(numpy.float32),
             }

--- a/onnxscript/rewriter/ort_fusions/cos_sin_cache.py
+++ b/onnxscript/rewriter/ort_fusions/cos_sin_cache.py
@@ -96,6 +96,8 @@ class CosSinCacheFusion(pattern.RewriteRuleClassBase):
 
         # If we do not compute max_pos_id using ONNX ops, use inv_freq and position_ids
         # to compute angles and cos/sin values
+        # Note: The one is added to max_pos_id as position_ids are 0-indexed
+        # and the range of position ids should be [0, max_pos_id], max_pos_id inclusive.
         inv_freq_values = inv_freq.const_value.numpy().reshape(1, -1)
         pos_id_range = np.arange(max_pos_id + 1, dtype=np.float32).reshape(-1, 1)
         angles = np.matmul(pos_id_range, inv_freq_values)

--- a/onnxscript/rewriter/ort_fusions/cos_sin_cache.py
+++ b/onnxscript/rewriter/ort_fusions/cos_sin_cache.py
@@ -97,7 +97,7 @@ class CosSinCacheFusion(pattern.RewriteRuleClassBase):
         # If we do not compute max_pos_id using ONNX ops, use inv_freq and position_ids
         # to compute angles and cos/sin values
         inv_freq_values = inv_freq.const_value.numpy().reshape(1, -1)
-        pos_id_range = np.arange(max_pos_id, dtype=np.float32).reshape(-1, 1)
+        pos_id_range = np.arange(max_pos_id + 1, dtype=np.float32).reshape(-1, 1)
         angles = np.matmul(pos_id_range, inv_freq_values)
         return self._compute_const_freqs(op, angles)
 


### PR DESCRIPTION
To apply the cos sin fusion pattern-rewrite, we need to know the maximum position id.
- If model/config has this information, use it calculate max_pos_id
- If not, calculate max_pos_id using position ids using ONNX ops
- Removes dependence of pre-setting the max_pos_id for each rewrite rule