### PR TITLE
Update release.yml to change the section for passes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -18,10 +18,10 @@ changelog:
     - title: ONNX IR
       labels:
         - "module: IR"
+        - "topic: passes"
     - title: Torch Lib
       labels:
         - "module: torchlib"
-        - "topic: passes"
     - title: Documentation
       labels:
         - "topic: documentation"


### PR DESCRIPTION
Previously the passes were incorrectly placed under torchlib