### PR TITLE
[IR] Allow pass result as pass input

### DIFF
--- a/onnxscript/ir/passes/_pass_infra.py
+++ b/onnxscript/ir/passes/_pass_infra.py
@@ -108,7 +108,11 @@ class PassBase(abc.ABC):
         """
         return not self.in_place and self.changes_input
 
-    def __call__(self, model: ir.Model) -> PassResult:
+    def __call__(self, model_or_result: ir.Model | PassResult, /) -> PassResult:
+        if isinstance(model_or_result, PassResult):
+            model = model_or_result.model
+        else:
+            model = model_or_result
         # Check preconditions
         try:
             self.requires(model)

--- a/onnxscript/ir/passes/_pass_infra_test.py
+++ b/onnxscript/ir/passes/_pass_infra_test.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 import unittest
-from onnxscript.ir.passes import _pass_infra
+
 from onnxscript import ir
+from onnxscript.ir.passes import _pass_infra
 
 
 class PassBaseTest(unittest.TestCase):
@@ -18,18 +19,13 @@ class PassBaseTest(unittest.TestCase):
             @property
             def changes_input(self) -> bool:
                 return False
+
             def call(self, model: ir.Model) -> _pass_infra.PassResult:
                 # This is a no-op pass
-                return _pass_infra.PassResult(
-                    model=model,
-                    modified=False
-                )
+                return _pass_infra.PassResult(model=model, modified=False)
 
         pass_ = TestPass()
-        model = ir.Model(
-            graph=ir.Graph([], [], nodes=[]),
-            ir_version=10
-        )
+        model = ir.Model(graph=ir.Graph([], [], nodes=[]), ir_version=10)
         result = pass_(model)
         self.assertIsInstance(result, _pass_infra.PassResult)
         # pass can take the result of another pass as input

--- a/onnxscript/ir/passes/_pass_infra_test.py
+++ b/onnxscript/ir/passes/_pass_infra_test.py
@@ -1,0 +1,43 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+import unittest
+from onnxscript.ir.passes import _pass_infra
+from onnxscript import ir
+
+
+class PassBaseTest(unittest.TestCase):
+    def test_pass_results_can_be_used_as_pass_input(self):
+        class TestPass(_pass_infra.PassBase):
+            @property
+            def in_place(self) -> bool:
+                return True
+
+            @property
+            def changes_input(self) -> bool:
+                return False
+            def call(self, model: ir.Model) -> _pass_infra.PassResult:
+                # This is a no-op pass
+                return _pass_infra.PassResult(
+                    model=model,
+                    modified=False
+                )
+
+        pass_ = TestPass()
+        model = ir.Model(
+            graph=ir.Graph([], [], nodes=[]),
+            ir_version=10
+        )
+        result = pass_(model)
+        self.assertIsInstance(result, _pass_infra.PassResult)
+        # pass can take the result of another pass as input
+        result_1 = pass_(result)
+        # It can also take the model as input
+        result_2 = pass_(result.model)
+        self.assertIs(result_1.model, result_2.model)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Allow pass result as pass input so users can chain calls to multiple passes more easily

Before:

```py
result = pass1(model)
result = pass(result.model)
```

Now it is also possible to do:

```py
result = pass1(model)
result = pass(result)
```