### PR TITLE
Fix optimizer tests

### DIFF
--- a/tests/optimizer/test_models.py
+++ b/tests/optimizer/test_models.py
@@ -16,10 +16,7 @@ from onnxscript import optimizer
 from onnxscript.rewriter import onnxruntime as ort_rewriter
 from onnxscript.utils import evaluation_utils
 
-_SKIP_TABLE = {
-    "resnet18": "fixme: ORT aborts when loading the model - https://github.com/microsoft/onnxruntime/issues/24473",
-    "mobilenetv2_100": "fixme: ORT aborts when loading the model - https://github.com/microsoft/onnxruntime/issues/24473",
-}
+_SKIP_TABLE = {}
 
 model_folder_path = (
     pathlib.Path(__file__).resolve().parent.parent.parent / "testdata" / "e2e_models"
@@ -41,7 +38,7 @@ class ModelTest(unittest.TestCase):
         if not model_path.exists():
             self.skipTest(f"Model {model_name!r} does not exist")
         model = onnx.load(model_path)
-        model = optimizer.optimize(model, onnx_shape_inference=False)
+        model = optimizer.optimize(model, onnx_shape_inference=True)
 
         with tempfile.TemporaryDirectory() as tmp_folder:
             tmp_folder = pathlib.Path(tmp_folder)

--- a/tests/optimizer/test_models.py
+++ b/tests/optimizer/test_models.py
@@ -38,7 +38,7 @@ class ModelTest(unittest.TestCase):
         if not model_path.exists():
             self.skipTest(f"Model {model_name!r} does not exist")
         model = onnx.load(model_path)
-        model = optimizer.optimize(model, onnx_shape_inference=True)
+        model = optimizer.optimize(model)
 
         with tempfile.TemporaryDirectory() as tmp_folder:
             tmp_folder = pathlib.Path(tmp_folder)


### PR DESCRIPTION
Fix optimizer tests by turning on onnx shape inference. This is needed to elimininate an If node that is causing ORT to crash (https://github.com/microsoft/onnxruntime/issues/24473).

I removed the argument because shape inference is the default.