### PR TITLE
[rewrite] Specify transpose op when TransposeMatMul checks the pattern

### DIFF
--- a/onnxscript/rewriter/ort_fusions/fused_matmul_rule_sets.py
+++ b/onnxscript/rewriter/ort_fusions/fused_matmul_rule_sets.py
@@ -130,7 +130,7 @@ class MatMulTranspose(orp.RewriteRuleClassBase):
         check_result = orp.MatchResult()
         assert x.consumers()
         matmul = x.consumers()[0]
-        assert matmul.outputs()[0].consumers()
+        assert matmul.outputs[0].consumers()
         transpose = matmul.outputs[0].consumers()[0]
         perm = transpose.attributes["perm"].value
         expected_perm = list(range(len(perm)))

--- a/onnxscript/rewriter/ort_fusions/fused_matmul_rule_sets.py
+++ b/onnxscript/rewriter/ort_fusions/fused_matmul_rule_sets.py
@@ -45,7 +45,7 @@ class FusedMatMulDiv2(orp.RewriteRuleClassBase):
     def rewrite(self, op, x, y, cst):
         value = cst.const_value.numpy()
         c = float(value[0] if value.shape == (1,) else value)
-        node = x.consumers()
+        node = x.consumers()[0]
 
         kwargs = {}
         alpha = node.attributes.get("alpha", None)
@@ -77,7 +77,7 @@ class _TransposeMatMulBase(orp.RewriteRuleClassBase):
 
     def rewrite(self, op, x, y):
         the_value = x if self._pos == 1 else y
-        node = the_value.consumers()
+        node = the_value.consumers()[0]
         kwargs = {}
         for name in ["alpha", "transA", "transB", "transBatchA", "transBatchB"]:
             att = node.attributes.get(name)


### PR DESCRIPTION
Found in Whisper that `list((x if self._pos == 1 else y).uses())[0][0]` could be not op.Transpose. This PR specifies transpose node so that it does not crash with keyerror on 'perm'.