### PR TITLE
Unify rule implementations with classes

### DIFF
--- a/docs/api/rewriter_pattern.md
+++ b/docs/api/rewriter_pattern.md
@@ -32,8 +32,8 @@
     rewriter.pattern.PatternMatcher
     rewriter.pattern.SimplePatternMatcher
     rewriter.pattern.RewriteRule
-    rewriter.pattern.RewriteRuleAsClass
     rewriter.pattern.RewriteRuleSet
+    rewriter.pattern.RewriteRuleClassBase
     rewriter.pattern.MatchStatus
     rewriter.pattern.MatchInfo
     rewriter.pattern.MatchingTracer

--- a/onnxscript/rewriter/llama_rule_sets.py
+++ b/onnxscript/rewriter/llama_rule_sets.py
@@ -190,7 +190,8 @@ class TransposeIdentity(orp.RewriteRuleClassBase):
         if isinstance(perm, ir.RefAttr):
             return check_result.fail("Permutation is a reference attribute.")
         if perm.type == ir.AttributeType.INTS:
-            if perm.as_ints() == list(range(len(perm.as_ints()))):
+            perm_ints = perm.as_ints()
+            if perm_ints == list(range(len(perm_ints))):
                 return check_result
         return check_result.fail("Permutation is not identity.")
 

--- a/onnxscript/rewriter/llama_rule_sets.py
+++ b/onnxscript/rewriter/llama_rule_sets.py
@@ -212,7 +212,7 @@ class TransposeTranspose(orp.RewriteRuleClassBase):
             return check_result.fail("Permutation is a reference attribute.")
         return check_result
 
-    def _apply_transpose(self, perm: Sequence[int, ...], on: list[int]) -> list[int]:
+    def _apply_transpose(self, perm: Sequence[int], on: list[int]) -> list[int]:
         assert len(perm) == len(on), "length mismatch"
         res = [-1 for i in on]
         for i, p in enumerate(perm):

--- a/onnxscript/rewriter/llama_rule_sets.py
+++ b/onnxscript/rewriter/llama_rule_sets.py
@@ -46,7 +46,7 @@ class CastIdentity(orp.RewriteRuleAsClass):
     @classmethod
     def check(cls, context, x, to) -> orp.MatchResult:
         check_result = orp.MatchResult()
-        if x.dtype != to.value:
+        if x.dtype != to.as_int():
             return check_result.fail("Input and output types are not the same")
         return check_result
 
@@ -68,10 +68,10 @@ class CastCast(orp.RewriteRuleAsClass):
     @classmethod
     def check(cls, context, x: ir.Value, to: ir.Attr, to_ignored: ir.Attr) -> orp.MatchResult:
         check_result = orp.MatchResult()
-        if to.value not in cls._allowed_tensor_types:
-            return check_result.fail(f"Output type {to.value} is not allowed")
+        if to.as_int() not in cls._allowed_tensor_types:
+            return check_result.fail(f"Output type {to.as_int()} is not allowed")
         if to_ignored.as_int() not in cls._allowed_tensor_types:
-            return check_result.fail(f"Ignored type {to_ignored.value} is not allowed")
+            return check_result.fail(f"Ignored type {to_ignored.as_int()} is not allowed")
         return check_result
 
     @classmethod
@@ -207,7 +207,7 @@ class TransposeIdentity(orp.RewriteRuleAsClass):
         if isinstance(perm, ir.RefAttr):
             return check_result.fail("Permutation is a reference attribute.")
         if perm.type == ir.AttributeType.INTS:
-            if perm.value == list(range(len(perm.value))):
+            if perm.as_ints() == list(range(len(perm.as_ints()))):
                 return check_result
         return check_result.fail("Permutation is not identity.")
 
@@ -252,8 +252,8 @@ class TransposeTranspose(orp.RewriteRuleAsClass):
 
     @classmethod
     def rewrite(cls, op, x: ir.Value, perm1: ir.Attr, perm2: ir.Attr):
