### PR TITLE
[pass] Create check to ensure in-place passes are actually inplace

### DIFF
--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -141,14 +141,14 @@ class PassBase(abc.ABC):
         if self.in_place and result.model is not model:
             raise PassError(
                 f"The pass '{self.__class__.__name__}' is declared in-place, "
-                "but the model returned is not the same object as the input model. "
-                "Pass should return the same model object or self.in_place should return False."
+                "but the model returned is *not* the same object as the input model. "
+                "Pass developer: Pass should return the same model object or the in_place property should return False."
             )
         if not self.in_place and result.model is model:
             raise PassError(
                 f"The pass '{self.__class__.__name__}' is declared not in-place, "
-                "but the model returned is the same object as the input model. "
-                "Pass should return a new model object or self.in_place should return True."
+                "but the model returned *is* the same object as the input model. "
+                "Pass developer: Pass should return a new model object or the in_place property should return True."
             )
         return result
 

--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -140,13 +140,13 @@ class PassBase(abc.ABC):
         # Checks that the declared in-place property is respected
         if self.in_place and result.model is not model:
             raise PassError(
-                f"The pass '{self.__class__.__name__}' declared in place, "
+                f"The pass '{self.__class__.__name__}' is declared in-place, "
                 "but the model returned is not the same object as the input model. "
                 "Pass should return the same model object or self.in_place should return False."
             )
         if not self.in_place and result.model is model:
             raise PassError(
-                f"The pass '{self.__class__.__name__}' declared not in place, "
+                f"The pass '{self.__class__.__name__}' is declared not in-place, "
                 "but the model returned is the same object as the input model. "
                 "Pass should return a new model object or self.in_place should return True."
             )

--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -136,6 +136,20 @@ class PassBase(abc.ABC):
                 f"The result of the pass '{self.__class__.__name__}' should be type PassResult. "
                 "Please create one with ir.passes.PassResult()."
             )
+
+        # Checks that the declared in-place property is respected
+        if self.in_place and result.model is not model:
+            raise PassError(
+                f"The pass '{self.__class__.__name__}' declared in place, "
+                "but the model returned is not the same object as the input model. "
+                "Pass should return the same model object or self.in_place should return False."
+            )
+        if not self.in_place and result.model is model:
+            raise PassError(
+                f"The pass '{self.__class__.__name__}' declared not in place, "
+                "but the model returned is the same object as the input model. "
+                "Pass should return a new model object or self.in_place should return True."
+            )
         return result
 
     @abc.abstractmethod


### PR DESCRIPTION
This pull request introduces validation to ensure the in-place property of a pass is respected.

Validation of in-place property:

* [`onnxscript/ir/passes/_pass_infra.py`](diffhunk://#diff-70c7e5b3422f4daaf1611d4f76578c96e4c5894cced3d51718efa0290219f7f5R139-R152): Added checks to ensure that if a pass is declared in-place, the returned model must be the same object as the input model, and if not in-place, the returned model must be a different object. Raises `PassError` if these conditions are not met.