### PR TITLE
Annotate `script()` with `ParamSpec` for more accurate typing

### DIFF
--- a/onnxscript/main.py
+++ b/onnxscript/main.py
@@ -6,13 +6,17 @@ from __future__ import annotations
 import ast
 import inspect
 import sys
-from typing import Any, Callable, Optional, Sequence
+from typing import Any, Callable, Optional, Sequence, TypeVar
 
 import onnx.helper
+from typing_extensions import ParamSpec
 
 import onnxscript
 from onnxscript import converter, irbuilder, values
 from onnxscript._internal import ast_utils
+
+_R = TypeVar("_R")
+_P = ParamSpec("_P")
 
 
 def script_check(
@@ -39,7 +43,7 @@ def script(
     opset: Optional[values.Opset] = None,
     default_opset: Optional[values.Opset] = None,
     **kwargs: Any,
-) -> Callable[[Callable], onnxscript.OnnxFunction]:
+) -> Callable[[Callable[_P, _R]], onnxscript.OnnxFunction[_P, _R]]:
     """Main decorator. Declares a function as an onnx function.
 
     Args:
@@ -75,7 +79,7 @@ def script(
             "Script parameter must be an opset. Did you use @script instead of @script()?"
         )
 
-    def transform(f: Callable) -> onnxscript.OnnxFunction:
+    def transform(f: Callable[_P, _R]) -> onnxscript.OnnxFunction[_P, _R]:
         if not inspect.isfunction(f):
             raise TypeError("The ONNXScript decorator should be applied to functions only.")
 

--- a/onnxscript/values.py
+++ b/onnxscript/values.py
@@ -13,19 +13,26 @@ from typing import (  # type: ignore[attr-defined]
     Any,
     Callable,
     ClassVar,
+    Generic,
     Optional,
     Protocol,
     Sequence,
+    TypeVar,
     _GenericAlias,
 )
 
 import onnx
 import onnx.defs
+from typing_extensions import ParamSpec
 
 from onnxscript import converter as converter_module
 from onnxscript import irbuilder, sourceinfo, type_annotation
 from onnxscript._internal import ast_utils, deprecation
 from onnxscript.ir import _schemas
+
+_R = TypeVar("_R")
+_P = ParamSpec("_P")
+
 
 _ATTRIBUTE_TYPE_TO_PYTHON_TYPE = {
     onnx.defs.OpSchema.AttrType.FLOAT: float,
@@ -464,7 +471,7 @@ def _op_schema_from_function_ir(
     )
 
 
-class OnnxFunction(Op):
+class OnnxFunction(Op, Generic[_P, _R]):
     """Represents an ONNX op for which a function-body has been defined in onnxscript.
 
     Attributes:
@@ -566,12 +573,12 @@ class OnnxFunction(Op):
 
         return fun
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R:
         """Implements an eager-mode execution of an onnxscript function."""
         # FIXME(after #225): Move import to the top of the file.
         from onnxscript import evaluator  # pylint: disable=import-outside-toplevel
 
-        return evaluator.default().eval_function(self, args, kwargs)
+        return evaluator.default().eval_function(self, args, kwargs)  # type: ignore[return-value]
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.function!r})"

--- a/onnxscript/values.py
+++ b/onnxscript/values.py
@@ -578,7 +578,7 @@ class OnnxFunction(Op, Generic[_P, _R]):
         # FIXME(after #225): Move import to the top of the file.
         from onnxscript import evaluator  # pylint: disable=import-outside-toplevel
 
-        return evaluator.default().eval_function(self, args, kwargs)  # type: ignore[return-value]
+        return evaluator.default().eval_function(self, args, kwargs)  # type: ignore[arg-type, return-value]
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.function!r})"


### PR DESCRIPTION
This pull request introduces type parameterization using `TypeVar` and `ParamSpec` to enhance type safety and flexibility in the `onnxscript` module.

### Type Parameterization Enhancements:

* [`onnxscript/main.py`](diffhunk://#diff-1f9f494aa46ce42a47c4191deb91aaded1b216b24accc43685561281507e7ca8L9-R20): Introduced `_R` and `_P` type variables, and updated the `script` decorator and `transform` function signatures to use `Callable[_P, _R]` for better type inference. [[1]](diffhunk://#diff-1f9f494aa46ce42a47c4191deb91aaded1b216b24accc43685561281507e7ca8L9-R20) [[2]](diffhunk://#diff-1f9f494aa46ce42a47c4191deb91aaded1b216b24accc43685561281507e7ca8L42-R46) [[3]](diffhunk://#diff-1f9f494aa46ce42a47c4191deb91aaded1b216b24accc43685561281507e7ca8L78-R82)
* [`onnxscript/values.py`](diffhunk://#diff-9625fb4ad20b7aa13388f751c0fde3a809f2b6c91023413a02ea2249f9071248R16-R36): Added `Generic`, `TypeVar`, and `ParamSpec` imports, and updated the `OnnxFunction` class to inherit from `Generic[_P, _R]`. Modified the `__call__` method to use `_P.args` and `_P.kwargs` for improved type checking. [[1]](diffhunk://#diff-9625fb4ad20b7aa13388f751c0fde3a809f2b6c91023413a02ea2249f9071248R16-R36) [[2]](diffhunk://#diff-9625fb4ad20b7aa13388f751c0fde3a809f2b6c91023413a02ea2249f9071248L467-R474) [[3]](diffhunk://#diff-9625fb4ad20b7aa13388f751c0fde3a809f2b6c91023413a02ea2249f9071248L569-R581)