### PR TITLE
Fix handling of attention-bias in MHA fusion

### DIFF
--- a/onnxscript/rewriter/ort_fusions/fused_matmul_rule_sets.py
+++ b/onnxscript/rewriter/ort_fusions/fused_matmul_rule_sets.py
@@ -32,7 +32,7 @@ class FusedMatMulDiv2(orp.RewriteRuleClassBase):
     """Replaces ``FusedMatMul + Div`` by FusedMatMul."""
 
     def pattern(self, op, x, y, cst):
-        return op.Div(op.FusedMatMul(x, y, _domain="com.microsoft", _output=["fused"]), cst)
+        return op.Div(op.FusedMatMul(x, y, _domain="com.microsoft"), cst)
 
     def check(self, context, x, y, cst) -> orp.MatchResult:
         check_result = orp.MatchResult()
@@ -42,10 +42,10 @@ class FusedMatMulDiv2(orp.RewriteRuleClassBase):
             return check_result.fail("Divisor is not a scalar value.")
         return check_result
 
-    def rewrite(self, op, x, y, cst, fused):
+    def rewrite(self, op, x, y, cst):
         value = cst.const_value.numpy()
         c = float(value[0] if value.shape == (1,) else value)
-        node = list(x.uses())[0][0]  # noqa: RUF015 # fused.producer()
+        node = list(x.uses())[0][0]  # noqa: RUF015
 
         kwargs = {}
         alpha = node.attributes.get("alpha", None)

--- a/onnxscript/rewriter/ort_fusions/fused_matmul_rule_sets.py
+++ b/onnxscript/rewriter/ort_fusions/fused_matmul_rule_sets.py
@@ -32,7 +32,7 @@ class FusedMatMulDiv2(orp.RewriteRuleClassBase):
     """Replaces ``FusedMatMul + Div`` by FusedMatMul."""
 
     def pattern(self, op, x, y, cst):
-        return op.Div(op.FusedMatMul(x, y, _domain="com.microsoft"), cst)
+        return op.Div(op.FusedMatMul(x, y, _domain="com.microsoft", _output=["fused"]), cst)
 
     def check(self, context, x, y, cst) -> orp.MatchResult:
         check_result = orp.MatchResult()
@@ -42,10 +42,10 @@ class FusedMatMulDiv2(orp.RewriteRuleClassBase):
             return check_result.fail("Divisor is not a scalar value.")
         return check_result
 
-    def rewrite(self, op, x, y, cst):
+    def rewrite(self, op, x, y, cst, fused):
         value = cst.const_value.numpy()
         c = float(value[0] if value.shape == (1,) else value)
-        node = list(x.uses())[0][0]  # noqa: RUF015
+        node = list(x.uses())[0][0]  # noqa: RUF015 # fused.producer()
 
         kwargs = {}
         alpha = node.attributes.get("alpha", None)

--- a/onnxscript/rewriter/ort_fusions/mha.py
+++ b/onnxscript/rewriter/ort_fusions/mha.py
@@ -265,8 +265,23 @@ class MultiHeadAttention(pattern.RewriteRuleClassBase):
                         past_value,
                     )
 
-        # TODO: mask shape check: ideally, it should be (1 or B, 1 or H, S, St)
-        # But this also, unforunately, depends on ORT version.
+        # mask (aka attention_bias) shape check:
+        # ONNX's Attention op (named SDPA here) allows a mask broadcastable to (B, H, S, St)
+        # ORT's contrib ops (MHA, Attention) allow a mask of shape (1 or B, 1 or H, S, St)
+        # That is: broadcast allowed only for the first two dimensions. (Even that is not
+        # supported by some earlier versions of ORT, which are not supported here.)
+        if self._use_mask:
+            if no_match(mask, ["B_or_1", "H_or_1", "S_or_1", "St"]):
+                return check_result.fail(
+                    f"Shape mismatch: {mask} does not match expected dimensions ['1 or B', '1 or H', 'S', 'St']",
+                    mask,
+                )
+            mask_dim_2 = bindings.get("S_or_1")
+            self._use_mask_broadcast = (mask_dim_2 == 1)
+        else:
+            # If mask is not used, we can skip the check
+            self._use_mask_broadcast = False
+
 
         # TODO: verify Reshapes:
         # eg.: verify bindings["B"] * bindings["H"] == bindings["B*H"]:
@@ -314,6 +329,9 @@ class MultiHeadAttention(pattern.RewriteRuleClassBase):
         else:
             query_BSD_emb = query_BSD
             key_BSD_emb = key
+
+    if self._use_mask_broadcast:
+        mask = # ...
 
         num_outputs = 1 + (2 * self._has_past_present)
         return op.MultiHeadAttention(


### PR DESCRIPTION
In models generated from pytorch, masks may have shapes that are broadcastable to (B, H, S, St): eg., a 2D mask of shape (S, St) or even shape (1, 1, 1, St) in one example.

ONNX's opset23 Attention op allows masks of this shape. However, ORT's contrib ops (MHA, Attention) allow a mask of shape (1 or B, 1 or H, S, St). That is: they support broadcast only for the first two dimensions. (Even that is not supported by some earlier versions of ORT, which we don't consider here.)

So, while doing fusion for MHA, we should expand the mask to ensure it satisfies the constraints of MHA/Attention.