### PR TITLE
Rewrite Skip fusions with check functions

### DIFF
--- a/onnxscript/rewriter/ort_fusions/skip_normalization.py
+++ b/onnxscript/rewriter/ort_fusions/skip_normalization.py
@@ -2,115 +2,179 @@
 # Licensed under the MIT License.
 from __future__ import annotations
 
+from typing import Sequence, Union
+
+import onnxscript.ir as ir
 from onnxscript.rewriter import _fusion_utils, pattern
 
+Dim = Union[int, ir.SymbolicDim]
 
-def _skip_rms_norm_pattern(op, input, skip, gamma, epsilon, stash_type):
-    skip_sum = op.Add(input, skip)
-    normalized = op.SimplifiedLayerNormalization(
-        skip_sum,
-        gamma,
-        axis=-1,
-        epsilon=epsilon,
-        stash_type=stash_type,
-    )
-    return normalized, skip_sum
+# Fusion rule for SkipRMSNormalization
 
 
-def _skip_rms_normalization(op, input, skip, gamma, epsilon, stash_type):
-    if stash_type.value != 1:  # FLOAT type
-        return None
-    normalized, _mean, _inv_std_var, skip_sum = op.SkipSimplifiedLayerNormalization(
-        input,
-        skip,
-        gamma,
-        epsilon=epsilon,
-        _outputs=4,
-        _domain="com.microsoft",
-    )
-    return normalized, skip_sum
+class SkipRmsNormFusion(pattern.RewriteRuleClassBase):
+    def __init__(self, name: str, has_bias: bool = False):
+        """Fusion rule for SkipRMSNormalization."""
+        super().__init__(name=name)
+        self._has_bias = has_bias
+
+    def pattern(self, op, input, skip, gamma, bias, epsilon, stash_type):
+        skip_sum = op.Add(input, skip)
+        if self._has_bias:
+            skip_sum = op.Add(skip_sum, bias)
+        normalized = op.SimplifiedLayerNormalization(
+            skip_sum,
+            gamma,
+            axis=-1,
+            epsilon=epsilon,
+            stash_type=stash_type,
+        )
+        return normalized, skip_sum
+
+    def check(self, op, input, skip, gamma, bias, epsilon, stash_type) -> pattern.MatchResult:  # type: ignore[name-defined]
+        """Check if the pattern matches conditions for use of SkipSimplifiedLayerNormalization op."""
+        check_result = pattern.MatchResult()
+        bindings: dict[str, Dim] = {}
+
+        def no_match(val: ir.Value, dims: Sequence[str]) -> bool:
+            return not _fusion_utils._check_shape(bindings, val, dims)
+
+        if no_match(input, ["B", "S", "D"]):
+            return check_result.fail(
+                f"Shape mismatch: {input} does not match expected dimensions ['B', 'S', 'D']",
+                input,
+            )
+        if no_match(skip, ["B", "S", "D"]):
+            return check_result.fail(
+                f"Shape mismatch: {skip} does not match expected dimensions ['B', 'S', 'D']",
+                skip,
+            )
+        if no_match(gamma, ["D"]):
+            return check_result.fail(
+                f"Shape mismatch: {gamma} does not match expected dimensions ['D']",
+                gamma,
+            )
+        if self._has_bias:
+            if no_match(bias, ["D"]):
+                return check_result.fail(
+                    f"Shape mismatch: {bias} does not match expected dimensions ['D']",
+                    bias,
+                )
+
+        return check_result
+
+    def rewrite(self, op, input, skip, gamma, bias, epsilon, stash_type):
+        if self._has_bias:
+            normalized, _mean, _inv_std_var, skip_sum = op.SkipSimplifiedLayerNormalization(
+                input,
+                skip,
+                gamma,
+                bias,
+                epsilon=epsilon,
+                _outputs=4,
+                _domain="com.microsoft",
+            )
+        else:
+            normalized, _mean, _inv_std_var, skip_sum = op.SkipSimplifiedLayerNormalization(
+                input,
+                skip,
+                gamma,
+                epsilon=epsilon,
+                _outputs=4,
+                _domain="com.microsoft",
+            )
+        return normalized, skip_sum
 
 
-_skip_rms_rule = pattern.RewriteRule(_skip_rms_norm_pattern, _skip_rms_normalization)
+_skip_rms_add_bias_rule = SkipRmsNormFusion.rule("SkipRmsNormBias", has_bias=True)
+_skip_rms_rule = SkipRmsNormFusion.rule("SkipRmsNorm", has_bias=False)
 
