### PR TITLE
Add add/remove initializers passes

### DIFF
--- a/onnxscript/ir/passes/common/constant_manipulation.py
+++ b/onnxscript/ir/passes/common/constant_manipulation.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 __all__ = [
     "LiftConstantsToInitializersPass",
+    "RemoveInitializersFromInputsPass",
+    "AddInitializersToInputsPass",
 ]
 
 import logging
@@ -126,3 +128,40 @@ class LiftConstantsToInitializersPass(ir.passes.InPlacePass):
             )
             return None
         return tensor
+
+
+class RemoveInitializersFromInputsPass(ir.passes.InPlacePass):
+    """Remove initializers from inputs.
+
+    This pass finds all graph inputs that have a const_value and removes them from the graph.inputs list.
+    """
+
+    def call(self, model: ir.Model) -> ir.passes.PassResult:
+        count = 0
+        for graph in model.graphs():
+            initializers = set(graph.initializers.values())
+            new_inputs = []
+            for input_value in graph.inputs:
+                if input_value in initializers:
+                    count += 1
+                else:
+                    new_inputs.append(input_value)
+            graph.inputs = new_inputs
+        return ir.passes.PassResult(model, modified=bool(count))
+
+
+class AddInitializersToInputsPass(ir.passes.InPlacePass):
+    """Add initializers to inputs.
+
+    This pass finds all initializers and adds them to the graph.inputs list if they are not already present.
+    """
+
+    def call(self, model: ir.Model) -> ir.passes.PassResult:
+        count = 0
+        for graph in model.graphs():
+            inputs_set = set(graph.inputs)
+            for initializer in graph.initializers.values():
+                if initializer not in inputs_set:
+                    graph.inputs.append(initializer)
+                    count += 1
+        return ir.passes.PassResult(model, modified=bool(count))

--- a/onnxscript/ir/passes/common/constant_manipulation.py
+++ b/onnxscript/ir/passes/common/constant_manipulation.py
@@ -146,7 +146,9 @@ class RemoveInitializersFromInputsPass(ir.passes.InPlacePass):
                     count += 1
                 else:
                     new_inputs.append(input_value)
-            graph.inputs = new_inputs
+            graph.inputs.clear()
+            graph.inputs.extend(new_inputs)
+        logger.info("Removed %s initializers from graph inputs", count)
         return ir.passes.PassResult(model, modified=bool(count))
 
 
@@ -164,4 +166,5 @@ class AddInitializersToInputsPass(ir.passes.InPlacePass):
                 if initializer not in inputs_set:
                     graph.inputs.append(initializer)
                     count += 1
+        logger.info("Added %s initializers to graph inputs", count)
         return ir.passes.PassResult(model, modified=bool(count))

--- a/onnxscript/ir/passes/common/constant_manipulation_test.py
+++ b/onnxscript/ir/passes/common/constant_manipulation_test.py
@@ -251,5 +251,117 @@ class TestLiftConstantsToInitializersPass(unittest.TestCase):
         self.assertEqual(len(result.model.graph.initializers), 0)
 
 
