### PR TITLE
Update constant fold to use correct numpy type

### DIFF
--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -297,7 +297,7 @@ def _get_numpy_value(
         if size_limit is not None and const_value.size > size_limit:
             return None
         try:
-            array = const_value.numpy()
+            array = const_value.numpy().view(const_value.dtype.numpy())
         except FileNotFoundError:
             # External data is not available.
             return None

--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -298,7 +298,7 @@ def _get_numpy_value(
             return None
         try:
             # Reinterpret the array with `.view()` because some implementations of
-            # ir.TensorProtocol (e.g. PyTorch<2.7) do not use ml_dtypes for bfloat16 etc.
+            # ir.TensorProtocol (e.g. PyTorch<=2.7) do not use ml_dtypes for bfloat16 etc.
             array = const_value.numpy().view(const_value.dtype.numpy())
         except FileNotFoundError:
             # External data is not available.

--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -297,6 +297,8 @@ def _get_numpy_value(
         if size_limit is not None and const_value.size > size_limit:
             return None
         try:
+            # Reinterpret the array with `.view()` because some implementations of
+            # ir.TensorProtocol (e.g. PyTorch<2.7) do not use ml_dtypes for bfloat16 etc.
             array = const_value.numpy().view(const_value.dtype.numpy())
         except FileNotFoundError:
             # External data is not available.


### PR DESCRIPTION
In PyTorch<=2.7, the numpy arrays for bfloat16 and float8 types have dtypes UINT16 and UINT8, which leads to incorrect constant folded graphs. This PR updates the numpy helper to cast the arrays to the correct dtypes.

Fix https://github.com/microsoft/onnxscript/issues/2187
