### PR TITLE
[IR] Fix sequence handling in tensor function

### DIFF
--- a/onnxscript/ir/_convenience/_constructors.py
+++ b/onnxscript/ir/_convenience/_constructors.py
@@ -101,11 +101,17 @@ def tensor(
     elif isinstance(value, float):
         # If the value is a single float, we use np.float32 as the default dtype
         numpy_dtype = np.dtype(np.float32)
-    elif isinstance(value, Sequence) and value and all(
-        (isinstance(elem, int) and not isinstance(value, bool)) for elem in value
+    elif (
+        isinstance(value, Sequence)
+        and value
+        and all((isinstance(elem, int) and not isinstance(value, bool)) for elem in value)
     ):
         numpy_dtype = np.dtype(np.int64)
-    elif isinstance(value, Sequence) and value and all(isinstance(elem, float) for elem in value):
+    elif (
+        isinstance(value, Sequence)
+        and value
+        and all(isinstance(elem, float) for elem in value)
+    ):
         # If the value is a sequence of floats, we use np.float32 as the default dtype
         numpy_dtype = np.dtype(np.float32)
     elif isinstance(value, Sequence) and not value:

--- a/onnxscript/ir/_convenience/_constructors.py
+++ b/onnxscript/ir/_convenience/_constructors.py
@@ -92,11 +92,14 @@ def tensor(
         return tensor_adapters.TorchTensor(value, name=name, doc_string=doc_string)  # type: ignore[arg-type]
     elif isinstance(value, (_protocols.DLPackCompatible, _protocols.ArrayCompatible)):
         return _core.Tensor(value, dtype=dtype, name=name, doc_string=doc_string)
-    # Plain Python object
+
+    # Plain (numerical) Python object. Determine the numpy dtype and use np.array to construct the tensor
     if dtype is not None:
         if not isinstance(dtype, _enums.DataType):
             raise TypeError(f"dtype must be an instance of DataType. dtype={dtype}")
         numpy_dtype = dtype.numpy()
+    elif isinstance(value, Sequence) and not value:
+        raise ValueError("dtype must be specified when value is an empty sequence.")
     elif isinstance(value, int) and not isinstance(value, bool):
         # Specify int64 for ints because on Windows this may be int32
         numpy_dtype = np.dtype(np.int64)
@@ -109,13 +112,9 @@ def tensor(
         elif all(isinstance(elem, float) for elem in value):
             # If the value is a sequence of floats, we use np.float32 as the default dtype
             numpy_dtype = np.dtype(np.float32)
-    elif isinstance(value, Sequence) and not value:
-        if dtype is None:
-            raise ValueError("dtype must be specified when value is an empty sequence.")
-        else:
-            numpy_dtype = dtype.numpy()
     else:
         numpy_dtype = None
+
     array = np.array(value, dtype=numpy_dtype)
 
     # Handle string tensors by encoding them

--- a/onnxscript/ir/_convenience/_constructors.py
+++ b/onnxscript/ir/_convenience/_constructors.py
@@ -101,19 +101,12 @@ def tensor(
     elif isinstance(value, float):
         # If the value is a single float, we use np.float32 as the default dtype
         numpy_dtype = np.dtype(np.float32)
-    elif (
-        isinstance(value, Sequence)
-        and value
-        and all((isinstance(elem, int) and not isinstance(value, bool)) for elem in value)
-    ):
-        numpy_dtype = np.dtype(np.int64)
-    elif (
-        isinstance(value, Sequence)
-        and value
-        and all(isinstance(elem, float) for elem in value)
-    ):
-        # If the value is a sequence of floats, we use np.float32 as the default dtype
-        numpy_dtype = np.dtype(np.float32)
+    elif isinstance(value, Sequence) and value:
+        if all((isinstance(elem, int) and not isinstance(value, bool)) for elem in value):
+            numpy_dtype = np.dtype(np.int64)
+        elif all(isinstance(elem, float) for elem in value):
+            # If the value is a sequence of floats, we use np.float32 as the default dtype
+            numpy_dtype = np.dtype(np.float32)
     elif isinstance(value, Sequence) and not value:
         if dtype is None:
             raise ValueError("dtype must be specified when value is an empty sequence.")

--- a/onnxscript/ir/_convenience/_constructors.py
+++ b/onnxscript/ir/_convenience/_constructors.py
@@ -94,6 +94,8 @@ def tensor(
         return _core.Tensor(value, dtype=dtype, name=name, doc_string=doc_string)
     # Plain Python object
     if dtype is not None:
+        if not isinstance(dtype, _enums.DataType):
+            raise TypeError(f"dtype must be an instance of DataType. dtype={dtype}")
         numpy_dtype = dtype.numpy()
     elif isinstance(value, int) and not isinstance(value, bool):
         # Specify int64 for ints because on Windows this may be int32

--- a/onnxscript/ir/_convenience/_constructors.py
+++ b/onnxscript/ir/_convenience/_constructors.py
@@ -102,7 +102,7 @@ def tensor(
         # If the value is a single float, we use np.float32 as the default dtype
         numpy_dtype = np.dtype(np.float32)
     elif isinstance(value, Sequence) and value:
-        if all((isinstance(elem, int) and not isinstance(value, bool)) for elem in value):
+        if all((isinstance(elem, int) and not isinstance(elem, bool)) for elem in value):
             numpy_dtype = np.dtype(np.int64)
         elif all(isinstance(elem, float) for elem in value):
             # If the value is a sequence of floats, we use np.float32 as the default dtype
@@ -110,7 +110,8 @@ def tensor(
     elif isinstance(value, Sequence) and not value:
         if dtype is None:
             raise ValueError("dtype must be specified when value is an empty sequence.")
-        numpy_dtype = dtype.numpy()
+        else:
+            numpy_dtype = dtype.numpy()
     else:
         numpy_dtype = None
     array = np.array(value, dtype=numpy_dtype)

--- a/onnxscript/ir/_convenience/_constructors.py
+++ b/onnxscript/ir/_convenience/_constructors.py
@@ -101,13 +101,17 @@ def tensor(
     elif isinstance(value, float):
         # If the value is a single float, we use np.float32 as the default dtype
         numpy_dtype = np.dtype(np.float32)
-    elif isinstance(value, Sequence) and all(
+    elif isinstance(value, Sequence) and value and all(
         (isinstance(elem, int) and not isinstance(value, bool)) for elem in value
     ):
         numpy_dtype = np.dtype(np.int64)
-    elif isinstance(value, Sequence) and all(isinstance(elem, float) for elem in value):
+    elif isinstance(value, Sequence) and value and all(isinstance(elem, float) for elem in value):
         # If the value is a sequence of floats, we use np.float32 as the default dtype
         numpy_dtype = np.dtype(np.float32)
+    elif isinstance(value, Sequence) and not value:
+        if dtype is None:
+            raise ValueError("dtype must be specified when value is an empty sequence.")
+        numpy_dtype = dtype.numpy()
     else:
         numpy_dtype = None
     array = np.array(value, dtype=numpy_dtype)

--- a/onnxscript/ir/_convenience/_constructors.py
+++ b/onnxscript/ir/_convenience/_constructors.py
@@ -112,6 +112,8 @@ def tensor(
         elif all(isinstance(elem, float) for elem in value):
             # If the value is a sequence of floats, we use np.float32 as the default dtype
             numpy_dtype = np.dtype(np.float32)
+        else:
+            numpy_dtype = None
     else:
         numpy_dtype = None
 

--- a/onnxscript/ir/_convenience/_constructors_test.py
+++ b/onnxscript/ir/_convenience/_constructors_test.py
@@ -6,6 +6,7 @@ import unittest
 
 import numpy as np
 
+from onnxscript import ir
 from onnxscript.ir._convenience import _constructors
 
 
@@ -22,7 +23,7 @@ class ConstructorsTest(unittest.TestCase):
             _constructors.tensor([])
 
     def test_tensor_handles_empty_sequence_with_dtype(self):
-        tensor = _constructors.tensor([], dtype=np.float32)
+        tensor = _constructors.tensor([], dtype=ir.DataType.FLOAT)
         np.testing.assert_array_equal(tensor.numpy(), np.array([], dtype=np.float32))
 
 

--- a/onnxscript/ir/_convenience/_constructors_test.py
+++ b/onnxscript/ir/_convenience/_constructors_test.py
@@ -17,6 +17,14 @@ class ConstructorsTest(unittest.TestCase):
         tensor = _constructors.tensor(torch_tensor)
         np.testing.assert_array_equal(tensor, torch_tensor.numpy())
 
+    def test_tensor_raises_value_error_for_empty_sequence_without_dtype(self):
+        with self.assertRaises(ValueError):
+            _constructors.tensor([])
+
+    def test_tensor_handles_empty_sequence_with_dtype(self):
+        tensor = _constructors.tensor([], dtype=np.float32)
+        np.testing.assert_array_equal(tensor.numpy(), np.array([], dtype=np.float32))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
(Copilot) Fix bug in `tensor()` function to handle empty sequences and require `dtype` when value is an empty sequence.

* Add a check to ensure the sequence is non-empty before performing type checks in the `tensor()` function in `onnxscript/ir/_convenience/_constructors.py`.
* Raise a `ValueError` if `dtype` is `None` and `value` is an empty sequence in the `tensor()` function.
* Update the `tensor()` function to handle the case when a sequence is empty explicitly.
* Add a test case to check if `tensor()` raises a `ValueError` when `dtype` is `None` and `value` is an empty sequence in `onnxscript/ir/_convenience/_constructors_test.py`.
* Add a test case to check if `tensor()` handles the case when a sequence is empty explicitly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/microsoft/onnxscript/pull/2252?shareId=2ab5ada5-c6bd-4bc8-be2d-e9357dcbaa7b).