### PR TITLE
[pass] Create topological sort pass

### DIFF
--- a/onnxscript/ir/passes/common/topological_sort.py
+++ b/onnxscript/ir/passes/common/topological_sort.py
@@ -1,0 +1,33 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Pass for topologically sorting the graphs."""
+
+from __future__ import annotations
+
+__all__ = [
+    "TopologicalSortPass",
+]
+
+
+from onnxscript import ir
+
+
+class TopologicalSortPass(ir.passes.InPlacePass):
+    """Topologically sort graphs and functions in a model."""
+
+    def call(self, model: ir.Model) -> ir.passes.PassResult:
+        nodes = list(model.graph)
+        model.graph.sort()
+        new_nodes = list(model.graph)
+        for function in model.functions.values():
+            nodes.extend(function)
+            function.sort()
+            new_nodes.extend(function)
+
+        # Compare node orders to determine if any changes were made
+        modified = False
+        for node, new_node in zip(nodes, new_nodes):
+            if node is not new_node:
+                modified = True
+                break
+        return ir.passes.PassResult(model=model, modified=modified)

--- a/onnxscript/ir/passes/common/topological_sort.py
+++ b/onnxscript/ir/passes/common/topological_sort.py
@@ -16,17 +16,17 @@ class TopologicalSortPass(ir.passes.InPlacePass):
     """Topologically sort graphs and functions in a model."""
 
     def call(self, model: ir.Model) -> ir.passes.PassResult:
-        nodes = list(model.graph)
+        original_nodes = list(model.graph)
         model.graph.sort()
-        new_nodes = list(model.graph)
+        sorted_nodes = list(model.graph)
         for function in model.functions.values():
-            nodes.extend(function)
+            original_nodes.extend(function)
             function.sort()
-            new_nodes.extend(function)
+            sorted_nodes.extend(function)
 
         # Compare node orders to determine if any changes were made
         modified = False
-        for node, new_node in zip(nodes, new_nodes):
+        for node, new_node in zip(original_nodes, sorted_nodes):
             if node is not new_node:
                 modified = True
                 break

--- a/onnxscript/ir/passes/common/topological_sort_test.py
+++ b/onnxscript/ir/passes/common/topological_sort_test.py
@@ -22,10 +22,10 @@ class TopologicalSortPassTest(unittest.TestCase):
             name="test_graph",
         )
         model = ir.Model(graph, ir_version=10)
-        pass_result = topological_sort.TopologicalSortPass()(model)
-        self.assertTrue(pass_result.modified)
+        result = topological_sort.TopologicalSortPass()(model)
+        self.assertTrue(result.modified)
         self.assertEqual(
-            tuple(pass_result.model.graph),
+            tuple(result.model.graph),
             (self.node_a, self.node_b, self.node_c),
         )
 
@@ -38,10 +38,10 @@ class TopologicalSortPassTest(unittest.TestCase):
             name="test_graph",
         )
         sorted_model = ir.Model(sorted_graph, ir_version=10)
-        pass_result = topological_sort.TopologicalSortPass()(sorted_model)
-        self.assertFalse(pass_result.modified)
+        result = topological_sort.TopologicalSortPass()(sorted_model)
+        self.assertFalse(result.modified)
         self.assertEqual(
-            tuple(pass_result.model.graph),
+            tuple(result.model.graph),
             (self.node_a, self.node_b, self.node_c),
         )
 

--- a/onnxscript/ir/passes/common/topological_sort_test.py
+++ b/onnxscript/ir/passes/common/topological_sort_test.py
@@ -24,6 +24,10 @@ class TopologicalSortPassTest(unittest.TestCase):
         model = ir.Model(graph, ir_version=10)
         pass_result = topological_sort.TopologicalSortPass()(model)
         self.assertTrue(pass_result.modified)
+        self.assertEqual(
+            tuple(pass_result.model.graph),
+            (self.node_a, self.node_b, self.node_c),
+        )
 
     def test_topological_sort_modified_false(self):
         """Test that modified is False when the input model is already sorted."""
@@ -36,6 +40,10 @@ class TopologicalSortPassTest(unittest.TestCase):
         sorted_model = ir.Model(sorted_graph, ir_version=10)
         pass_result = topological_sort.TopologicalSortPass()(sorted_model)
         self.assertFalse(pass_result.modified)
+        self.assertEqual(
+            tuple(pass_result.model.graph),
+            (self.node_a, self.node_b, self.node_c),
+        )
 
 
 if __name__ == "__main__":

--- a/onnxscript/ir/passes/common/topological_sort_test.py
+++ b/onnxscript/ir/passes/common/topological_sort_test.py
@@ -11,8 +11,8 @@ from onnxscript.ir.passes.common import topological_sort
 class TopologicalSortPassTest(unittest.TestCase):
     def setUp(self):
         self.node_a = ir.node("A", inputs=[], name="node_a")
-        self.node_b = ir.node("B", inputs=[self.node_a.outputs[0]], name="node_b")
-        self.node_c = ir.node("C", inputs=[self.node_b.outputs[0]], name="node_c")
+        self.node_b = ir.node("B", inputs=self.node_a.outputs, name="node_b")
+        self.node_c = ir.node("C", inputs=self.node_b.outputs, name="node_c")
 
     def test_topological_sort_modified_true(self):
         graph = ir.Graph(

--- a/onnxscript/ir/passes/common/topological_sort_test.py
+++ b/onnxscript/ir/passes/common/topological_sort_test.py
@@ -1,0 +1,42 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Unit tests for the TopologicalSortPass."""
+
+import unittest
+
+from onnxscript import ir
+from onnxscript.ir.passes.common import topological_sort
+
+
+class TopologicalSortPassTest(unittest.TestCase):
+    def setUp(self):
+        self.node_a = ir.Node("", "A", inputs=[], num_outputs=1, name="node_a")
+        self.node_b = ir.Node("", "B", inputs=[self.node_a.outputs[0]], num_outputs=1, name="node_b")
+        self.node_c = ir.Node("", "C", inputs=[self.node_b.outputs[0]], num_outputs=1, name="node_c")
+
+    def test_topological_sort_modified_true(self):
+        graph = ir.Graph(
+            inputs=self.node_a.inputs,
+            outputs=self.node_c.outputs,
+            nodes=[self.node_c, self.node_b, self.node_a],  # Unsorted nodes
+            name="test_graph",
+        )
+        model = ir.Model(graph, ir_version=10)
+        pass_result = topological_sort.TopologicalSortPass(model)
+        self.assertTrue(pass_result.modified)
+
+    def test_topological_sort_modified_false(self):
+        """Test that modified is False when the input model is already sorted."""
+        sorted_graph = ir.Graph(
+            inputs=self.node_a.inputs,
+            outputs=self.node_c.outputs,
+            nodes=[self.node_a, self.node_b, self.node_c],  # Sorted nodes
+            name="test_graph",
+        )
+        sorted_model = ir.Model(sorted_graph, ir_version=10)
+        pass_result = topological_sort.TopologicalSortPass().call(sorted_model)
+        self.assertFalse(pass_result.modified)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnxscript/ir/passes/common/topological_sort_test.py
+++ b/onnxscript/ir/passes/common/topological_sort_test.py
@@ -10,9 +10,9 @@ from onnxscript.ir.passes.common import topological_sort
 
 class TopologicalSortPassTest(unittest.TestCase):
     def setUp(self):
