### PR TITLE
[IR] Display constant tensors for Value

### DIFF
--- a/onnxscript/ir/_convenience/__init__.py
+++ b/onnxscript/ir/_convenience/__init__.py
@@ -212,7 +212,7 @@ def convert_attributes(
         ...     "type_protos": [ir.TensorType(ir.DataType.FLOAT), ir.TensorType(ir.DataType.FLOAT)],
         ... }
         >>> convert_attributes(attrs)
-        [Attr('int', INT, 1), Attr('float', FLOAT, 1.0), Attr('str', STRING, 'hello'), Attr('ints', INTS, [1, 2, 3]), Attr('floats', FLOATS, [1.0, 2.0, 3.0]), Attr('strings', STRINGS, ['hello', 'world']), Attr('tensor', TENSOR, Tensor<DOUBLE,[3]>(array([1., 2., 3.]), name=None)), TensorProtoTensor<FLOAT,[3]>(array([1., 2., 3.], dtype=float32), name='proto')), Attr('graph', INTS, Graph(
+        [Attr('int', INT, 1), Attr('float', FLOAT, 1.0), Attr('str', STRING, 'hello'), Attr('ints', INTS, [1, 2, 3]), Attr('floats', FLOATS, [1.0, 2.0, 3.0]), Attr('strings', STRINGS, ['hello', 'world']), Attr('tensor', TENSOR, Tensor<DOUBLE,[3]>(array([1., 2., 3.]), name=None)), Attr('tensor_proto', TENSOR, TensorProtoTensor<FLOAT,[3]>(array([1., 2., 3.], dtype=float32), name='proto')), Attr('graph', INTS, Graph(
             name='graph0',
             inputs=(
         <BLANKLINE>

--- a/onnxscript/ir/_convenience/__init__.py
+++ b/onnxscript/ir/_convenience/__init__.py
@@ -190,7 +190,7 @@ def convert_attributes(
         ...     "type_protos": [ir.TensorType(ir.DataType.FLOAT), ir.TensorType(ir.DataType.FLOAT)],
         ... }
         >>> convert_attributes(attrs)
-        [Attr('int', INT, 1), Attr('float', FLOAT, 1.0), Attr('str', STRING, 'hello'), Attr('ints', INTS, [1, 2, 3]), Attr('floats', FLOATS, [1.0, 2.0, 3.0]), Attr('strings', STRINGS, ['hello', 'world']), Attr('tensor', TENSOR, Tensor<DOUBLE,[3]>(array([1., 2., 3.]), name=None)), Attr('tensor_proto', TENSOR, TensorProtoTensor<FLOAT,[3]>(name='proto')), Attr('graph', INTS, Graph(
+        [Attr('int', INT, 1), Attr('float', FLOAT, 1.0), Attr('str', STRING, 'hello'), Attr('ints', INTS, [1, 2, 3]), Attr('floats', FLOATS, [1.0, 2.0, 3.0]), Attr('strings', STRINGS, ['hello', 'world']), Attr('tensor', TENSOR, Tensor<DOUBLE,[3]>(array([1., 2., 3.]), name=None)), TensorProtoTensor<FLOAT,[3]>(array([1., 2., 3.], dtype=float32), name='proto')), Attr('graph', INTS, Graph(
             name='graph0',
             inputs=(
         <BLANKLINE>

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -406,7 +406,9 @@ class Tensor(TensorBase, _protocols.TensorProtocol, Generic[TArrayCompatible]): 
         return self.__array__().__dlpack_device__()
 
     def __repr__(self) -> str:
-        return f"{self._repr_base()}({self._raw!r}, name={self.name!r})"
+        tensor_lines = str(self._raw).split("\n")
+        tensor_text = " ".join(line.strip() for line in tensor_lines)
+        return f"{self._repr_base()}({tensor_text}, name={self.name!r})"
 
     @property
     def dtype(self) -> _enums.DataType:
@@ -1848,7 +1850,7 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
         index_text = f", index={self.index()}" if self.index() is not None else ""
         if self.const_value is not None:
             # Take the first line only
-            tensor_text = repr(self.const_value).replace("\n", " ")
+            tensor_text = repr(self.const_value)
             if len(tensor_text) > 100:
                 tensor_text = tensor_text[:100] + "...)"
             const_value_text = f", const_value={tensor_text}"
@@ -1860,10 +1862,14 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
         value_name = self.name if self.name is not None else "anonymous:" + str(id(self))
         shape_text = str(self.shape) if self.shape is not None else "?"
         type_text = str(self.type) if self.type is not None else "?"
-        if self.const_value is not None and self.const_value.size <= 10:
-            const_value_text = f"{{{self.const_value}}}".replace("\n", " ")
+        if self.const_value is not None:
+            # Only display when the const value is small
+            if self.const_value.size <= 10:
+                const_value_text = f"{{{self.const_value}}}"
+            else:
+                const_value_text = "{...}"
         else:
-            const_value_text = "{...}"
+            const_value_text = ""
 
         # Quote the name because in reality the names can have invalid characters
         # that make them hard to read

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1848,7 +1848,7 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
         index_text = f", index={self.index()}" if self.index() is not None else ""
         if self.const_value is not None:
             # The the first line only
-            tensor_text = repr(self.const_value).replace('\n', ' ')
+            tensor_text = repr(self.const_value).replace("\n", " ")
             if len(tensor_text) > 100:
                 tensor_text = tensor_text[:100] + "...)"
             const_value_text = f", const_value={tensor_text}"
@@ -1861,7 +1861,7 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
         shape_text = str(self.shape) if self.shape is not None else "?"
         type_text = str(self.type) if self.type is not None else "?"
         if self.const_value is not None and self.const_value.size <= 10:
-            const_value_text = f"{{{self.const_value}}}".replace('\n', ' ')
+            const_value_text = f"{{{self.const_value}}}".replace("\n", " ")
         else:
             const_value_text = ""
 

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -406,6 +406,7 @@ class Tensor(TensorBase, _protocols.TensorProtocol, Generic[TArrayCompatible]): 
         return self.__array__().__dlpack_device__()
 
     def __repr__(self) -> str:
+        # Avoid multi-line repr
         tensor_lines = repr(self._raw).split("\n")
         tensor_text = " ".join(line.strip() for line in tensor_lines)
         return f"{self._repr_base()}({tensor_text}, name={self.name!r})"

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1863,7 +1863,7 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
         if self.const_value is not None and self.const_value.size <= 10:
             const_value_text = f"{{{self.const_value}}}".replace("\n", " ")
         else:
-            const_value_text = ""
+            const_value_text = "{...}"
 
         # Quote the name because in reality the names can have invalid characters
         # that make them hard to read

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1854,7 +1854,7 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
             if self.const_value.size <= 10:
                 tensor_text = f"{{{self.const_value}}}"
             else:
-                tensor_text = "{...}"
+                tensor_text = f"{{{self.const_value.__class__.__name__}...}}"
             const_value_text = f", const_value={tensor_text}"
         else:
             const_value_text = ""
@@ -1869,7 +1869,7 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
             if self.const_value.size <= 10:
                 const_value_text = f"{{{self.const_value}}}"
             else:
-                const_value_text = "{...}"
+                const_value_text = f"{{{self.const_value.__class__.__name__}...}}"
         else:
             const_value_text = ""
 

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1850,10 +1850,11 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
             producer_text = f", producer=anonymous_node:{id(producer)}"
         index_text = f", index={self.index()}" if self.index() is not None else ""
         if self.const_value is not None:
-            # Take the first line only
-            tensor_text = repr(self.const_value)
-            if len(tensor_text) > 100:
-                tensor_text = tensor_text[:100] + "...)"
+            # Only display when the const value is small
+            if self.const_value.size <= 10:
+                tensor_text = f"{{{self.const_value}}}"
+            else:
+                tensor_text = "{...}"
             const_value_text = f", const_value={tensor_text}"
         else:
             const_value_text = ""

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1847,7 +1847,11 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
             producer_text = f", producer=anonymous_node:{id(producer)}"
         index_text = f", index={self.index()}" if self.index() is not None else ""
         if self.const_value is not None:
-            const_value_text = f", const_value={self.const_value!r}"
+            # The the first line only
+            tensor_text = repr(self.const_value).replace('\n', ' ')
+            if len(tensor_text) > 100:
+                tensor_text = tensor_text[:100] + "...)"
+            const_value_text = f", const_value={tensor_text}"
         else:
             const_value_text = ""
         return f"{self.__class__.__name__}(name={value_name!r}{type_text}{shape_text}{producer_text}{index_text}{const_value_text})"
@@ -1856,8 +1860,8 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
         value_name = self.name if self.name is not None else "anonymous:" + str(id(self))
         shape_text = str(self.shape) if self.shape is not None else "?"
         type_text = str(self.type) if self.type is not None else "?"
-        if self.const_value is not None and self.const_value.size < 10:
-            const_value_text = f"{{{self.const_value}}}"
+        if self.const_value is not None and self.const_value.size <= 10:
+            const_value_text = f"{{{self.const_value}}}".replace('\n', ' ')
         else:
             const_value_text = ""
 

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1854,7 +1854,7 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
             if self.const_value.size <= 10:
                 tensor_text = f"{{{self.const_value}}}"
             else:
-                tensor_text = f"{{{self.const_value.__class__.__name__}...}}"
+                tensor_text = f"{{{self.const_value.__class__.__name__}(...)}}"
             const_value_text = f", const_value={tensor_text}"
         else:
             const_value_text = ""
@@ -1869,7 +1869,7 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
             if self.const_value.size <= 10:
                 const_value_text = f"{{{self.const_value}}}"
             else:
-                const_value_text = f"{{{self.const_value.__class__.__name__}...}}"
+                const_value_text = f"{{{self.const_value.__class__.__name__}(...)}}"
         else:
             const_value_text = ""
 

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1836,14 +1836,22 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
 
     def __repr__(self) -> str:
         value_name = self.name if self.name else "anonymous:" + str(id(self))
+
+        type_text = f", type={self.type!r}" if self.type is not None else ""
+        shape_text = f", shape={self.shape!r}" if self.shape is not None else ""
         producer = self.producer()
         if producer is None:
-            producer_text = "None"
+            producer_text = ""
         elif producer.name is not None:
-            producer_text = producer.name
+            producer_text = f", producer='{producer.name}'"
         else:
-            producer_text = f"anonymous_node:{id(producer)}"
-        return f"{self.__class__.__name__}({value_name!r}, type={self.type!r}, shape={self.shape}, producer={producer_text}, index={self.index()})"
+            producer_text = f", producer=anonymous_node:{id(producer)}"
+        index_text = f", index={self.index()}" if self.index() is not None else ""
+        if self.const_value is not None:
+            const_value_text = f", const_value={self.const_value!r}"
+        else:
+            const_value_text = ""
+        return f"{self.__class__.__name__}(name={value_name!r}{type_text}{shape_text}{producer_text}{index_text}{const_value_text})"
 
     def __str__(self) -> str:
         value_name = self.name if self.name is not None else "anonymous:" + str(id(self))

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1847,7 +1847,7 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
             producer_text = f", producer=anonymous_node:{id(producer)}"
         index_text = f", index={self.index()}" if self.index() is not None else ""
         if self.const_value is not None:
-            # The the first line only
+            # Take the first line only
             tensor_text = repr(self.const_value).replace("\n", " ")
             if len(tensor_text) > 100:
                 tensor_text = tensor_text[:100] + "...)"

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -406,7 +406,7 @@ class Tensor(TensorBase, _protocols.TensorProtocol, Generic[TArrayCompatible]): 
         return self.__array__().__dlpack_device__()
 
     def __repr__(self) -> str:
-        tensor_lines = str(self._raw).split("\n")
+        tensor_lines = repr(self._raw).split("\n")
         tensor_text = " ".join(line.strip() for line in tensor_lines)
         return f"{self._repr_base()}({tensor_text}, name={self.name!r})"
 

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1836,7 +1836,6 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
 
     def __repr__(self) -> str:
         value_name = self.name if self.name else "anonymous:" + str(id(self))
-
         type_text = f", type={self.type!r}" if self.type is not None else ""
         shape_text = f", shape={self.shape!r}" if self.shape is not None else ""
         producer = self.producer()

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1856,10 +1856,14 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
         value_name = self.name if self.name is not None else "anonymous:" + str(id(self))
         shape_text = str(self.shape) if self.shape is not None else "?"
         type_text = str(self.type) if self.type is not None else "?"
+        if self.const_value is not None and self.const_value.size < 10:
+            const_value_text = f"{{{self.const_value}}}"
+        else:
+            const_value_text = ""
 
         # Quote the name because in reality the names can have invalid characters
         # that make them hard to read
-        return f"%{_quoted(value_name)}<{type_text},{shape_text}>"
+        return f"%{_quoted(value_name)}<{type_text},{shape_text}>{const_value_text}"
 
     def producer(self) -> Node | None:
         """The node that produces this value.

--- a/onnxscript/ir/serde.py
+++ b/onnxscript/ir/serde.py
@@ -278,9 +278,10 @@ class TensorProtoTensor(_core.TensorBase):  # pylint: disable=too-many-ancestors
         return self._proto
 
     def __repr__(self) -> str:
-        # It is a little hard to display the content when there can be types
-        # unsupported by numpy
-        # Preferably we should display some content when the tensor is small
+        if self.size <= 10:
+            tensor_lines = repr(self.numpy()).split("\n")
+            tensor_text = " ".join(line.strip() for line in tensor_lines)
+            return f"{self._repr_base()}({tensor_text}, name={self.name!r})"
         return f"{self._repr_base()}(name={self.name!r})"
 
     def __array__(self, dtype: Any = None) -> np.ndarray:


### PR DESCRIPTION
Display constant values and simplify the value repr string when fields are empty.

```py
>>> from onnxscript import ir
>>> v = ir.Value(name="v1", const_value=ir.tensor(1))
>>> v
Value(name='v1', const_value=Tensor<INT64,[]>(array(1), name=None))
>>> v = ir.Value(name="v1", const_value=ir.tensor([[1]]))
>>> v
Value(name='v1', const_value=Tensor<INT64,[1,1]>(array([[1]]), name=None))
>>> print(v)
%"v1"<?,?>{Tensor<INT64,[1,1]>(array([[1]]), name=None)}
```

Fix https://github.com/microsoft/onnxscript/issues/2073