### PR TITLE
Add support for backtracking in pattern matcher

### DIFF
--- a/onnxscript/rewriter/generic_pattern.py
+++ b/onnxscript/rewriter/generic_pattern.py
@@ -83,7 +83,9 @@ def _to_match_result(pmr: PatternMatchResult) -> orp.MatchResult:
     TODO: This is a temporary hack until MatchResult and PatternMatchResult are unified.
     """
     result = orp.MatchResult()
-    result.nodes.extend(pmr.model_nodes)
+    for node in pmr.model_nodes:
+        result.add_node(node)
+
     for var, val in pmr.matched_pattern_to_model_value.items():
         if var.name is not None:
             result.bind(var.name, val)

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -354,8 +354,12 @@ class MatchResult:
         return self._reason
 
     @property
-    def nodes(self) -> MutableSequence[ir.Node]:
-        return self._matched_nodes
+    def nodes(self) -> Sequence[ir.Node]:
+        return tuple(self._matched_nodes)
+
+    def add_node(self, node: ir.Node) -> None:
+        """Adds a node to the list of matched nodes."""
+        self._matched_nodes.append(node)
 
     def bind(self, var: str, value: Any) -> bool:
         """Binds a pattern variable name to a value from the matched IR.
@@ -1117,7 +1121,7 @@ class SimplePatternMatcher(PatternMatcher):
         if self._verbose:
             print(f"Matched: {node.op_type}")
 
-        match.nodes.append(node)
+        match.add_node(node)
         self._matched[pattern_node] = node
 
         # TODO: Revisit this to handle optional trailing inputs better.

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -10,6 +10,7 @@ import inspect
 import itertools
 import math
 from collections import defaultdict
+from collections.abc import Mapping
 from typing import (
     Any,
     Callable,
@@ -794,7 +795,7 @@ class _OpIdDispatchOr(ValuePattern):
 
     def __init__(
         self,
-        op_to_pattern: dict[ir.OperatorIdentifier, tuple[Any, ValuePattern]],
+        op_to_pattern: Mapping[ir.OperatorIdentifier, tuple[Any, ValuePattern]],
         name: str | None = None,
         tag_var: str | None = None,
     ) -> None:

--- a/onnxscript/rewriter/pattern_test.py
+++ b/onnxscript/rewriter/pattern_test.py
@@ -721,6 +721,39 @@ class RewriteRuleTest(unittest.TestCase):
         rule.apply_to_model(model)
         self.assertEqual([x.op_type for x in model.graph], ["WithBias"])
 
+    def test_backtracking_pattern(self):
+        def source_pattern(op, x, y, bias):
+            t1 = op.MatMul(x, y)
+            choice1 = op.Add(t1, bias)
+            choice2 = op.Add(bias, t1)
+            t2 = pattern.OrValue([choice1, choice2])
+            return op.Relu(t2)
+
+        def replacement(op, x, y, bias):
+            return op.GemmRelu(x, y, bias)
+
+        rule = pattern.RewriteRule(source_pattern, replacement)
+
+        @script()
+        def test_model1(x: FLOAT[16, 32], y: FLOAT[32, 16], bias: FLOAT[16]) -> FLOAT[16, 16]:
+            return op.Relu(op.Add(op.MatMul(x, y), bias))
+
+        model_proto = test_model1.to_model_proto()
+        model = ir.serde.deserialize_model(model_proto)
+        rule.apply_to_model(model)
+        self.assertEqual([x.op_type for x in model.graph], ["GemmRelu"])
+        self.assertEqual([x.name for x in model.graph.node(0).inputs], ["x", "y", "bias"])
+
+        @script()
+        def test_model2(x: FLOAT[16, 32], y: FLOAT[32, 16], bias: FLOAT[16]) -> FLOAT[16, 16]:
+            return op.Relu(op.Add(bias, op.MatMul(x, y)))
+
+        model_proto = test_model2.to_model_proto()
+        model = ir.serde.deserialize_model(model_proto)
+        rule.apply_to_model(model)
+        self.assertEqual([x.op_type for x in model.graph], ["GemmRelu"])
+        self.assertEqual([x.name for x in model.graph.node(0).inputs], ["x", "y", "bias"])
+
 
 class PatternBuilderTest(unittest.TestCase):
     def test_pattern_builder_context(self):


### PR DESCRIPTION
Extends the recently introduced "Or" patterns fully (without any restrictions). The general case is handled via backtracking. The Or pattern constructor function will automatically determine whether the optimized (deterministic) matching implementation can be used or if the backtracking-based implementation should be used.