### PR TITLE
Refine shape optimization

### DIFF
--- a/onnxscript/rewriter/_ir_utils.py
+++ b/onnxscript/rewriter/_ir_utils.py
@@ -68,7 +68,7 @@ def get_numpy_value(val: ir.Value | None) -> np.ndarray | None:
     """
     if val is None:
         return None
-    const_value = val.const_value
+    const_value = get_const_value(val)
     if const_value is not None:
         try:
             return const_value.numpy()

--- a/onnxscript/rewriter/ort_fusions/_core.py
+++ b/onnxscript/rewriter/ort_fusions/_core.py
@@ -53,6 +53,7 @@ def _pre_optimize(model: ir.Model) -> ir.Model:
     shape_inference.infer_shapes(model)
     optimize(model)
     shape_optimization.rules.apply_to_model(model)
+    optimize(model)
     return model
 
 

--- a/onnxscript/rewriter/ort_fusions/shape_optimization.py
+++ b/onnxscript/rewriter/ort_fusions/shape_optimization.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import onnxscript.ir as ir
+import onnxscript.rewriter._ir_utils as _ir_utils
 import onnxscript.rewriter.pattern as pattern
 
 
@@ -17,15 +18,15 @@ class ExtractDim(pattern.RewriteRuleClassBase):
     It can be simplified away.
     """
 
-    def pattern(self, op, x, dim0, dim1, dim2, dim3):
+    def pattern(self, op, x, dim0, dim1, dim2, dim3, start, end):
         shape = op.Concat(dim0, dim1, dim2, dim3, axis=0)
         reshaped = op.Reshape(x, shape, allowzero=0)
         transposed = op.Transpose(reshaped, perm=[0, 2, 1, 3])
         final_shape = op.Shape(transposed, _outputs=["final_shape"], start=0)
-        final_dim = op.Slice(final_shape, [-2], [-1])
+        final_dim = op.Slice(final_shape, start, end)
         return final_dim
 
-    def check(self, context, dim0, dim1, dim2, dim3, final_shape, **_) -> bool:
+    def check(self, context, dim0, dim1, dim2, dim3, final_shape, start, end, **_) -> bool:
         # All of the dimensions should have shape [1]
         for dim in (dim0, dim1, dim2, dim3):
             if dim.shape is None or dim.shape.dims != (1,):
@@ -37,11 +38,22 @@ class ExtractDim(pattern.RewriteRuleClassBase):
             return False
         if "start" in shape_node.attributes:
             start_attr = shape_node.attributes["start"]
-            return isinstance(start_attr, ir.Attr) and start_attr.value == 0
+            if not (isinstance(start_attr, ir.Attr) and start_attr.value == 0):
+                return False
+        self._start_val = _ir_utils.get_singleton_value(start)
+        self._end_val = _ir_utils.get_singleton_value(end)
+        if self._start_val is None or self._end_val is None:
+            return False
         return True
 
-    def rewrite(self, op, dim1, **_):
-        return dim1
+    def rewrite(self, op, dim0, dim1, dim2, dim3, **_):
+        transposed_dims = [dim0, dim2, dim1, dim3]
+        sliced_result = transposed_dims[self._start_val : self._end_val]
+        if len(sliced_result) == 1:
+            return sliced_result[0]
+        if len(sliced_result) == 0:
+            return False
+        return op.Concat(*sliced_result, axis=0)
 
 
 rules = pattern.RewriteRuleSet([ExtractDim.rule()])


### PR DESCRIPTION
Refine the recently introduced shape optimization: more patterns showed up in the openai whisper model, extracting different slices of the concatenated shape.

The optimization improves MHA fusions (which are other handicapped by the reuse of some intermediate values that prevent fusion).