-        first = list(range(len(perm1.value)))
-        last = cls._apply_transposes([perm1.value, perm2.value])
+        first = list(range(len(perm1.as_ints())))
+        last = cls._apply_transposes([perm1.as_ints(), perm2.as_ints()])
         if first == last:
             return op.Identity(x)
         return op.Transpose(x, perm=last)

--- a/onnxscript/rewriter/pattern.py
+++ b/onnxscript/rewriter/pattern.py
@@ -1722,78 +1722,6 @@ class RewriteRule:
         return [replace_pattern(p) for p in self._target_pattern.commute()]
 
 
-class RewriteRuleAsClass:
-    """Defines a class grouping method pattern, rewrite, check.
-    This class is then given to function :func:`make_rewrite_rule_from_class`
-    to define a new rule.
-    """
-
-    @classmethod
-    def pattern(cls, op, *_) -> Any:
-        raise NotImplementedError("Method 'pattern' must be overwritten.")
-
-    @classmethod
-    def rewrite(cls, op, *_) -> Any:
-        raise NotImplementedError("Method 'rewrite' must be overwritten.")
-
-    @classmethod
-    def check(cls, context, *_, **__) -> bool | MatchResult:
-        return MatchResult()
-
-
-def make_rewrite_rule_from_class(
-    rule_class: type | RewriteRuleAsClass, generic: bool = False
-) -> RewriteRule:
-    """Creates a RewriteRule from a class defining the function
-    pattern, rewrite, check with class method. It makes it is easier
-    to read when a module contains multiple patterns.
-
-    Example::
-
-        class TransposeIdentity(RewriteRuleAsClass):
-            @classmethod
-            def pattern(cls, op, x, perm):
-                return op.Transpose(x, perm=perm)
-
-            @classmethod
-            def check(cls, context, x: ir.Value, perm: ir.Attr | ir.RefAttr) -> bool:
-                if isinstance(perm, ir.RefAttr):
-                    return False
-                if perm.type == ir.AttributeType.INTS:
-                    if perm.value == list(range(len(perm.value))):
-                        return True
-                return False
-
-            @classmethod
-            def rewrite(cls, op, x: ir.Value, perm: ir.Attr | None = None):
-                return op.Identity(x)
-
-        transpose_identity_rule = make_rewrite_rule_from_class(TransposeIdentity)
-    """
-    assert hasattr(rule_class, "pattern"), f"Method 'pattern' is missing from {rule_class!r}."
-    assert hasattr(rule_class, "rewrite"), f"Method 'rewrite' is missing from {rule_class!r}."
-    assert hasattr(rule_class, "check"), f"Method 'check' is missing from {rule_class!r}."
-    if generic:
-        import onnxscript.rewriter.generic_pattern as orpp
-
-        return RewriteRule(
-            rule_class.pattern,
-            rule_class.rewrite,
-            rule_class.check,
-            orpp.GenericPatternMatcher,
-            name=rule_class.__name__,  # type: ignore[union-attr]
-        )
-    return RewriteRule(
-        rule_class.pattern,
-        rule_class.rewrite,
-        rule_class.check,
-        name=rule_class.__name__,  # type: ignore[union-attr]
-    )
-
-
-# Variation of RewriteRuleAsClass that is based on instance methods instead of class methods.
-# Useful to implement a family of rules to support pattern variations.
-# TODO: cleanup the naming conventions for these inter-related classes.
 class RewriteRuleClassBase:
     @classmethod
     def rule(cls, *args, **kwargs):
@@ -1819,7 +1747,7 @@ class RewriteRuleClassBase:
     def pattern(self, op, *args, **kwargs):
         raise NotImplementedError("Method 'pattern' must be implemented by derived class.")
 
-    def check(self, op, *args, **kwargs):
+    def check(self, op, *args, **kwargs) -> MatchResult:
         # Default check function that returns a
         # MatchResult object with success always set to True.
         return MatchResult()


### PR DESCRIPTION
- Replace RewriteRuleAsClass with RewriteRuleClassBase to unify rule implementations.
- Also: Use as ints() on attributes in rewrite rules