### PR TITLE
[IR] Handle invalid output deserialization

### DIFF
--- a/onnxscript/ir/serde.py
+++ b/onnxscript/ir/serde.py
@@ -683,15 +683,11 @@ def _deserialize_graph(
                 output_name,
             )
             value = _core.Value(name=output_name)
-            # Fill in shape/type information
-            deserialize_value_info_proto(info, value)
-            if output_name in quantization_annotations:
-                _deserialize_quantization_annotation(
-                    quantization_annotations[output_name], value
-                )
         else:
             # A valid, normal graph output
             value = values[output_name]
+        # Fill in shape/type information
+        deserialize_value_info_proto(info, value)
         outputs.append(value)
 
     # Exit the graph scope by popping the values for this scope from the stack

--- a/onnxscript/ir/serde.py
+++ b/onnxscript/ir/serde.py
@@ -680,7 +680,7 @@ def _deserialize_graph(
             # Handle (invalid) graph outputs that do not have any producers
             logger.warning(
                 "Output '%s' is not produced by any node. The graph has an invalid output",
-                output_name
+                output_name,
             )
             value = _core.Value(name=output_name)
             # Fill in shape/type information

--- a/onnxscript/ir/serde_test.py
+++ b/onnxscript/ir/serde_test.py
@@ -290,6 +290,23 @@ class DeserializeGraphTest(unittest.TestCase):
         self.assertEqual(deserialized_graph[0].op_type, "Op_1")
         self.assertEqual(deserialized_graph[1].op_type, "Op_0")
 
+    def test_deserialize_graph_handles_invalid_output(self):
+        # The graph has an output that is not connected to any node, and it does not
+        # have shape/type information.
+        graph_with_invalid_output = ir.Graph(
+            inputs=[],
+            outputs=[ir.Value(name="invalid_output")],
+            nodes=[],
+            name="graph_with_invalid_output",
+        )
+        graph_proto = serde.serialize_graph(graph_with_invalid_output)
+        deserialized_graph = serde.deserialize_graph(graph_proto)
+        self.assertEqual(len(deserialized_graph.outputs), 1)
+        self.assertEqual(deserialized_graph.outputs[0].name, "invalid_output")
+        self.assertEqual(deserialized_graph.outputs[0].type, None)
+        self.assertEqual(deserialized_graph.outputs[0].shape, None)
+        self.assertEqual(deserialized_graph.outputs[0].dtype, None)
+
 
 class QuantizationAnnotationTest(unittest.TestCase):
     """Test that quantization annotations are correctly serialized and deserialized."""


### PR DESCRIPTION
Handle deserializing a graph if an output that is not produced by any nodes.

This is discovered when working on https://github.com/microsoft/onnxruntime-genai/pull/1416