+class TestRemoveInitializersFromInputsPass(unittest.TestCase):
+    def test_remove_initializers_from_inputs(self):
+        input_value = ir.Value(
+            name="input", type=ir.TensorType(ir.DataType.FLOAT), shape=ir.Shape((2, 3))
+        )
+        initializer_value = ir.Value(
+            name="initializer",
+            type=ir.TensorType(ir.DataType.FLOAT),
+            shape=ir.Shape((2, 3)),
+            const_value=ir.tensor(np.random.rand(2, 3).astype(np.float32)),
+        )
+        identity_node = ir.node("Identity", inputs=[input_value], num_outputs=1)
+
+        model = ir.Model(
+            graph=ir.Graph(
+                inputs=[input_value, initializer_value],
+                outputs=identity_node.outputs,
+                nodes=[identity_node],
+                initializers=[initializer_value],
+                opset_imports={"": 20},
+            ),
+            ir_version=10,
+        )
+
+        # Check that the initializer is in the graph inputs
+        self.assertIn(initializer_value, model.graph.inputs)
+
+        # Perform remove initializers from inputs
+        result = constant_manipulation.RemoveInitializersFromInputsPass()(model)
+        self.assertTrue(result.modified)
+        # Check that the initializer is removed from the graph inputs
+        self.assertNotIn(initializer_value, result.model.graph.inputs)
+
+    def test_remove_initializers_from_inputs_with_no_initializers(self):
+        input_value = ir.Value(
+            name="input", type=ir.TensorType(ir.DataType.FLOAT), shape=ir.Shape((2, 3))
+        )
+        identity_node = ir.node("Identity", inputs=[input_value], num_outputs=1)
+
+        model = ir.Model(
+            graph=ir.Graph(
+                inputs=[input_value],
+                outputs=identity_node.outputs,
+                nodes=[identity_node],
+                opset_imports={"": 20},
+            ),
+            ir_version=10,
+        )
+
+        # Perform remove initializers from inputs
+        result = constant_manipulation.RemoveInitializersFromInputsPass()(model)
+        self.assertFalse(result.modified)
+        # Check that the graph inputs remain unchanged
+        self.assertEqual(result.model.graph.inputs, [input_value])
+
+
+class TestAddInitializersToInputsPass(unittest.TestCase):
+    def test_add_initializers_to_inputs(self):
+        input_value = ir.Value(
+            name="input", type=ir.TensorType(ir.DataType.FLOAT), shape=ir.Shape((2, 3))
+        )
+        initializer_value = ir.Value(
+            name="initializer",
+            type=ir.TensorType(ir.DataType.FLOAT),
+            shape=ir.Shape((2, 3)),
+            const_value=ir.tensor(np.random.rand(2, 3).astype(np.float32)),
+        )
+        identity_node = ir.node("Identity", inputs=[input_value], num_outputs=1)
+
+        model = ir.Model(
+            graph=ir.Graph(
+                inputs=[input_value],
+                outputs=identity_node.outputs,
+                nodes=[identity_node],
+                initializers=[initializer_value],
+                opset_imports={"": 20},
+            ),
+            ir_version=10,
+        )
+
+        # Check that the initializer is not in the graph inputs
+        self.assertNotIn(initializer_value, model.graph.inputs)
+
+        # Perform add initializers to inputs
+        result = constant_manipulation.AddInitializersToInputsPass()(model)
+        self.assertTrue(result.modified)
+        # Check that the initializer is added to the graph inputs
+        self.assertIn(initializer_value, result.model.graph.inputs)
+
+    def test_add_initializers_to_inputs_with_no_initializers(self):
+        input_value = ir.Value(
+            name="input", type=ir.TensorType(ir.DataType.FLOAT), shape=ir.Shape((2, 3))
+        )
+        identity_node = ir.node("Identity", inputs=[input_value], num_outputs=1)
+
+        model = ir.Model(
+            graph=ir.Graph(
+                inputs=[input_value],
+                outputs=identity_node.outputs,
+                nodes=[identity_node],
+                opset_imports={"": 20},
+            ),
+            ir_version=10,
+        )
+
+        # Perform add initializers to inputs
+        result = constant_manipulation.AddInitializersToInputsPass()(model)
+        self.assertFalse(result.modified)
+        # Check that the graph inputs remain unchanged
+        self.assertEqual(result.model.graph.inputs, [input_value])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Implement `RemoveInitializersFromInputsPass` and `AddInitializersToInputsPass` in `onnxscript/ir/passes/common/constant_manipulation.py`.

* **RemoveInitializersFromInputsPass**
  - Add `RemoveInitializersFromInputsPass` class to find and remove graph inputs with `const_value`.
  - Implement `call` method to remove inputs with `const_value` from `graph.inputs`.
  - Register `RemoveInitializersFromInputsPass` in the `__all__` list.

* **AddInitializersToInputsPass**
  - Add `AddInitializersToInputsPass` class to find and add initializers to the graph inputs.
  - Implement `call` method to add all initializers to the graph inputs if not already present.
  - Register `AddInitializersToInputsPass` in the `__all__` list.

* **Tests**
  - Add test cases for `RemoveInitializersFromInputsPass` in `onnxscript/ir/passes/common/constant_manipulation_test.py` to verify removal of inputs with `const_value`.
  - Add test cases for `AddInitializersToInputsPass` in `onnxscript/ir/passes/common/constant_manipulation_test.py` to verify addition of initializers to the graph inputs.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/microsoft/onnxscript/pull/2253?shareId=321de9a6-ee5d-4a2a-a84d-27ef7a4c6d6f).