-skip_rms_normalization_rules = [_skip_rms_rule]
-skip_rms_normalization_ruleset = pattern.RewriteRuleSet(skip_rms_normalization_rules)
-
-
-def _skip_layer_norm_pattern(op, input, skip, gamma, beta, epsilon, stash_type):
-    skip_sum = op.Add(input, skip)
-    normalized = op.LayerNormalization(
-        skip_sum,
-        gamma,
-        beta,
-        axis=-1,
-        epsilon=epsilon,
-        stash_type=stash_type,
-    )
-    return normalized, skip_sum
-
-
-def _skip_layer_normalization(op, input, skip, gamma, beta, epsilon, stash_type):
-    if stash_type.value != 1:  # FLOAT type
-        return None
-    normalized, _mean, _inv_std_var, skip_sum = op.SkipLayerNormalization(
-        input,
-        skip,
-        gamma,
-        beta,
-        epsilon=epsilon,
-        _outputs=4,
-        _domain="com.microsoft",
-    )
-    return normalized, skip_sum
-
-
-# Fusion rule for Add + SkipLayerNormalization
-def _skip_layer_norm_add_bias_pattern(op, input, skip, gamma, beta, bias, epsilon, stash_type):
-    bias_sum = op.Add(input, bias)
-    normalized, _mean, _inv_std_var, skip_sum = op.SkipLayerNormalization(
-        bias_sum,
-        skip,
-        gamma,
-        beta,
-        epsilon=epsilon,
-        _outputs=4,
-        _domain="com.microsoft",
-    )
-    return normalized, skip_sum
-
-
-def _skip_layer_normalization_add_bias(
-    op, input, skip, gamma, beta, bias, epsilon, stash_type
-):
-    normalized, _mean, _inv_std_var, skip_sum = op.SkipLayerNormalization(
-        input,
-        skip,
-        gamma,
-        beta,
-        bias,
-        epsilon=epsilon,
-        _outputs=4,
-        _domain="com.microsoft",
-    )
-    return normalized, skip_sum
-
-
-_skip_layer_rule = pattern.RewriteRule(
-    _skip_layer_norm_pattern, _skip_layer_normalization, name="SkipLayerNorm"
+skip_rms_normalization_ruleset = pattern.RewriteRuleSet(
+    [_skip_rms_rule, _skip_rms_add_bias_rule]
 )
-_skip_layer_add_bias_rule = pattern.RewriteRule(
-    _skip_layer_norm_add_bias_pattern,
-    _skip_layer_normalization_add_bias,
-    name="SkipLayerNormAddBias",
-)
-
-
-skip_layer_normalization_rules = [_skip_layer_rule, _skip_layer_add_bias_rule]
-skip_layer_normalization_ruleset = pattern.RewriteRuleSet(skip_layer_normalization_rules)
-
-
 fuse_skip_rms_normalization = _fusion_utils.apply_fusion_rules(skip_rms_normalization_ruleset)
+
+
+# Fusion rule for SkipLayerNormalization
+class SkipLayerNormFusion(pattern.RewriteRuleClassBase):
+    def __init__(self, name: str, has_bias: bool = False):
+        """Fusion rule for SkipLayerNormalization."""
+        super().__init__(name=name)
+        self._has_bias = False
+
+    def pattern(self, op, input, skip, gamma, beta, bias, epsilon, stash_type):
+        skip_sum = op.Add(input, skip)
+        if self._has_bias:
+            skip_sum = op.Add(skip_sum, bias)
+        normalized = op.LayerNormalization(
+            skip_sum,
+            gamma,
+            beta,
+            axis=-1,
+            epsilon=epsilon,
+            stash_type=stash_type,
+        )
+        return normalized, skip_sum
+
+    def check(
+        self, op, input, skip, gamma, beta, bias, epsilon, stash_type
+    ) -> pattern.MatchResult:  # type: ignore[name-defined]
+        """Check if the pattern matches conditions for use of SimplifiedLayerNormalization op."""
+        check_result = pattern.MatchResult()
+        bindings: dict[str, Dim] = {}
+
+        def no_match(val: ir.Value, dims: Sequence[str]) -> bool:
+            return not _fusion_utils._check_shape(bindings, val, dims)
+
+        if no_match(input, ["B", "S", "D"]):
+            return check_result.fail(
+                f"Shape mismatch: {input} does not match expected dimensions ['B', 'S', 'D']",
+                input,
+            )
+        if no_match(skip, ["B", "S", "D"]):
+            return check_result.fail(
+                f"Shape mismatch: {skip} does not match expected dimensions ['B', 'S', 'D']",
+                skip,
+            )
+        if no_match(gamma, ["D"]):
+            return check_result.fail(
+                f"Shape mismatch: {gamma} does not match expected dimensions ['D']",
+                gamma,
+            )
+        if no_match(beta, ["D"]):
+            return check_result.fail(
+                f"Shape mismatch: {beta} does not match expected dimensions ['D']",
+                beta,
+            )
+        if self._has_bias:
+            if no_match(bias, ["D"]):
+                return check_result.fail(
+                    f"Shape mismatch: {bias} does not match expected dimensions ['D']",
+                    bias,
+                )
+
+        return check_result
+
+    def rewrite(self, op, input, skip, gamma, beta, bias, epsilon, stash_type):
+        normalized, _mean, _inv_std_var, skip_sum = op.SkipLayerNormalization(
+            input,
+            skip,
+            gamma,
+            beta,
+            bias,
+            epsilon=epsilon,
+            _outputs=4,
+            _domain="com.microsoft",
+        )
+        return normalized, skip_sum
+
+
+_skip_layer_add_bias_rule = SkipLayerNormFusion.rule("SkipLayerNormBias", has_bias=True)
+_skip_layer_rule = SkipLayerNormFusion.rule("SkipLayerNorm", has_bias=False)
+
+skip_layer_normalization_ruleset = pattern.RewriteRuleSet(
+    [_skip_layer_rule, _skip_layer_add_bias_rule]
+)
 
 
 fuse_skip_layer_normalization = _fusion_utils.apply_fusion_rules(

--- a/onnxscript/rewriter/ort_fusions/skip_normalization.py
+++ b/onnxscript/rewriter/ort_fusions/skip_normalization.py
@@ -93,7 +93,7 @@ _skip_rms_add_bias_rule = SkipRmsNormFusion.rule(
     "SkipRmsNormBias", has_bias=True, bias_pre_add=False
 )
 _skip_rms_pre_add_bias_rule = SkipRmsNormFusion.rule(
-    "SkipRmsNormBias", has_bias=True, bias_pre_add=True
+    "SkipRmsNormPreBias", has_bias=True, bias_pre_add=True
 )
 _skip_rms_rule = SkipRmsNormFusion.rule("SkipRmsNorm", has_bias=False)
 
@@ -184,7 +184,7 @@ _skip_layer_add_bias_rule = SkipLayerNormFusion.rule(
     "SkipLayerNormBias", has_bias=True, bias_pre_add=False
 )
 _skip_layer_pre_add_bias_rule = SkipLayerNormFusion.rule(
-    "SkipLayerNormBias", has_bias=True, bias_pre_add=True
+    "SkipLayerNormPreBias", has_bias=True, bias_pre_add=True
 )
 _skip_layer_rule = SkipLayerNormFusion.rule("SkipLayerNorm", has_bias=False)
 

--- a/onnxscript/rewriter/ort_fusions/skip_normalization.py
+++ b/onnxscript/rewriter/ort_fusions/skip_normalization.py
@@ -25,6 +25,8 @@ class SkipRmsNormFusion(pattern.RewriteRuleClassBase):
         skip_sum = op.Add(input, skip)
         if self._has_bias and not self._bias_pre_add:
             skip_sum = op.Add(skip_sum, bias)
+        # Note: ORT's SimplifiedLayerNormalization was placed in onnx domain by mistake.
+        # No need to use com.microsoft domain here; but this is a custom op in ORT.
         normalized = op.SimplifiedLayerNormalization(
             skip_sum,
             gamma,


### PR DESCRIPTION
- Rewrite SkipLayerNorm fusions and SkipRMSNorm fusions to match format of other ort-fusion patterns.
- Added check functions for ensuring shapes are as expected.
- Moving these fusions out of PR #2221 

Fusion support patterns with:
- `Add(input, skip) -> Norm`
- `Add(input, skip) -> Add (result, bias) -> Norm`
- `Add(input, bias) -> Add (result, skip) -> Norm`


NOTE:
These fusions should support:
- Planned whisper-related optimizations
- Benchmark failures stemming from wrong bias shapes for SkipLayerNorm fusions
