### PR TITLE
Remove the RefAttr class

### DIFF
--- a/onnxscript/ir/_convenience/__init__.py
+++ b/onnxscript/ir/_convenience/__init__.py
@@ -32,7 +32,6 @@ SupportedAttrTypes = Union[
     _protocols.TensorProtocol,  # This includes all in-memory tensor types
     onnx.TensorProto,
     _core.Attr,
-    _core.RefAttr,
     _protocols.GraphProtocol,
     Sequence[_protocols.GraphProtocol],
     onnx.GraphProto,
@@ -50,7 +49,7 @@ def _infer_attribute_type(attr: SupportedAttrTypes) -> _enums.AttributeType:
         return _enums.AttributeType.FLOAT
     if isinstance(attr, str):
         return _enums.AttributeType.STRING
-    if isinstance(attr, (_core.Attr, _core.RefAttr)):
+    if isinstance(attr, _core.Attr):
         return attr.type
     if isinstance(attr, Sequence) and all(isinstance(x, int) for x in attr):
         return _enums.AttributeType.INTS
@@ -97,7 +96,7 @@ def convert_attribute(
     name: str,
     attr: SupportedAttrTypes,
     attr_type: _enums.AttributeType | None = None,
-) -> _core.Attr | _core.RefAttr:
+) -> _core.Attr:
     """Convert a Python object to a _core.Attr object.
 
     This method is useful when constructing nodes with attributes. It infers the
@@ -121,7 +120,7 @@ def convert_attribute(
             raise ValueError("attr_type must be provided when attr is None")
         return _core.Attr(name, attr_type, None)
 
-    if isinstance(attr, (_core.Attr, _core.RefAttr)):
+    if isinstance(attr, _core.Attr):
         if attr.name != name:
             raise ValueError(
                 f"Attribute name '{attr.name}' does not match provided name '{name}'"
@@ -181,7 +180,7 @@ def convert_attribute(
 
 def convert_attributes(
     attrs: Mapping[str, SupportedAttrTypes],
-) -> list[_core.Attr | _core.RefAttr]:
+) -> list[_core.Attr]:
     """Convert a dictionary of attributes to a list of _core.Attr objects.
 
     It infers the attribute type based on the type of the value. The supported
