### PR TITLE
[torchlib] Fix scatter reduce on error cases

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -7627,6 +7627,8 @@ def aten_scatter_reduce(
                 value = ir.tensor([np.finfo(dtype.numpy()).min], dtype=dtype)
             elif dtype == ir.DataType.BFLOAT16:
                 value = ir.tensor([torch.finfo(torch.bfloat16).min], dtype=dtype)
+            elif dtype == ir.DataType.BOOL:
+                value = ir.tensor([False], dtype=dtype)
             else:
                 value = ir.tensor([np.iinfo(dtype.numpy()).min], dtype=dtype)
             reduction_init = "min"
@@ -7638,7 +7640,9 @@ def aten_scatter_reduce(
             }:
                 value = ir.tensor([np.finfo(dtype.numpy()).max], dtype=dtype)
             elif dtype == ir.DataType.BFLOAT16:
-                value = ir.tensor([torch.finfo(torch.bfloat16).min], dtype=dtype)
+                value = ir.tensor([torch.finfo(torch.bfloat16).max], dtype=dtype)
+            elif dtype == ir.DataType.BOOL:
+                value = ir.tensor([True], dtype=dtype)
             else:
                 value = ir.tensor([np.iinfo(dtype.numpy()).max], dtype=dtype)
             reduction_init = "max"

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -7649,7 +7649,7 @@ def aten_scatter_reduce(
             value = ir.tensor([1], dtype=dtype)
             reduction_init = "none"
         else:
-            value = 0
+            value = ir.tensor([0], dtype=dtype)
             reduction_init = "none"
 
         cst = op.ConstantOfShape(op.Shape(src), value=value)


### PR DESCRIPTION
Fix three errors

```pytb
value = ir.tensor([np.iinfo(dtype.numpy()).min], dtype=dtype)
                       ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/numpy/_core/getlimits.py", line 706, in __init__
    raise ValueError("Invalid integer data type %r." % (self.kind,))
ValueError: Invalid integer data type 'b'.
```

```pytb
Traceback (most recent call last):
  File "/Users/runner/work/torch-onnx-op-matrix/torch-onnx-op-matrix/op_matrix/onnx_dynamo_op_survey.py", line 54, in check_single_op
    onnx.checker.check_model(onnx_model, full_check=True)  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/onnx/checker.py", line 180, in check_model
    C.check_model(
onnx.onnx_cpp2py_export.checker.ValidationError: Mismatched attribute type in 'node_ConstantOfShape_1 : value'. Expected: 'TENSOR', actual: 'INT'

==> Context: Bad node spec for node. Name: node_ConstantOfShape_1 OpType: ConstantOfShape
```

Fix a case for bfloat16 when min should be max.