### PR TITLE
[pass] Avoid lifting tensors that are too small to initializers

### DIFF
--- a/onnxscript/ir/passes/common/constant_manipulation.py
+++ b/onnxscript/ir/passes/common/constant_manipulation.py
@@ -24,7 +24,7 @@ class LiftConstantsToInitializersPass(ir.passes.InPlacePass):
         lift_all_constants: Whether to lift all Constant nodes, including those that does not contain a tensor attribute (e.g. with value_ints etc.)
             Default to False, where only Constants with the ``value`` attribute are lifted.
         size_limit: The minimum size of the tensor to be lifted. If the tensor contains
-            less than this number of elements, it will not be lifted.
+            number of elements less than size_limit, it will not be lifted.
     """
 
     def __init__(self, lift_all_constants: bool = False, size_limit: int = 16):

--- a/onnxscript/ir/passes/common/constant_manipulation.py
+++ b/onnxscript/ir/passes/common/constant_manipulation.py
@@ -90,34 +90,39 @@ class LiftConstantsToInitializersPass(ir.passes.InPlacePass):
             )
             return None
 
+        tensor: ir.TensorProtocol
         if attr_name == "value":
             tensor = attr_value.as_tensor()
-            if tensor.size < self.size_limit:
-                logger.debug(
-                    "Tensor from node '%s' has less than %s elements",
-                    node.name,
-                    self.size_limit,
-                )
-                return None
-            return tensor
-        if attr_name == "value_int":
-            return ir.tensor(
+        elif attr_name == "value_int":
+            tensor = ir.tensor(
                 attr_value.as_int(), dtype=ir.DataType.INT64, name=initializer_name
             )
-        if attr_name == "value_ints":
-            return ir.tensor(
+        elif attr_name == "value_ints":
+            tensor = ir.tensor(
                 attr_value.as_ints(), dtype=ir.DataType.INT64, name=initializer_name
             )
-        if attr_name == "value_float":
-            return ir.tensor(
+        elif attr_name == "value_float":
+            tensor = ir.tensor(
                 attr_value.as_float(), dtype=ir.DataType.FLOAT, name=initializer_name
             )
-        if attr_name == "value_floats":
-            return ir.tensor(
+        elif attr_name == "value_floats":
+            tensor = ir.tensor(
                 attr_value.as_floats(), dtype=ir.DataType.FLOAT, name=initializer_name
             )
-        if attr_name in ("value_string", "value_strings"):
-            return ir.StringTensor(
+        elif attr_name in ("value_string", "value_strings"):
+            tensor = ir.StringTensor(
                 np.array(attr_value.value, dtype=np.bytes_), name=initializer_name
             )
-        return None
+        else:
+            raise ValueError(
+                f"Unsupported constant node '{node.name}' attribute '{attr_name}'"
+            )
+
+        if tensor.size < self.size_limit:
+            logger.debug(
+                "Tensor from node '%s' has less than %s elements",
+                node.name,
+                self.size_limit,
+            )
+            return None
+        return tensor

--- a/onnxscript/ir/passes/common/constant_manipulation.py
+++ b/onnxscript/ir/passes/common/constant_manipulation.py
@@ -24,7 +24,7 @@ class LiftConstantsToInitializersPass(ir.passes.InPlacePass):
         lift_all_constants: Whether to lift all Constant nodes, including those that does not contain a tensor attribute (e.g. with value_ints etc.)
             Default to False, where only Constants with the ``value`` attribute are lifted.
         size_limit: The minimum size of the tensor to be lifted. If the tensor contains
-            number of elements less than size_limit, it will not be lifted.
+            number of elements less than size_limit, it will not be lifted. Default is 16.
     """
 
     def __init__(self, lift_all_constants: bool = False, size_limit: int = 16):

--- a/onnxscript/ir/passes/common/constant_manipulation_test.py
+++ b/onnxscript/ir/passes/common/constant_manipulation_test.py
@@ -56,7 +56,7 @@ class TestLiftConstantsToInitializersPass(unittest.TestCase):
 
         # Perform lift constants to initializers
         result = constant_manipulation.LiftConstantsToInitializersPass(
-            lift_all_constants=lift_all_constants
+            lift_all_constants=lift_all_constants, size_limit=0
         )(model)
         self.assertTrue(result.modified)
         # Check that the constant node is lifted to an initializer
@@ -130,7 +130,7 @@ class TestLiftConstantsToInitializersPass(unittest.TestCase):
             ir_version=10,
         )
         result = constant_manipulation.LiftConstantsToInitializersPass(
-            lift_all_constants=lift_all_constants
+            lift_all_constants=lift_all_constants, size_limit=0
         )(model)
         self.assertTrue(result.modified)
         # Check that the constant node is lifted to the subgraph initializers
@@ -206,7 +206,7 @@ class TestLiftConstantsToInitializersPass(unittest.TestCase):
 
         # Perform lift constants to initializers
         result = constant_manipulation.LiftConstantsToInitializersPass(
-            lift_all_constants=lift_all_constants
+            lift_all_constants=lift_all_constants, size_limit=0
         )(model)
         if lift_all_constants:
             self.assertTrue(result.modified)
@@ -249,3 +249,7 @@ class TestLiftConstantsToInitializersPass(unittest.TestCase):
         self.assertFalse(result.modified)
         # Check that the constant node is not lifted to an initializer
         self.assertEqual(len(result.model.graph.initializers), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Tensors with too few elements are usually not weights and are plenty. Lifting them will make the initializer list very noisy. I added a parameter `size_limit` to control this and defaulted it to 16.