### PR TITLE
[IR] Export all common passes in `onnxscript.ir.passes.common`

### DIFF
--- a/docs/ir/ir_api/ir_passes_common.md
+++ b/docs/ir/ir_api/ir_passes_common.md
@@ -1,25 +1,10 @@
 # ir.passes.common
 
-```{eval-rst}
-.. currentmodule:: onnxscript
-```
-
-## Built-in passes
-
+Built-in passes provided by the ONNX IR
 
 ```{eval-rst}
-.. autosummary::
-    :toctree: generated
-    :template: classtemplate.rst
-    :nosignatures:
+.. automodule:: onnxscript.ir.passes.common
+    :members:
+    :undoc-members:
 
-    ir.passes.common.unused_removal.RemoveUnusedNodesPass
-    ir.passes.common.unused_removal.RemoveUnusedFunctionsPass
-    ir.passes.common.unused_removal.RemoveUnusedOpsetsPass
-    ir.passes.common.inliner.InlinePass
-    ir.passes.common.topological_sort.TopologicalSortPass
-    ir.passes.common.constant_manipulation.LiftConstantsToInitializersPass
-    ir.passes.common.shape_inference.ShapeInferencePass
-    ir.passes.common.onnx_checker.CheckerPass
-    ir.passes.common.clear_metadata_and_docstring.ClearMetadataAndDocStringPass
 ```

--- a/onnxscript/ir/passes/__init__.py
+++ b/onnxscript/ir/passes/__init__.py
@@ -13,8 +13,11 @@ __all__ = [
     "PreconditionError",
     "PostconditionError",
     "PassError",
+    # Common passes
+    "common",
 ]
 
