### PR TITLE
[IR] Implement tofile for tensors

### DIFF
--- a/onnxscript/ir/_protocols.py
+++ b/onnxscript/ir/_protocols.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import typing
 from typing import (
     Any,
+    BinaryIO,
     Collection,
     Iterable,
     Iterator,
@@ -144,6 +145,9 @@ class TensorProtocol(ArrayCompatible, DLPackCompatible, Protocol):
     def tobytes(self) -> bytes:
         """Return the tensor as a byte string conformed to the ONNX specification, in little endian."""
         ...
+
+    def tofile(self, file: BinaryIO, /) -> None:
+        """Write the tensor content as bytes to a file-like object."""
 
 
 @typing.runtime_checkable


### PR DESCRIPTION
This pull request introduces a new `tofile` method to write tensor content as bytes to a file-like object, along with the necessary type updates to support this functionality. The changes span across multiple files and ensure consistent implementation across tensor-related classes and protocols.

### Addition of `tofile` Method:

* **`onnxscript/ir/_core.py`:** Added the `tofile` method to two classes, allowing tensors to be serialized as bytes to a file-like object. The implementation includes handling for specific data types (e.g., INT4, UINT4) and ensures compatibility with numpy arrays. [[1]](diffhunk://#diff-33a5ea7182ac2a3ba4127e9fea3cd2db2dbe54810994ca210727d28fccf2b5cfR126-R143) [[2]](diffhunk://#diff-33a5ea7182ac2a3ba4127e9fea3cd2db2dbe54810994ca210727d28fccf2b5cfR721-R731)