@@ -247,7 +246,7 @@ def convert_attributes(
     Returns:
         A list of _core.Attr objects.
     """
-    attributes: list[_core.Attr | _core.RefAttr] = []
+    attributes: list[_core.Attr] = []
     for name, attr in attrs.items():
         if attr is not None:
             attributes.append(convert_attribute(name, attr))

--- a/onnxscript/ir/_convenience/_constructors.py
+++ b/onnxscript/ir/_convenience/_constructors.py
@@ -194,7 +194,7 @@ def node(
         A node with the given op_type and inputs.
     """
     if attributes is None:
-        attrs: Sequence[ir.Attr | ir.RefAttr] = ()
+        attrs: Sequence[ir.Attr] = ()
     else:
         attrs = _convenience.convert_attributes(attributes)
     return _core.Node(

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -3106,7 +3106,11 @@ def {full_name}(
         return f"{self.__class__.__name__}({self.domain!r}, {self.name!r}, {self.overload!r}, inputs={self.inputs!r}, attributes={self.attributes!r}), outputs={self.outputs!r})"
 
 
-class Attr(_protocols.AttributeProtocol, _protocols.ReferenceAttributeProtocol, _display.PrettyPrintable):
+class Attr(
+    _protocols.AttributeProtocol,
+    _protocols.ReferenceAttributeProtocol,
+    _display.PrettyPrintable,
+):
     """Base class for ONNX attributes or references."""
 
     __slots__ = ("_name", "_ref_attr_name", "_type", "_value", "doc_string")

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -3134,6 +3134,10 @@ class Attr(
     def name(self) -> str:
         return self._name
 
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
+
     @property
     def type(self) -> _enums.AttributeType:
         return self._type

--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1321,7 +1321,7 @@ class Node(_protocols.NodeProtocol, _display.PrettyPrintable):
         domain: str,
         op_type: str,
         inputs: Iterable[Value | None],
-        attributes: Iterable[Attr | RefAttr] = (),
+        attributes: Iterable[Attr] = (),
         *,
         overload: str = "",
         num_outputs: int | None = None,
@@ -1353,7 +1353,7 @@ class Node(_protocols.NodeProtocol, _display.PrettyPrintable):
             metadata_props: The metadata properties.
 
         Raises:
-            TypeError: If the attributes are not :class:`Attr` or :class:`RefAttr`.
+            TypeError: If the attributes are not :class:`Attr`.
             ValueError: If ``num_outputs``, when not ``None``, is not the same as the length of the outputs.
             ValueError: If an output value is ``None``, when outputs is specified.
             ValueError: If an output value has a producer set already, when outputs is specified.
@@ -1368,13 +1368,13 @@ class Node(_protocols.NodeProtocol, _display.PrettyPrintable):
         # Values belong to their defining nodes. The values list is immutable
         self._outputs: tuple[Value, ...] = self._create_outputs(num_outputs, outputs)
         attributes = tuple(attributes)
-        if attributes and not isinstance(attributes[0], (Attr, RefAttr)):
+        if attributes and not isinstance(attributes[0], Attr):
             raise TypeError(
-                f"Expected the attributes to be Attr or RefAttr, got {type(attributes[0])}. "
+                f"Expected the attributes to be Attr, got {type(attributes[0])}. "
                 "If you are copying the attributes from another node, make sure you call "
                 "node.attributes.values() because it is a dictionary."
             )
-        self._attributes: OrderedDict[str, Attr | RefAttr] = OrderedDict(
+        self._attributes: OrderedDict[str, Attr] = OrderedDict(
             (attr.name, attr) for attr in attributes
         )
         self._overload: str = overload
@@ -1633,7 +1633,7 @@ class Node(_protocols.NodeProtocol, _display.PrettyPrintable):
         raise AttributeError("outputs is immutable. Please create a new node instead.")
 
     @property
-    def attributes(self) -> OrderedDict[str, Attr | RefAttr]:
+    def attributes(self) -> OrderedDict[str, Attr]:
         """The attributes of the node."""
         return self._attributes
 
@@ -3106,69 +3106,45 @@ def {full_name}(
         return f"{self.__class__.__name__}({self.domain!r}, {self.name!r}, {self.overload!r}, inputs={self.inputs!r}, attributes={self.attributes!r}), outputs={self.outputs!r})"
 
 
-class RefAttr(_protocols.ReferenceAttributeProtocol, _display.PrettyPrintable):
-    """Reference attribute."""
+class Attr(_protocols.AttributeProtocol, _protocols.ReferenceAttributeProtocol, _display.PrettyPrintable):
+    """Base class for ONNX attributes or references."""
 
-    __slots__ = ("_name", "_ref_attr_name", "_type", "doc_string")
-
-    def __init__(
-        self,
-        name: str,
-        ref_attr_name: str,
-        type: _enums.AttributeType,
-        *,
-        doc_string: str | None = None,
-    ) -> None:
-        self._name = name
-        self._ref_attr_name = ref_attr_name
-        self._type = type
-        self.doc_string = doc_string
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    @name.setter
-    def name(self, value: str) -> None:
-        self._name = value
-
-    @property
-    def ref_attr_name(self) -> str:
-        return self._ref_attr_name
-
-    @ref_attr_name.setter
-    def ref_attr_name(self, value: str) -> None:
-        self._ref_attr_name = value
-
-    @property
-    def type(self) -> _enums.AttributeType:
-        return self._type
-
-    @type.setter
-    def type(self, value: _enums.AttributeType) -> None:
-        self._type = value
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self._name!r}, {self._type!r}, ref_attr_name={self.ref_attr_name!r})"
-
-
-class Attr(_protocols.AttributeProtocol, _display.PrettyPrintable):
-    """Base class for ONNX attributes."""
-
-    __slots__ = ("doc_string", "name", "type", "value")
+    __slots__ = ("_name", "_ref_attr_name", "_type", "_value", "doc_string")
 
     def __init__(
         self,
         name: str,
         type: _enums.AttributeType,
         value: Any,
+        ref_attr_name: str | None = None,
         *,
         doc_string: str | None = None,
     ):
-        self.name = name
-        self.type = type
-        self.value = value
+        self._name = name
+        self._type = type
+        self._value = value
+        self._ref_attr_name = ref_attr_name
         self.doc_string = doc_string
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def type(self) -> _enums.AttributeType:
+        return self._type
+
+    @property
+    def value(self) -> Any:
+        return self._value
+
+    @property
+    def ref_attr_name(self) -> str | None:
+        return self._ref_attr_name
+
+    def is_ref(self) -> bool:
+        """Check if this attribute is a reference attribute."""
+        return self.ref_attr_name is not None
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, _protocols.AttributeProtocol):
@@ -3185,11 +3161,15 @@ class Attr(_protocols.AttributeProtocol, _display.PrettyPrintable):
         return True
 
     def __str__(self) -> str:
+        if self.is_ref():
+            return f"@{self.ref_attr_name}"
         if self.type == _enums.AttributeType.GRAPH:
             return textwrap.indent("\n" + str(self.value), " " * 4)
         return str(self.value)
 
     def __repr__(self) -> str:
+        if self.is_ref():
+            return f"{self.__class__.__name__}({self.name!r}, {self.type!r}, ref_attr_name={self.ref_attr_name!r})"
         return f"{self.__class__.__name__}({self.name!r}, {self.type!r}, {self.value!r})"
 
     # Well typed getters
@@ -3269,6 +3249,29 @@ class Attr(_protocols.AttributeProtocol, _display.PrettyPrintable):
 
 
 # NOTE: The following functions are just for convenience
+
+
+def RefAttr(
+    name: str,
+    ref_attr_name: str,
+    type: _enums.AttributeType,
+    doc_string: str | None = None,
+) -> Attr:
+    """Create a reference attribute.
+
+    Args:
+        name: The name of the attribute.
+        type: The type of the attribute.
+        ref_attr_name: The name of the referenced attribute.
+        doc_string: Documentation string.
+
+    Returns:
+        A reference attribute.
+    """
+    # NOTE: The function name is capitalized to maintain API backward compatibility.
+    return Attr(name, type, None, ref_attr_name=ref_attr_name, doc_string=doc_string)
+
+
 def AttrFloat32(name: str, value: float, doc_string: str | None = None) -> Attr:
     """Create a float attribute."""
     # NOTE: The function name is capitalized to maintain API backward compatibility.

--- a/onnxscript/ir/_protocols.py
+++ b/onnxscript/ir/_protocols.py
@@ -36,6 +36,7 @@ from typing import (
     Collection,
     Iterable,
     Iterator,
+    Literal,
     Mapping,
     MutableMapping,
     MutableSequence,
@@ -422,6 +423,9 @@ class AttributeProtocol(Protocol):
     value: Any
     doc_string: str | None
 
+    def is_ref(self) -> Literal[False]:
+        ...
+
 
 @typing.runtime_checkable
 class ReferenceAttributeProtocol(Protocol):
@@ -440,6 +444,9 @@ class ReferenceAttributeProtocol(Protocol):
     ref_attr_name: str
     type: _enums.AttributeType
     doc_string: str | None
+
+    def is_ref(self) -> Literal[True]:
+        ...
 
 
 @typing.runtime_checkable

--- a/onnxscript/ir/_protocols.py
+++ b/onnxscript/ir/_protocols.py
@@ -423,8 +423,7 @@ class AttributeProtocol(Protocol):
     value: Any
     doc_string: str | None
 
-    def is_ref(self) -> Literal[False]:
-        ...
+    def is_ref(self) -> Literal[False]: ...
 
 
 @typing.runtime_checkable
@@ -445,8 +444,7 @@ class ReferenceAttributeProtocol(Protocol):
     type: _enums.AttributeType
     doc_string: str | None
 
-    def is_ref(self) -> Literal[True]:
-        ...
+    def is_ref(self) -> Literal[True]: ...
 
 
 @typing.runtime_checkable

--- a/onnxscript/ir/_tape.py
+++ b/onnxscript/ir/_tape.py
@@ -89,7 +89,7 @@ class Tape:
         output: ir.Value | None = None,
     ) -> ir.Value:
         if attributes is None:
-            attrs: Sequence[ir.Attr | ir.RefAttr] = ()
+            attrs: Sequence[ir.Attr] = ()
         else:
             attrs = _convenience.convert_attributes(attributes)
         output_kwargs: dict[str, Any]
@@ -141,7 +141,7 @@ class Tape:
         else:
             output_kwargs = dict(outputs=outputs)
         if attributes is None:
-            attrs: Sequence[ir.Attr | ir.RefAttr] = ()
+            attrs: Sequence[ir.Attr] = ()
         else:
             attrs = _convenience.convert_attributes(attributes)
         node = ir.Node(

--- a/onnxscript/ir/external_data.py
+++ b/onnxscript/ir/external_data.py
@@ -70,7 +70,7 @@ def _all_tensors(
     # Look at constant attributes in nodes
     for node in _traversal.RecursiveGraphIterator(graph):
         for attr in node.attributes.values():
-            if isinstance(attr, _core.RefAttr):
+            if attr.is_ref():
                 continue
             if attr.type == _enums.AttributeType.TENSOR and attr.value is not None:
                 yield attr.value

--- a/onnxscript/ir/serde.py
+++ b/onnxscript/ir/serde.py
@@ -234,9 +234,10 @@ def to_proto(ir_object: object) -> object:
         return serialize_tensor(ir_object)
     if isinstance(ir_object, _protocols.ValueProtocol):
         return serialize_value(ir_object)
-    if isinstance(ir_object, _protocols.AttributeProtocol):
+    if isinstance(ir_object, _protocols.AttributeProtocol) and not ir_object.is_ref():
         return serialize_attribute(ir_object)
     if isinstance(ir_object, _protocols.ReferenceAttributeProtocol):
+        assert ir_object.is_ref()
         return serialize_reference_attribute_into(onnx.AttributeProto(), ir_object)
     if isinstance(ir_object, _protocols.TypeProtocol):
         return serialize_type_into(onnx.TypeProto(), ir_object)

--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -1059,7 +1059,7 @@ class FoldConstantsPass(ir.passes.InPlacePass):
         # TODO: what about new opset_imports?
         # TODO: track statistics about replaced nodes and sizes of new constants
 
-    def visit_attribute(self, attr: ir.Attr | ir.RefAttr) -> None:
+    def visit_attribute(self, attr: ir.Attr) -> None:
         if isinstance(attr, ir.Attr):
             if attr.type == ir.AttributeType.GRAPH:
                 self.visit_graph(attr.as_graph())

--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -1060,12 +1060,13 @@ class FoldConstantsPass(ir.passes.InPlacePass):
         # TODO: track statistics about replaced nodes and sizes of new constants
 
     def visit_attribute(self, attr: ir.Attr) -> None:
-        if isinstance(attr, ir.Attr):
-            if attr.type == ir.AttributeType.GRAPH:
-                self.visit_graph(attr.as_graph())
-            elif attr.type == ir.AttributeType.GRAPHS:
-                for graph in attr.as_graphs():
-                    self.visit_graph(graph)
+        if attr.is_ref():
+            return
+        if attr.type == ir.AttributeType.GRAPH:
+            self.visit_graph(attr.as_graph())
+        elif attr.type == ir.AttributeType.GRAPHS:
+            for graph in attr.as_graphs():
+                self.visit_graph(graph)
 
     def visit_node(self, node: ir.Node, root: ir.Graph | ir.Function) -> None:
         replacement = self.process_node(node)

--- a/onnxscript/rewriter/_pattern_ir.py
+++ b/onnxscript/rewriter/_pattern_ir.py
@@ -73,7 +73,7 @@ class PrefixPattern(StringPattern):
         return f"{self._value}*"
 
 
-class AttrPattern(Pattern[Union[ir.Attr, ir.RefAttr]]):
+class AttrPattern(Pattern[ir.Attr]):
     """Base class for an attribute pattern. Matches any attribute value by default."""
 
     def __init__(self, name: str | None):
@@ -83,7 +83,7 @@ class AttrPattern(Pattern[Union[ir.Attr, ir.RefAttr]]):
     def name(self) -> str | None:
         return self._name
 
-    def matches(self, attr: ir.Attr | ir.RefAttr) -> bool:
+    def matches(self, attr: ir.Attr) -> bool:
         return True
 
     def __str__(self) -> str:
@@ -112,7 +112,7 @@ class AttrConstantPattern(AttrPattern):
         super().__init__(None)
         self._value = value
 
-    def matches(self, attr: ir.Attr | ir.RefAttr) -> bool:
+    def matches(self, attr: ir.Attr) -> bool:
         return isinstance(attr, ir.Attr) and attr.value == self._value
 
     def __str__(self) -> str:

--- a/onnxscript/rewriter/_rewrite_rule.py
+++ b/onnxscript/rewriter/_rewrite_rule.py
@@ -261,8 +261,8 @@ class RewriteRuleClassBase(abc.ABC):
             def pattern(cls, op, x, perm):
                 return op.Transpose(x, perm=perm)
 
-            def check(cls, context, x: ir.Value, perm: ir.Attr | ir.RefAttr) -> bool:
-                if isinstance(perm, ir.RefAttr):
+            def check(cls, context, x: ir.Value, perm: ir.Attr) -> bool:
+                if perm.is_ref():
                     return False
                 if perm.type == ir.AttributeType.INTS:
                     if perm.as_ints() == list(range(len(perm.as_ints()))):
@@ -364,8 +364,8 @@ def _copy_for_function(
             raise ValueError(f"Value {value} not found in value_map.")
         return value_map[value]
 
-    def copy_attr_value(attr: ir.Attr | ir.RefAttr) -> ir.Attr | ir.RefAttr:
-        if not isinstance(attr, ir.Attr):
+    def copy_attr_value(attr: ir.Attr) -> ir.Attr:
+        if attr.is_ref():
             # No need to support this currently, as rewriting inside a function is
             # not used, as it has several challenges.
             raise NotImplementedError("RefAttr not supported.")

--- a/onnxscript/rewriter/llama_rule_sets.py
+++ b/onnxscript/rewriter/llama_rule_sets.py
@@ -187,7 +187,7 @@ class TransposeIdentity(orp.RewriteRuleClassBase):
 
     def check(self, context, x: ir.Value, perm: ir.Attr) -> orp.MatchResult:
         check_result = orp.MatchResult()
-        if isinstance(perm, ir.RefAttr):
+        if perm.is_ref():
             return check_result.fail("Permutation is a reference attribute.")
         if perm.type == ir.AttributeType.INTS:
             perm_ints = perm.as_ints()
@@ -209,7 +209,7 @@ class TransposeTranspose(orp.RewriteRuleClassBase):
 
     def check(self, context, x: ir.Value, perm1: ir.Attr, perm2: ir.Attr) -> orp.MatchResult:
         check_result = orp.MatchResult()
-        if isinstance(perm1, ir.RefAttr) or isinstance(perm2, ir.RefAttr):
+        if perm1.is_ref() or perm2.is_ref():
             return check_result.fail("Permutation is a reference attribute.")
         return check_result
 

--- a/onnxscript/version_converter/_version_converter.py
+++ b/onnxscript/version_converter/_version_converter.py
@@ -265,10 +265,10 @@ class _VersionConverter:
         if attr.is_ref():
             return
         if attr.type == ir.AttributeType.GRAPH:
-            self.visit_graph(attr.value)  # type: ignore[arg-type]
+            self.visit_graph(attr.as_graph())
         elif attr.type == ir.AttributeType.GRAPHS:
-            for graph in attr.value:
-                self.visit_graph(graph)  # type: ignore[arg-type]
+            for graph in attr.as_graphs():
+                self.visit_graph(graph)
 
     def visit_node(
         self,

--- a/onnxscript/version_converter/_version_converter.py
+++ b/onnxscript/version_converter/_version_converter.py
@@ -261,7 +261,7 @@ class _VersionConverter:
             root, node, [node], replacement.new_nodes, node.outputs, replacement.new_outputs
         )
 
-    def visit_attribute(self, attr: ir.Attr | ir.RefAttr) -> None:
+    def visit_attribute(self, attr: ir.Attr) -> None:
         if isinstance(attr, ir.Attr):
             if attr.type == ir.AttributeType.GRAPH:
                 self.visit_graph(attr.value)  # type: ignore[arg-type]

--- a/onnxscript/version_converter/_version_converter.py
+++ b/onnxscript/version_converter/_version_converter.py
@@ -262,12 +262,13 @@ class _VersionConverter:
         )
 
     def visit_attribute(self, attr: ir.Attr) -> None:
-        if isinstance(attr, ir.Attr):
-            if attr.type == ir.AttributeType.GRAPH:
-                self.visit_graph(attr.value)  # type: ignore[arg-type]
-            elif attr.type == ir.AttributeType.GRAPHS:
-                for graph in attr.value:
-                    self.visit_graph(graph)  # type: ignore[arg-type]
+        if attr.is_ref():
+            return
+        if attr.type == ir.AttributeType.GRAPH:
+            self.visit_graph(attr.value)  # type: ignore[arg-type]
+        elif attr.type == ir.AttributeType.GRAPHS:
+            for graph in attr.value:
+                self.visit_graph(graph)  # type: ignore[arg-type]
 
     def visit_node(
         self,


### PR DESCRIPTION
## Rational

We defined the class `RefAttr` in the IR to represent reference attributes in ONNX. Node attributes can be `Attr` and `RefAttr`. However, since most of the time we are working with concrete attributes, the union of types creates a typing situation where we always need to assert the types before taking the values, even if we know a `RefAttr` cannot exist (outside of a function definition). 

This additionally matches the definition of AttributeProto in ONNX.

## Change

This change merged the two classes, and instead defines a `is_ref()` method for users to check the reference attribute.

The change is BC breaking for usage like `isinstance(attr, ir.RefAttr)`. Fortunately all such usages exist in this code base and not in PyTorch, so we are safe to complete the change.