### PR TITLE
Create value_infos in subgraphs

### DIFF
--- a/onnxscript/ir/serde.py
+++ b/onnxscript/ir/serde.py
@@ -1332,9 +1332,8 @@ def serialize_graph_into(
     for node in from_:
         serialize_node_into(graph_proto.node.add(), from_=node)
         for node_input in node.inputs:
-            if (
-                node_input not in value_info_added
-                and _should_create_value_info_for_value(node_input)
+            if node_input not in value_info_added and _should_create_value_info_for_value(
+                node_input
             ):
                 # NOTE:
                 # If the input is from an outer graph, we add its information in the subgraph as well

--- a/onnxscript/ir/serde.py
+++ b/onnxscript/ir/serde.py
@@ -1332,8 +1332,10 @@ def serialize_graph_into(
     for node in from_:
         serialize_node_into(graph_proto.node.add(), from_=node)
         for node_input in node.inputs:
-            if node_input not in value_info_added and _should_create_value_info_for_value(
-                node_input
+            if (
+                node_input is not None
+                and node_input not in value_info_added
+                and _should_create_value_info_for_value(node_input)
             ):
                 # NOTE:
                 # If the input is from an outer graph, we add its information in the subgraph as well


### PR DESCRIPTION
This is useful when the subgraph refers to values in the main graph. By storing a copy of the value info in the subgraph, downstream tools have access to the value information of all values used in the subgraph directly inside it.

## Note

This is due to https://github.com/microsoft/onnxruntime/issues/24880, and should probably be fixed there.