### PR TITLE
[torchlib] Fix pow.Tensor_Scalar type promotion

### DIFF
--- a/onnxscript/ir/_core.py
+++ b/onnxscript/ir/_core.py
@@ -1266,7 +1266,7 @@ class Usage(NamedTuple):
     idx: int
 
 
-def _short_tensor_str_for_node(x: Value) -> str:
+def _short_tensor_str(x: Value) -> str:
     if x.const_value is None:
         return ""
     if x.const_value.size <= 10:
@@ -1451,7 +1451,7 @@ class Node(_protocols.NodeProtocol, _display.PrettyPrintable):
             + ", ".join(
                 [
                     (
-                        f"%{_quoted(x.name) if x.name else 'anonymous:' + str(id(x))}{_short_tensor_str_for_node(x)}"
+                        f"%{_quoted(x.name) if x.name else 'anonymous:' + str(id(x))}{_short_tensor_str(x)}"
                         if x is not None
                         else "None"
                     )
@@ -1898,9 +1898,7 @@ class Value(_protocols.ValueProtocol, _display.PrettyPrintable):
 
         # Quote the name because in reality the names can have invalid characters
         # that make them hard to read
-        return (
-            f"%{_quoted(value_name)}<{type_text},{shape_text}>{self._constant_tensor_part()}"
-        )
+        return f"%{_quoted(value_name)}<{type_text},{shape_text}>{_short_tensor_str(self)}"
 
     def _constant_tensor_part(self) -> str:
         """Display string for the constant tensor attached to str of Value."""

--- a/onnxscript/ir/_enums.py
+++ b/onnxscript/ir/_enums.py
@@ -142,6 +142,20 @@ class DataType(enum.IntEnum):
             raise TypeError(f"Short name not available for ONNX data type: {self}")
         return _DATA_TYPE_TO_SHORT_NAME[self]
 
+    def is_floating_point(self) -> bool:
+        """Returns True if the data type is a floating point type."""
+        return self in {
+            DataType.FLOAT,
+            DataType.FLOAT16,
+            DataType.DOUBLE,
+            DataType.BFLOAT16,
+            DataType.FLOAT8E4M3FN,
+            DataType.FLOAT8E4M3FNUZ,
+            DataType.FLOAT8E5M2,
+            DataType.FLOAT8E5M2FNUZ,
+            DataType.FLOAT4E2M1,
+        }
+
     def __repr__(self) -> str:
         return self.name
 

--- a/tests/function_libs/torch_lib/e2e_ops_tests.py
+++ b/tests/function_libs/torch_lib/e2e_ops_tests.py
@@ -5,13 +5,11 @@
 
 import unittest
 
-import onnxruntime
 import torch
+from torch.onnx._internal.exporter import _testing
 
-from tests.common import testutils
 
-
-class TorchLibe2eTest(testutils.TestBase):
+class TorchLibe2eTest(unittest.TestCase):
     def test_investigate_one_particular_model(self):
         """This test can be used to investigate a particular issue."""
         red, include, stype = "amin", False, "int32"
@@ -35,19 +33,48 @@ class TorchLibe2eTest(testutils.TestBase):
             torch.tensor([[0, 0, 0], [1, 1, 1]], dtype=torch.int64),
             torch.tensor([[-1, -1, -1], [-1, -1, -1]], dtype=dtype),
         )
-        expected = model(*xs)
-        model_path = (
-            f"test_aten_scatter_{red}_{'include' if include else 'exclude'}_{stype}.onnx"
-        )
-        torch.onnx.export(model, xs, model_path, dynamo=True)
-        feeds = dict(zip(["x", "indices", "updates"], [x.numpy() for x in xs]))
+        onnx_program = torch.onnx.export(model, xs, dynamo=True)
+        _testing.assert_onnx_program(onnx_program)
 
-        sess_options = onnxruntime.SessionOptions()
-        sess = onnxruntime.InferenceSession(
-            model_path, sess_options=sess_options, providers=["CPUExecutionProvider"]
+    def test_pow_scalar_int_float(self):
+        class PowModel(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x**0.5
+
+        onnx_program = torch.onnx.export(
+            PowModel(), (torch.tensor(2),), dynamo=True, optimize=False
         )
-        got = sess.run(None, feeds)[0]
-        torch.testing.assert_close(expected, torch.from_numpy(got), atol=1e-5, rtol=1e-5)
+        _testing.assert_onnx_program(onnx_program)
+
+    def test_pow_scalar_int_int(self):
+        class PowModel(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x**2
+
+        onnx_program = torch.onnx.export(
+            PowModel(), (torch.tensor(2),), dynamo=True, optimize=False
+        )
+        _testing.assert_onnx_program(onnx_program)
+
+    def test_pow_scalar_float16_int(self):
+        class PowModel(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x**2
+
+        onnx_program = torch.onnx.export(
+            PowModel(), (torch.tensor(0.5, dtype=torch.float16),), dynamo=True, optimize=False
+        )
+        _testing.assert_onnx_program(onnx_program)
+
+    def test_pow_scalar_float16_float(self):
+        class PowModel(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x**0.5
+
+        onnx_program = torch.onnx.export(
+            PowModel(), (torch.tensor(0.5, dtype=torch.float16),), dynamo=True, optimize=False
+        )
+        _testing.assert_onnx_program(onnx_program)
 
 
 if __name__ == "__main__":

--- a/tests/function_libs/torch_lib/e2e_ops_tests.py
+++ b/tests/function_libs/torch_lib/e2e_ops_tests.py
@@ -36,7 +36,7 @@ class TorchLibe2eTest(unittest.TestCase):
         onnx_program = torch.onnx.export(model, xs, dynamo=True)
         _testing.assert_onnx_program(onnx_program)
 
-    def test_pow_scalar_int_float(self):
+    def test_pow_tensor_scalar_int_float(self):
         class PowModel(torch.nn.Module):
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 return x**0.5
@@ -46,7 +46,7 @@ class TorchLibe2eTest(unittest.TestCase):
         )
         _testing.assert_onnx_program(onnx_program)
 
-    def test_pow_scalar_int_int(self):
+    def test_pow_tensor_scalar_int_int(self):
         class PowModel(torch.nn.Module):
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 return x**2
@@ -56,7 +56,7 @@ class TorchLibe2eTest(unittest.TestCase):
         )
         _testing.assert_onnx_program(onnx_program)
 
-    def test_pow_scalar_float16_int(self):
+    def test_pow_tensor_scalar_float16_int(self):
         class PowModel(torch.nn.Module):
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 return x**2
@@ -66,7 +66,7 @@ class TorchLibe2eTest(unittest.TestCase):
         )
         _testing.assert_onnx_program(onnx_program)
 
-    def test_pow_scalar_float16_float(self):
+    def test_pow_tensor_scalar_float16_float(self):
         class PowModel(torch.nn.Module):
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 return x**0.5


### PR DESCRIPTION
Fix pow.Tensor_Scalar type promotion by accounting different combination of input dtypes. This change ensures the inputs to Pow is always the same type for compatibility with downstream tools.