### PR TITLE
Improve `ir.node` annotations to accept None inputs

### DIFF
--- a/onnxscript/ir/_convenience/_constructors.py
+++ b/onnxscript/ir/_convenience/_constructors.py
@@ -109,7 +109,7 @@ def tensor(
 
 def node(
     op_type: str,
-    inputs: Sequence[ir.Value],
+    inputs: Sequence[ir.Value | None],
     attributes: Mapping[str, _convenience.SupportedAttrTypes] | None = None,
     *,
     domain: str = "",


### PR DESCRIPTION
Previously Node was omitted.