### PR TITLE
[Pass] Fix bugs in LiftConstantsToInitializersPass

### DIFF
--- a/onnxscript/ir/passes/common/constant_manipulation.py
+++ b/onnxscript/ir/passes/common/constant_manipulation.py
@@ -18,13 +18,28 @@ logger = logging.getLogger(__name__)
 
 
 class LiftConstantsToInitializersPass(ir.passes.InPlacePass):
+    """Lift constants to initializers.
+
+    Attributes:
+        lift_all_constants: Whether to lift all constants, including non-tensor values.
+            Default to False, where only tensor constants are lifted.
+    """
+
+    def __init__(self, lift_all_constants: bool = False):
+        super().__init__()
+        self._lift_all_constants = lift_all_constants
+
     def call(self, model: ir.Model) -> ir.passes.PassResult:
-        """Convert constant nodes from node belonged graph to its initializers."""
         count = 0
         for node in ir.traversal.RecursiveGraphIterator(model.graph):
+            assert node.graph is not None
             if node.op_type != "Constant" or node.domain not in ("", "onnx.ai"):
                 continue
-
+            if node.outputs[0] in node.graph.outputs:
+                logger.debug(
+                    "Constant node '%s' is used as output, so it can't be lifted.", node.name
+                )
+                continue
             constant_node_attribute = set(node.attributes.keys())
             if len(constant_node_attribute) != 1:
                 logger.debug(
@@ -36,13 +51,11 @@ class LiftConstantsToInitializersPass(ir.passes.InPlacePass):
             initializer_name = node.outputs[0].name
             assert initializer_name is not None
             assert isinstance(attr_value, ir.Attr)
-            tensor = _constant_node_attribute_to_tensor(
-                attr_name, attr_value, initializer_name
+            tensor = self._constant_node_attribute_to_tensor(
+                node, attr_name, attr_value, initializer_name
             )
             if tensor is None:
-                logger.debug(
-                    "Invalid constant node '%s' has unsupported attribute value", node.name
-                )
+                # The reason of None is logged in _constant_node_attribute_to_tensor
                 continue
             # Register an initializer with the tensor value
             initializer = ir.Value(
@@ -51,7 +64,6 @@ class LiftConstantsToInitializersPass(ir.passes.InPlacePass):
                 type=ir.TensorType(tensor.dtype),
                 const_value=tensor,
             )
-            assert node.graph is not None
             assert isinstance(node.graph, ir.Graph)
             node.graph.register_initializer(initializer)
             # Replace the constant node with the initilizer
@@ -65,31 +77,43 @@ class LiftConstantsToInitializersPass(ir.passes.InPlacePass):
             logger.debug("Lifted %s constants to initializers", count)
         return ir.passes.PassResult(model, modified=bool(count))
 
+    def _constant_node_attribute_to_tensor(
+        self, node, attr_name: str, attr_value: ir.Attr, initializer_name: str
+    ) -> ir.Tensor | None:
+        """Convert constant node attribute to tensor."""
+        if not self._lift_all_constants and attr_name != "value":
+            logger.debug(
+                "Constant node '%s' has non-tensor attribute '%s'", node.name, attr_name
+            )
+            return None
 
-def _constant_node_attribute_to_tensor(
-    attr_name: str, attr_value: ir.Attr, initializer_name: str
-) -> ir.Tensor | None:
-    """Convert constant node attribute to tensor."""
-    if attr_name == "value":
-        tensor = attr_value.as_tensor()  # type: ignore[union-attr]
-    elif attr_name == "value_int":
-        tensor = ir.tensor(attr_value.as_int(), dtype=ir.DataType.INT64, name=initializer_name)
-    elif attr_name == "value_ints":
-        tensor = ir.tensor(
-            attr_value.as_ints(), dtype=ir.DataType.INT64, name=initializer_name
-        )
-    elif attr_name == "value_float":
-        tensor = ir.tensor(
-            attr_value.as_float(), dtype=ir.DataType.FLOAT, name=initializer_name
-        )
-    elif attr_name == "value_floats":
-        tensor = ir.tensor(
-            attr_value.as_floats(), dtype=ir.DataType.FLOAT, name=initializer_name
-        )
-    elif attr_name in ("value_string", "value_strings"):
-        tensor = ir.StringTensor(
-            np.array(attr_value.value, dtype=np.bytes_), name=initializer_name
-        )
-    else:
-        tensor = None
-    return tensor  # type: ignore[return-value]
+        # Dispatch table for attribute-to-tensor conversion
+        tensor_converters = {
+            "value": lambda: attr_value.as_tensor(),  # pylint: disable=unnecessary-lambda`
+            "value_int": lambda: ir.tensor(
+                attr_value.as_int(), dtype=ir.DataType.INT64, name=initializer_name
+            ),
+            "value_ints": lambda: ir.tensor(
+                attr_value.as_ints(), dtype=ir.DataType.INT64, name=initializer_name
+            ),
+            "value_float": lambda: ir.tensor(
+                attr_value.as_float(), dtype=ir.DataType.FLOAT, name=initializer_name
+            ),
+            "value_floats": lambda: ir.tensor(
+                attr_value.as_floats(), dtype=ir.DataType.FLOAT, name=initializer_name
+            ),
+            "value_string": lambda: ir.StringTensor(
+                np.array(attr_value.value, dtype=np.bytes_), name=initializer_name
+            ),
+            "value_strings": lambda: ir.StringTensor(
+                np.array(attr_value.value, dtype=np.bytes_), name=initializer_name
+            ),
+        }
+        converter = tensor_converters.get(attr_name)
+        if converter is None:
+            logger.debug(
+                "Unsupported constant node attribute '%s' in node '%s'", attr_name, node.name
+            )
+            return None
+
+        return converter()  # type: ignore[return-value]

--- a/onnxscript/ir/passes/common/constant_manipulation.py
+++ b/onnxscript/ir/passes/common/constant_manipulation.py
@@ -22,7 +22,7 @@ class LiftConstantsToInitializersPass(ir.passes.InPlacePass):
 
     Attributes:
         lift_all_constants: Whether to lift all Constant nodes, including those that does not contain a tensor attribute (e.g. with value_ints etc.)
-            Default to False, where only tensor constants are lifted.
+            Default to False, where only Constants with the ``value`` attribute are lifted.
     """
 
     def __init__(self, lift_all_constants: bool = False):

--- a/onnxscript/ir/passes/common/constant_manipulation.py
+++ b/onnxscript/ir/passes/common/constant_manipulation.py
@@ -21,7 +21,7 @@ class LiftConstantsToInitializersPass(ir.passes.InPlacePass):
     """Lift constants to initializers.
 
     Attributes:
-        lift_all_constants: Whether to lift all constants, including non-tensor values.
+        lift_all_constants: Whether to lift all Constant nodes, including those that does not contain a tensor attribute (e.g. with value_ints etc.)
             Default to False, where only tensor constants are lifted.
     """
 

--- a/onnxscript/ir/passes/common/constant_manipulation.py
+++ b/onnxscript/ir/passes/common/constant_manipulation.py
@@ -35,7 +35,7 @@ class LiftConstantsToInitializersPass(ir.passes.InPlacePass):
             assert node.graph is not None
             if node.op_type != "Constant" or node.domain not in ("", "onnx.ai"):
                 continue
-            if node.outputs[0] in node.graph.outputs:
+            if node.outputs[0].is_graph_output():
                 logger.debug(
                     "Constant node '%s' is used as output, so it can't be lifted.", node.name
                 )

--- a/onnxscript/ir/passes/common/constant_manipulation.py
+++ b/onnxscript/ir/passes/common/constant_manipulation.py
@@ -87,33 +87,28 @@ class LiftConstantsToInitializersPass(ir.passes.InPlacePass):
             )
             return None
 
-        # Dispatch table for attribute-to-tensor conversion
-        tensor_converters = {
-            "value": lambda: attr_value.as_tensor(),  # pylint: disable=unnecessary-lambda`
-            "value_int": lambda: ir.tensor(
+        if attr_name == "value":
+            tensor = attr_value.as_tensor()  # type: ignore[union-attr]
+        elif attr_name == "value_int":
+            tensor = ir.tensor(
                 attr_value.as_int(), dtype=ir.DataType.INT64, name=initializer_name
-            ),
-            "value_ints": lambda: ir.tensor(
-                attr_value.as_ints(), dtype=ir.DataType.INT64, name=initializer_name
-            ),
-            "value_float": lambda: ir.tensor(
-                attr_value.as_float(), dtype=ir.DataType.FLOAT, name=initializer_name
-            ),
-            "value_floats": lambda: ir.tensor(
-                attr_value.as_floats(), dtype=ir.DataType.FLOAT, name=initializer_name
-            ),
-            "value_string": lambda: ir.StringTensor(
-                np.array(attr_value.value, dtype=np.bytes_), name=initializer_name
-            ),
-            "value_strings": lambda: ir.StringTensor(
-                np.array(attr_value.value, dtype=np.bytes_), name=initializer_name
-            ),
-        }
-        converter = tensor_converters.get(attr_name)
-        if converter is None:
-            logger.debug(
-                "Unsupported constant node attribute '%s' in node '%s'", attr_name, node.name
             )
-            return None
-
-        return converter()  # type: ignore[return-value]
+        elif attr_name == "value_ints":
+            tensor = ir.tensor(
+                attr_value.as_ints(), dtype=ir.DataType.INT64, name=initializer_name
+            )
+        elif attr_name == "value_float":
+            tensor = ir.tensor(
+                attr_value.as_float(), dtype=ir.DataType.FLOAT, name=initializer_name
+            )
+        elif attr_name == "value_floats":
+            tensor = ir.tensor(
+                attr_value.as_floats(), dtype=ir.DataType.FLOAT, name=initializer_name
+            )
+        elif attr_name in ("value_string", "value_strings"):
+            tensor = ir.StringTensor(
+                np.array(attr_value.value, dtype=np.bytes_), name=initializer_name
+            )
+        else:
+            tensor = None
+        return tensor  # type: ignore[return-value]

--- a/onnxscript/ir/passes/common/constant_manipulation_test.py
+++ b/onnxscript/ir/passes/common/constant_manipulation_test.py
@@ -21,7 +21,7 @@ class TestLiftConstantsToInitializersPass(unittest.TestCase):
         ]
     )
     def test_pass_with_lifting_float_and_int_constants_to_initializers(
-        self, ir_dtype, lift_all_constants
+        self, ir_dtype: ir.DataType, lift_all_constants: bool
     ):
         inputs = [
             ir.Value(name="input_a", type=ir.TensorType(ir_dtype), shape=ir.Shape((2, 3))),
@@ -80,7 +80,7 @@ class TestLiftConstantsToInitializersPass(unittest.TestCase):
         ]
     )
     def test_pass_with_lifting_constants_to_initializers_within_subgraph(
-        self, lift_all_constants
+        self, lift_all_constants: bool
     ):
         input_value = ir.Value(
             name="input", type=ir.TensorType(ir.DataType.FLOAT), shape=ir.Shape((2, 3))
@@ -167,7 +167,11 @@ class TestLiftConstantsToInitializersPass(unittest.TestCase):
         ]
     )
     def test_pass_with_lifting_constants_to_initializers_with_floats_ints_strings(
-        self, value, constant_attribute, np_dtype, lift_all_constants
+        self,
+        value: float | int | str | list[float] | list[int] | list[str],
+        constant_attribute: str,
+        np_dtype: type[np.dtype],
+        lift_all_constants: bool,
     ):
         input_value = ir.Value(
             name="input", type=ir.TensorType(ir.DataType.FLOAT), shape=ir.Shape((2, 3))


### PR DESCRIPTION
Fix #2184 

(1) Fix the corner case when the constant is the graph output, we don't lift it.
(2) Add an option to the pass controlling lifting all constants to initializers, or only "value". (following ort pass: https://github.com/microsoft/onnxruntime/blob/d7c688e15c1dc40f57140bff08c78e01a88b19fc/onnxruntime/python/tools/transformers/onnx_model.py#L525). Default to False, where we only lift "value".