+from onnxscript.ir.passes import common
 from onnxscript.ir.passes._pass_infra import (
     FunctionalPass,
     InPlacePass,

--- a/onnxscript/ir/passes/__init__.py
+++ b/onnxscript/ir/passes/__init__.py
@@ -13,11 +13,8 @@ __all__ = [
     "PreconditionError",
     "PostconditionError",
     "PassError",
-    # Common passes
-    "common",
 ]
 
-from onnxscript.ir.passes import common
 from onnxscript.ir.passes._pass_infra import (
     FunctionalPass,
     InPlacePass,

--- a/onnxscript/ir/passes/common/__init__.py
+++ b/onnxscript/ir/passes/common/__init__.py
@@ -2,31 +2,35 @@
 # Licensed under the MIT License.
 
 __all__ = [
-    "clear_metadata_and_docstring",
-    "constant_manipulation",
-    "inliner",
-    "onnx_checker",
-    "shape_inference",
-    "topological_sort",
-    "unused_removal",
+    "AddInitializersToInputsPass",
+    "CheckerPass",
+    "ClearMetadataAndDocStringPass",
+    "InlinePass",
+    "LiftConstantsToInitializersPass",
+    "LiftSubgraphInitializersToMainGraphPass",
+    "RemoveInitializersFromInputsPass",
+    "RemoveUnusedFunctionsPass",
+    "RemoveUnusedNodesPass",
+    "RemoveUnusedOpsetsPass",
+    "ShapeInferencePass",
+    "TopologicalSortPass",
 ]
 
-from onnxscript.ir.passes.common import (
-    clear_metadata_and_docstring,
-    constant_manipulation,
-    inliner,
-    onnx_checker,
-    shape_inference,
-    topological_sort,
-    unused_removal,
+from onnxscript.ir.passes.common.clear_metadata_and_docstring import (
+    ClearMetadataAndDocStringPass,
 )
-
-
-def __set_module() -> None:
-    """Set the module of all functions in this module to this public module."""
-    global_dict = globals()
-    for name in __all__:
-        global_dict[name].__module__ = __name__
-
-
-__set_module()
+from onnxscript.ir.passes.common.constant_manipulation import (
+    AddInitializersToInputsPass,
+    LiftConstantsToInitializersPass,
+    LiftSubgraphInitializersToMainGraphPass,
+    RemoveInitializersFromInputsPass,
+)
+from onnxscript.ir.passes.common.inliner import InlinePass
+from onnxscript.ir.passes.common.onnx_checker import CheckerPass
+from onnxscript.ir.passes.common.shape_inference import ShapeInferencePass
+from onnxscript.ir.passes.common.topological_sort import TopologicalSortPass
+from onnxscript.ir.passes.common.unused_removal import (
+    RemoveUnusedFunctionsPass,
+    RemoveUnusedNodesPass,
+    RemoveUnusedOpsetsPass,
+)

--- a/onnxscript/optimizer/__init__.py
+++ b/onnxscript/optimizer/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
 
 import onnx
 
+import onnxscript.ir.passes.common
 import onnxscript.optimizer._constant_folding as constant_folding
 from onnxscript import ir
 from onnxscript.optimizer._constant_folding import (
@@ -89,7 +90,7 @@ def optimize(
 def inline(model: ir.Model) -> None:
     """Inline all function calls (recursively) in the model."""
     if model.functions:
-        ir.passes.common.InlinePass()(model)
+        onnxscript.ir.passes.common.InlinePass()(model)
 
 
 def fold_constants(
@@ -113,10 +114,10 @@ def fold_constants(
 def remove_unused_nodes(model: ir.Model | onnx.ModelProto) -> None:
     """Removes unused nodes from a model inplace."""
     if isinstance(model, ir.Model):
-        ir.passes.common.RemoveUnusedNodesPass()(model)
+        onnxscript.ir.passes.common.RemoveUnusedNodesPass()(model)
     else:
         model_ir = ir.serde.deserialize_model(model)
-        model_ir = ir.passes.common.RemoveUnusedNodesPass()(model_ir).model
+        model_ir = onnxscript.ir.passes.common.RemoveUnusedNodesPass()(model_ir).model
         new_proto = ir.serde.serialize_model(model_ir)
         model.Clear()
         model.CopyFrom(new_proto)
@@ -125,10 +126,10 @@ def remove_unused_nodes(model: ir.Model | onnx.ModelProto) -> None:
 def remove_unused_functions(model: ir.Model | onnx.ModelProto) -> None:
     """Removes unused functions from a model inplace."""
     if isinstance(model, ir.Model):
-        ir.passes.common.RemoveUnusedFunctionsPass()(model)
+        onnxscript.ir.passes.common.RemoveUnusedFunctionsPass()(model)
     else:
         model_ir = ir.serde.deserialize_model(model)
-        model_ir = ir.passes.common.RemoveUnusedFunctionsPass()(model_ir).model
+        model_ir = onnxscript.ir.passes.common.RemoveUnusedFunctionsPass()(model_ir).model
         new_proto = ir.serde.serialize_model(model_ir)
         model.Clear()
         model.CopyFrom(new_proto)

--- a/onnxscript/optimizer/__init__.py
+++ b/onnxscript/optimizer/__init__.py
@@ -16,8 +16,6 @@ __all__ = [
 
 import onnx
 
-import onnxscript.ir.passes.common.inliner
-import onnxscript.ir.passes.common.unused_removal
 import onnxscript.optimizer._constant_folding as constant_folding
 from onnxscript import ir
 from onnxscript.optimizer._constant_folding import (
@@ -91,7 +89,7 @@ def optimize(
 def inline(model: ir.Model) -> None:
     """Inline all function calls (recursively) in the model."""
     if model.functions:
-        onnxscript.ir.passes.common.inliner.InlinePass()(model)
+        ir.passes.common.InlinePass()(model)
 
 
 def fold_constants(
@@ -115,12 +113,10 @@ def fold_constants(
 def remove_unused_nodes(model: ir.Model | onnx.ModelProto) -> None:
     """Removes unused nodes from a model inplace."""
     if isinstance(model, ir.Model):
-        onnxscript.ir.passes.common.unused_removal.RemoveUnusedNodesPass()(model)
+        ir.passes.common.RemoveUnusedNodesPass()(model)
     else:
         model_ir = ir.serde.deserialize_model(model)
-        model_ir = onnxscript.ir.passes.common.unused_removal.RemoveUnusedNodesPass()(
-            model_ir
-        ).model
+        model_ir = ir.passes.common.RemoveUnusedNodesPass()(model_ir).model
         new_proto = ir.serde.serialize_model(model_ir)
         model.Clear()
         model.CopyFrom(new_proto)
@@ -129,12 +125,10 @@ def remove_unused_nodes(model: ir.Model | onnx.ModelProto) -> None:
 def remove_unused_functions(model: ir.Model | onnx.ModelProto) -> None:
     """Removes unused functions from a model inplace."""
     if isinstance(model, ir.Model):
-        onnxscript.ir.passes.common.unused_removal.RemoveUnusedFunctionsPass()(model)
+        ir.passes.common.RemoveUnusedFunctionsPass()(model)
     else:
         model_ir = ir.serde.deserialize_model(model)
-        model_ir = onnxscript.ir.passes.common.unused_removal.RemoveUnusedFunctionsPass()(
-            model_ir
-        ).model
+        model_ir = ir.passes.common.RemoveUnusedFunctionsPass()(model_ir).model
         new_proto = ir.serde.serialize_model(model_ir)
         model.Clear()
         model.CopyFrom(new_proto)

--- a/onnxscript/optimizer/_optimizer.py
+++ b/onnxscript/optimizer/_optimizer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 
+import onnxscript.ir.passes.common
 from onnxscript import ir, rewriter
 from onnxscript.optimizer import _constant_folding
 
@@ -42,20 +43,20 @@ def optimize_ir(
                     output_size_limit=output_size_limit,
                 ),
                 rewriter.RewritePass(rewriter._DEFAULT_REWRITE_RULES),
-                ir.passes.common.RemoveUnusedNodesPass(),
-                ir.passes.common.RemoveUnusedFunctionsPass(),
-                ir.passes.common.RemoveUnusedOpsetsPass(),
+                onnxscript.ir.passes.common.RemoveUnusedNodesPass(),
+                onnxscript.ir.passes.common.RemoveUnusedFunctionsPass(),
+                onnxscript.ir.passes.common.RemoveUnusedOpsetsPass(),
             ],
             steps=num_iterations,
             early_stop=stop_if_no_change,
         ),
-        ir.passes.common.RemoveUnusedNodesPass(),
-        ir.passes.common.LiftConstantsToInitializersPass(),
-        ir.passes.common.LiftSubgraphInitializersToMainGraphPass(),
+        onnxscript.ir.passes.common.RemoveUnusedNodesPass(),
+        onnxscript.ir.passes.common.LiftConstantsToInitializersPass(),
+        onnxscript.ir.passes.common.LiftSubgraphInitializersToMainGraphPass(),
     ]
     if inline:
         # Inline all functions first before optimizing
-        passes = [ir.passes.common.InlinePass(), *passes]
+        passes = [onnxscript.ir.passes.common.InlinePass(), *passes]
     optimizer_pass = ir.passes.Sequential(*passes)
     assert optimizer_pass.in_place
     result = optimizer_pass(model)

--- a/onnxscript/optimizer/_optimizer.py
+++ b/onnxscript/optimizer/_optimizer.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 import logging
 
-import onnxscript.ir.passes.common.constant_manipulation
-import onnxscript.ir.passes.common.inliner
-import onnxscript.ir.passes.common.unused_removal
 from onnxscript import ir, rewriter
 from onnxscript.optimizer import _constant_folding
 
@@ -45,20 +42,20 @@ def optimize_ir(
                     output_size_limit=output_size_limit,
                 ),
                 rewriter.RewritePass(rewriter._DEFAULT_REWRITE_RULES),
-                onnxscript.ir.passes.common.unused_removal.RemoveUnusedNodesPass(),
-                onnxscript.ir.passes.common.unused_removal.RemoveUnusedFunctionsPass(),
-                onnxscript.ir.passes.common.unused_removal.RemoveUnusedOpsetsPass(),
+                ir.passes.common.RemoveUnusedNodesPass(),
+                ir.passes.common.RemoveUnusedFunctionsPass(),
+                ir.passes.common.RemoveUnusedOpsetsPass(),
             ],
             steps=num_iterations,
             early_stop=stop_if_no_change,
         ),
-        onnxscript.ir.passes.common.unused_removal.RemoveUnusedNodesPass(),
-        onnxscript.ir.passes.common.constant_manipulation.LiftConstantsToInitializersPass(),
-        onnxscript.ir.passes.common.constant_manipulation.LiftSubgraphInitializersToMainGraphPass(),
+        ir.passes.common.RemoveUnusedNodesPass(),
+        ir.passes.common.LiftConstantsToInitializersPass(),
+        ir.passes.common.LiftSubgraphInitializersToMainGraphPass(),
     ]
     if inline:
         # Inline all functions first before optimizing
-        passes = [onnxscript.ir.passes.common.inliner.InlinePass(), *passes]
+        passes = [ir.passes.common.InlinePass(), *passes]
     optimizer_pass = ir.passes.Sequential(*passes)
     assert optimizer_pass.in_place
     result = optimizer_pass(model)

--- a/onnxscript/version_converter/__init__.py
+++ b/onnxscript/version_converter/__init__.py
@@ -13,8 +13,6 @@ import onnx
 
 from onnxscript import ir
 from onnxscript.ir.passes.common import _c_api_utils
-from onnxscript.ir.passes.common import inliner as _inliner
-from onnxscript.ir.passes.common import unused_removal as _unused_removal
 from onnxscript.version_converter import _version_converter
 
 logger = logging.getLogger(__name__)
@@ -40,14 +38,14 @@ class ConvertVersionPass(ir.passes.InPlacePass):
         self.target_version = target_version
         self.fallback = fallback
         self.convert_pass = ir.passes.Sequential(
-            _inliner.InlinePass(),
+            ir.passes.common.InlinePass(),
             _ConvertVersionPassRequiresInline(
                 target_version=target_version,
                 fallback=fallback,
             ),
-            _unused_removal.RemoveUnusedNodesPass(),
-            _unused_removal.RemoveUnusedFunctionsPass(),
-            _unused_removal.RemoveUnusedOpsetsPass(),
+            ir.passes.common.RemoveUnusedNodesPass(),
+            ir.passes.common.RemoveUnusedFunctionsPass(),
+            ir.passes.common.RemoveUnusedOpsetsPass(),
         )
 
     def call(self, model: ir.Model) -> ir.passes.PassResult:

--- a/onnxscript/version_converter/__init__.py
+++ b/onnxscript/version_converter/__init__.py
@@ -11,6 +11,7 @@ import logging
 
 import onnx
 
+import onnxscript.ir.passes.common
 from onnxscript import ir
 from onnxscript.ir.passes.common import _c_api_utils
 from onnxscript.version_converter import _version_converter
@@ -38,14 +39,14 @@ class ConvertVersionPass(ir.passes.InPlacePass):
         self.target_version = target_version
         self.fallback = fallback
         self.convert_pass = ir.passes.Sequential(
-            ir.passes.common.InlinePass(),
+            onnxscript.ir.passes.common.InlinePass(),
             _ConvertVersionPassRequiresInline(
                 target_version=target_version,
                 fallback=fallback,
             ),
-            ir.passes.common.RemoveUnusedNodesPass(),
-            ir.passes.common.RemoveUnusedFunctionsPass(),
-            ir.passes.common.RemoveUnusedOpsetsPass(),
+            onnxscript.ir.passes.common.RemoveUnusedNodesPass(),
+            onnxscript.ir.passes.common.RemoveUnusedFunctionsPass(),
+            onnxscript.ir.passes.common.RemoveUnusedOpsetsPass(),
         )
 
     def call(self, model: ir.Model) -> ir.passes.PassResult:
@@ -76,7 +77,7 @@ class _ConvertVersionPassRequiresInline(ir.passes.InPlacePass):
         if model.functions:
             raise ValueError(
                 "The model contains functions. The version conversion pass does not support "
-                "functions. Please use `onnxscript.ir.passes.common.inliner.InlinePass` to inline the "
+                "functions. Please use `onnxscript.onnxscript.ir.passes.common.inliner.InlinePass` to inline the "
                 f"functions before applying this pass ({self.__class__.__name__})."
             )
         if "" in model.graph.opset_imports:

--- a/tests/function_libs/torch_lib/ops_test_common.py
+++ b/tests/function_libs/torch_lib/ops_test_common.py
@@ -35,6 +35,7 @@ from torch.testing._internal.opinfo import core as opinfo_core
 
 import onnxscript
 import onnxscript.evaluator
+import onnxscript.ir.passes.common
 from onnxscript import ir
 from onnxscript.function_libs.torch_lib.ops import common as common_ops
 from tests.function_libs.torch_lib import error_reproduction
@@ -419,7 +420,7 @@ def add_torchlib_common_imports(model: ir.Model) -> None:
     is_scalar_func = ir.serde.deserialize_function(common_ops.IsScalar.to_function_proto())
     model.functions[rank_func.identifier()] = rank_func
     model.functions[is_scalar_func.identifier()] = is_scalar_func
-    removal_pass = ir.passes.common.unused_removal.RemoveUnusedFunctionsPass()
+    removal_pass = onnxscript.ir.passes.common.unused_removal.RemoveUnusedFunctionsPass()
     assert removal_pass.in_place
     removal_pass(model)
 

--- a/tests/function_libs/torch_lib/ops_test_common.py
+++ b/tests/function_libs/torch_lib/ops_test_common.py
@@ -35,7 +35,6 @@ from torch.testing._internal.opinfo import core as opinfo_core
 
 import onnxscript
 import onnxscript.evaluator
-import onnxscript.ir.passes.common.unused_removal
 from onnxscript import ir
 from onnxscript.function_libs.torch_lib.ops import common as common_ops
 from tests.function_libs.torch_lib import error_reproduction
@@ -420,7 +419,7 @@ def add_torchlib_common_imports(model: ir.Model) -> None:
     is_scalar_func = ir.serde.deserialize_function(common_ops.IsScalar.to_function_proto())
     model.functions[rank_func.identifier()] = rank_func
     model.functions[is_scalar_func.identifier()] = is_scalar_func
-    removal_pass = onnxscript.ir.passes.common.unused_removal.RemoveUnusedFunctionsPass()
+    removal_pass = ir.passes.common.unused_removal.RemoveUnusedFunctionsPass()
     assert removal_pass.in_place
     removal_pass(model)
 


### PR DESCRIPTION
## Rational

In actual usage, exposing the passes under `onnxscript.ir.passes.common.[module_name]` make the passes harder to be discovered. In pytorch, nn modules are exposed under the same namespace, `torch.nn`, making it easier for user to find and use them. We use the same idea and expose all common passes under `onnxscript.ir.passes.common`.

Before this change, users will need to do

```py
from onnxscript.ir.passes.common import unused_removal

unused_removal.RemoveUnusedNodesPass()(model)
```

With this change, uses can now do 

```py
import onnxscript.ir.passes.common

onnxscript.ir.passes.common.RemoveUnusedNodesPass()(model)
```

without having to know the module name.