-        self.node_a = ir.Node("", "A", inputs=[], num_outputs=1, name="node_a")
-        self.node_b = ir.Node("", "B", inputs=[self.node_a.outputs[0]], num_outputs=1, name="node_b")
-        self.node_c = ir.Node("", "C", inputs=[self.node_b.outputs[0]], num_outputs=1, name="node_c")
+        self.node_a = ir.node("A", inputs=[], name="node_a")
+        self.node_b = ir.node("B", inputs=[self.node_a.outputs[0]], name="node_b")
+        self.node_c = ir.node("C", inputs=[self.node_b.outputs[0]], name="node_c")
 
     def test_topological_sort_modified_true(self):
         graph = ir.Graph(
@@ -22,7 +22,7 @@ class TopologicalSortPassTest(unittest.TestCase):
             name="test_graph",
         )
         model = ir.Model(graph, ir_version=10)
-        pass_result = topological_sort.TopologicalSortPass(model)
+        pass_result = topological_sort.TopologicalSortPass()(model)
         self.assertTrue(pass_result.modified)
 
     def test_topological_sort_modified_false(self):
@@ -34,7 +34,7 @@ class TopologicalSortPassTest(unittest.TestCase):
             name="test_graph",
         )
         sorted_model = ir.Model(sorted_graph, ir_version=10)
-        pass_result = topological_sort.TopologicalSortPass().call(sorted_model)
+        pass_result = topological_sort.TopologicalSortPass()(sorted_model)
         self.assertFalse(pass_result.modified)
 
 


### PR DESCRIPTION
Simply expose the `sort()` api as a pass for composability.