### PR TITLE
[pass] Update DCE passes

### DIFF
--- a/onnxscript/ir/passes/common/unused_removal.py
+++ b/onnxscript/ir/passes/common/unused_removal.py
@@ -99,6 +99,7 @@ class RemoveUnusedNodesPass(ir.passes.InPlacePass):
     that unused nodes and initializers are removed while preserving the original
     contract of the model.
     """
+
     def call(self, model: ir.Model) -> ir.passes.PassResult:
         count = _remove_unused_nodes_in_graph_like(model.graph)
         graph_outputs = frozenset(model.graph.outputs)

--- a/onnxscript/ir/passes/common/unused_removal.py
+++ b/onnxscript/ir/passes/common/unused_removal.py
@@ -93,8 +93,12 @@ def _remove_unused_nodes_in_graph_like(function_or_graph: ir.Function | ir.Graph
 
 
 class RemoveUnusedNodesPass(ir.passes.InPlacePass):
-    """Pass for removing unused nodes and initializers (dead code elimination)."""
+    """Pass for removing unused nodes and initializers (dead code elimination).
 
+    This pass does not modify the model signature (inputs and outputs). It ensures
+    that unused nodes and initializers are removed while preserving the original
+    contract of the model.
+    """
     def call(self, model: ir.Model) -> ir.passes.PassResult:
         count = _remove_unused_nodes_in_graph_like(model.graph)
         graph_outputs = frozenset(model.graph.outputs)

--- a/onnxscript/ir/passes/common/unused_removal_test.py
+++ b/onnxscript/ir/passes/common/unused_removal_test.py
@@ -13,15 +13,13 @@ from onnxscript import ir
 class RemoveUnusedTest(unittest.TestCase):
     using_ir: bool
 
-    def remove_unused_nodes(
-        self, model: onnx.ModelProto, remove_initialized_inputs: bool = False
-    ):
+    def remove_unused_nodes(self, model: onnx.ModelProto):
         if self.using_ir:
             model_ir = ir.serde.deserialize_model(model)
-            onnxscript.optimizer.remove_unused_nodes(model_ir, remove_initialized_inputs)
+            onnxscript.optimizer.remove_unused_nodes(model_ir)
             model = ir.serde.serialize_model(model_ir)
             return model
-        onnxscript.optimizer.remove_unused_nodes(model, remove_initialized_inputs)
+        onnxscript.optimizer.remove_unused_nodes(model)
         return model
 
     def test_remove_unused_nodes(self):
@@ -56,24 +54,7 @@ class RemoveUnusedTest(unittest.TestCase):
         self.assertEqual(model.graph.node[0].op_type, "Mul")
         self.assertEqual(len(model.graph.initializer), 0)
 
-    def test_unused_initialized_inputs_are_removed_when_requested(self):
-        # https://github.com/microsoft/onnxscript/issues/2211
-        model = onnx.parser.parse_model(
-            """
-            <ir_version: 10, opset_import: [ "" : 17]>
-            agraph (float[N] x, float[N] two) => (float[N] z)
-            <float two = {2.0,2.0}> {
-                four = Add(two, two)
-                z = Mul(x, x)
-            }
-        """
-        )
-        model = self.remove_unused_nodes(model, remove_initialized_inputs=True)
-        self.assertEqual(len(model.graph.node), 1)
-        self.assertEqual(model.graph.node[0].op_type, "Mul")
-        self.assertEqual(len(model.graph.input), 1)
-
-    def test_unused_initialized_inputs_are_kept_by_default(self):
+    def test_unused_initialized_inputs_are_kept(self):
         model = onnx.parser.parse_model(
             """
             <ir_version: 10, opset_import: [ "" : 17]>
@@ -88,9 +69,9 @@ class RemoveUnusedTest(unittest.TestCase):
         self.assertEqual(len(model.graph.node), 1)
         self.assertEqual(model.graph.node[0].op_type, "Mul")
         self.assertEqual(len(model.graph.input), 2)
+        self.assertEqual(len(model.graph.initializer), 1)
 
-    @parameterized.parameterized.expand([True, False])
-    def test_unused_inputs_are_not_removed(self, remove_initialized_inputs: bool):
+    def test_unused_inputs_are_not_removed(self):
         # preserve inputs as part of interface
         model = onnx.parser.parse_model(
             """
@@ -102,9 +83,7 @@ class RemoveUnusedTest(unittest.TestCase):
             }
         """
         )
-        model = self.remove_unused_nodes(
-            model, remove_initialized_inputs=remove_initialized_inputs
-        )
+        model = self.remove_unused_nodes(model)
         self.assertEqual(len(model.graph.node), 1)
         self.assertEqual(model.graph.node[0].op_type, "Mul")
         self.assertEqual(len(model.graph.input), 2)

--- a/onnxscript/optimizer/__init__.py
+++ b/onnxscript/optimizer/__init__.py
@@ -112,19 +112,15 @@ def fold_constants(
         return result
 
 
-def remove_unused_nodes(
-    model: ir.Model | onnx.ModelProto, remove_initialized_inputs: bool = False
-) -> None:
+def remove_unused_nodes(model: ir.Model | onnx.ModelProto) -> None:
     """Removes unused nodes from a model inplace."""
     if isinstance(model, ir.Model):
-        onnxscript.ir.passes.common.unused_removal.RemoveUnusedNodesPass(
-            remove_initialized_inputs=remove_initialized_inputs
-        )(model)
+        onnxscript.ir.passes.common.unused_removal.RemoveUnusedNodesPass()(model)
     else:
         model_ir = ir.serde.deserialize_model(model)
-        model_ir = onnxscript.ir.passes.common.unused_removal.RemoveUnusedNodesPass(
-            remove_initialized_inputs=remove_initialized_inputs
-        )(model_ir).model
+        model_ir = onnxscript.ir.passes.common.unused_removal.RemoveUnusedNodesPass()(
+            model_ir
+        ).model
         new_proto = ir.serde.serialize_model(model_ir)
         model.Clear()
         model.CopyFrom(new_proto)


### PR DESCRIPTION
- Remove the `remove_initialized_inputs` option in dce because the contract of the pass it that it does not modify model signature. Fixed bugs where initializers are removed. Instead, users can use https://github.com/microsoft/onnxscript/pull/2253 to remove the initialized inputs first.
- Additionally updated RemoveUnusedOpsetsPass to always retain the default opset.