### PR TITLE
Export version_converter and support model proto

### DIFF
--- a/onnxscript/__init__.py
+++ b/onnxscript/__init__.py
@@ -7,6 +7,7 @@ __all__ = [
     "ir",
     "optimizer",
     "rewriter",
+    "version_converter",
     "export_onnx_lib",
     "OnnxFunction",
     "TracedOnnxFunction",
@@ -123,7 +124,7 @@ from .onnx_types import (
 
 # isort: on
 
-from . import ir, optimizer, rewriter
+from . import ir, optimizer, rewriter, version_converter
 from ._internal.utils import external_tensor
 from .values import OnnxFunction, TracedOnnxFunction
 


### PR DESCRIPTION
* Added `version_converter` to the list of public modules in `onnxscript/__init__.py`, allowing it to be used as onnxscript.version_converter.
* Updated the `convert_version` function in `onnxscript/version_converter/__init__.py` to support both `ir.Model` and `onnx.ModelProto` as input types.