### PR TITLE
Create short tensor str for nodes

### DIFF
--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1310,7 +1310,7 @@ def _short_tensor_str_for_node(x: Value) -> str:
     if x.const_value.size <= 10:
         try:
             data = x.const_value.numpy().tolist()
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             return "{...}"
         return f"{{{data}}}"
     return "{...}"

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1315,6 +1315,7 @@ def _short_tensor_str_for_node(x: Value) -> str:
         return f"{{{data}}}"
     return "{...}"
 
+
 class Node(_protocols.NodeProtocol, _display.PrettyPrintable):
     """IR Node.
 

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1304,6 +1304,19 @@ class Usage(NamedTuple):
     idx: int
 
 
+def _short_tensor_str_for_node(x: Value) -> str:
+    if x.const_value is None:
+        return ""
+    if x.const_value.size <= 10:
+        try:
+            array = x.const_value.numpy()
+        except Exception:
+            return "{...}"
+        tensor_lines = repr(array).split("\n")
+        tensor_text = "".join(line.strip() for line in tensor_lines)
+        return f"{{{tensor_text}}}"
+    return "{...}"
+
 class Node(_protocols.NodeProtocol, _display.PrettyPrintable):
     """IR Node.
 
@@ -1468,7 +1481,7 @@ class Node(_protocols.NodeProtocol, _display.PrettyPrintable):
             + ", ".join(
                 [
                     (
-                        f"%{_quoted(x.name) if x.name else 'anonymous:' + str(id(x))}{x._constant_tensor_part()}"
+                        f"%{_quoted(x.name) if x.name else 'anonymous:' + str(id(x))}{_short_tensor_str_for_node(x)}"
                         if x is not None
                         else "None"
                     )

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1309,12 +1309,10 @@ def _short_tensor_str_for_node(x: Value) -> str:
         return ""
     if x.const_value.size <= 10:
         try:
-            array = x.const_value.numpy()
+            data = x.const_value.numpy().tolist()
         except Exception:
             return "{...}"
-        tensor_lines = repr(array).split("\n")
-        tensor_text = "".join(line.strip() for line in tensor_lines)
-        return f"{{{tensor_text}}}"
+        return f"{{{data}}}"
     return "{...}"
 
 class Node(_protocols.NodeProtocol, _display.PrettyPrintable):


### PR DESCRIPTION
The display of constant value is now more concise.

```
>>> from onnxscript import ir
>>> n = ir.node("Add", [ir.Value(name="a", const_value=ir.tensor(1)), ir.Value(name="b", const_value=ir.tensor([1]*10))], name="n0")
>>> print(n)
%"anonymous:123273301338960"<?,?> ⬅️ ::Add(%"a"{1}, %"b"{[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]})
>>> print(repr(n))
Node(name='n0', domain='', op_type='Add', inputs=(Value(name='a', const_value={Tensor<INT64,[]>(array(1), name=None)}), Value(name='b', const_value={Tensor<INT64,[10]>(array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1]), name=None)})), attributes=OrderedDict(), overload='', outputs=(Value(name='anonymous:135329937264592', producer='n0', index=0),), version=None, doc_string=None)
```