### PR TITLE
SDPA fusion cleanup

### DIFF
--- a/onnxscript/rewriter/ort_fusions/mha_test.py
+++ b/onnxscript/rewriter/ort_fusions/mha_test.py
@@ -33,7 +33,7 @@ class TestMultiHeadAttention(unittest.TestCase):
             original_outputs = ort_run("original", model, inputs)
 
         # Fuse SDPA and MHA
-        sdpa_count = xformers.fuse_sdpa(model, debug=True)
+        sdpa_count = xformers.fuse_sdpa(model)
         self.assertGreater(sdpa_count, 0)
         mha_count = xformers.fuse_mha1(model)
         mha_count += xformers.fuse_mha2(model)

--- a/onnxscript/rewriter/ort_fusions/mha_test.py
+++ b/onnxscript/rewriter/ort_fusions/mha_test.py
@@ -33,7 +33,7 @@ class TestMultiHeadAttention(unittest.TestCase):
             original_outputs = ort_run("original", model, inputs)
 
         # Fuse SDPA and MHA
-        sdpa_count = xformers.fuse_sdpa(model)
+        sdpa_count = xformers.fuse_sdpa(model, debug=True)
         self.assertGreater(sdpa_count, 0)
         mha_count = xformers.fuse_mha1(model)
         mha_count += xformers.fuse_mha2(model)

--- a/onnxscript/rewriter/ort_fusions/sdpa.py
+++ b/onnxscript/rewriter/ort_fusions/sdpa.py
@@ -84,18 +84,14 @@ class SDPA(pattern.RewriteRuleClassBase):
         if query_scaling == "None":
             query_scale_value = 1.0
         elif query_scaling == "Mul":
-            if (
-                query_scale_value := _ir_utils.get_singleton_value(query_scale, rank=0)
-            ) is None:
+            if (query_scale_value := _ir_utils.get_singleton_value(query_scale)) is None:
                 return check_result.fail(
                     "Query scale is not a scalar.",
                     query_scale,
                 )
         else:
             assert query_scaling == "Div", "Unexpected query scaling operation"
-            if (
-                query_scale_value := _ir_utils.get_singleton_value(query_scale, rank=0)
-            ) is None:
+            if (query_scale_value := _ir_utils.get_singleton_value(query_scale)) is None:
                 return check_result.fail(
                     "Query scale is not a scalar.",
                     query_scale,
@@ -105,14 +101,14 @@ class SDPA(pattern.RewriteRuleClassBase):
         if key_scaling == "None":
             key_scale_value = 1.0
         elif key_scaling == "Mul":
-            if (key_scale_value := _ir_utils.get_singleton_value(key_scale, rank=0)) is None:
+            if (key_scale_value := _ir_utils.get_singleton_value(key_scale)) is None:
                 return check_result.fail(
                     "Key scale is not a scalar.",
                     key_scale,
                 )
         else:
             assert key_scaling == "Div", "Unexpected key scaling operation"
-            if (key_scale_value := _ir_utils.get_singleton_value(key_scale, rank=0)) is None:
+            if (key_scale_value := _ir_utils.get_singleton_value(key_scale)) is None:
                 return check_result.fail(
                     "Key scale is not a scalar.",
                     key_scale,
@@ -122,14 +118,14 @@ class SDPA(pattern.RewriteRuleClassBase):
         if qk_scaling == "None":
             qk_scale_value = 1.0
         elif qk_scaling == "Mul":
-            if (qk_scale_value := _ir_utils.get_singleton_value(qk_scale, rank=0)) is None:
+            if (qk_scale_value := _ir_utils.get_singleton_value(qk_scale)) is None:
                 return check_result.fail(
                     "QK scale is not a scalar.",
                     qk_scale,
                 )
         else:
             assert qk_scaling == "Div", "Unexpected QK scaling operation"
-            if (qk_scale_value := _ir_utils.get_singleton_value(qk_scale, rank=0)) is None:
+            if (qk_scale_value := _ir_utils.get_singleton_value(qk_scale)) is None:
                 return check_result.fail(
                     "QK scale is not a scalar.",
                     qk_scale,

--- a/onnxscript/rewriter/ort_fusions/sdpa.py
+++ b/onnxscript/rewriter/ort_fusions/sdpa.py
@@ -8,28 +8,7 @@ from onnxscript.rewriter import _fusion_utils, _ir_utils, pattern
 
 
 class SDPA(pattern.RewriteRuleClassBase):
-    def __init__(
-        self,
-        name: str,
-        *,
-        use_mask: bool,
-        pre_scale: bool,
-        pre_scale_q: bool,
-        use_mul: bool,
-        has_3d_query: bool,
-    ):
-        super().__init__(name=name)
-        self._use_mask = use_mask
-        self._pre_scale = pre_scale
-        # There are some patterns where only the query is scaled before the dot product
-        # and essentially (query * qk_scale) * key is equivalent to (query * key) * qk_scale
-        # TODO: Capture patterns where only the key is scaled before the dot product
-        self._pre_scale_q = pre_scale_q
-        self._use_mul = use_mul
-        # Capture patterns where the query is reshaped from 3D to 4D
-        # after scaling has been applied to query.
-        self._has_3d_query = has_3d_query
-        self._scale: float | None = None
+    _scale: float | None
 
     def pattern(
         self,
@@ -41,56 +20,82 @@ class SDPA(pattern.RewriteRuleClassBase):
         query_scale,
         key_scale,
         qk_scale,
-        # Shape used for reshaping the query in patterns where query is reshaped
-        # from 3D to 4D and scaling is applied before the reshaping.
-        query_reshape,
     ):
         # Some implementations scale the query and key before computing the dot product
-        query = pattern.OrValue([
-            op.Mul(query, query_scale),
-            op.Div(query, query_scale),
-            query,
-        ], tag_var="query_scaling", tag_values=["Mul", "Div", "None"])
-        key_transposed = pattern.OrValue([
-            op.Mul(key_transposed, key_scale),
-            op.Div(key_transposed, key_scale),
-            key_transposed,
-        ], tag_var="key_scaling", tag_values=["Mul", "Div", "None"])
-
+        query = pattern.OrValue(
+            [
+                op.Mul(query, query_scale),
+                op.Div(query, query_scale),
+                query,
+            ],
+            tag_var="query_scaling",
+            tag_values=["Mul", "Div", "None"],
+        )
+        key_transposed = pattern.OrValue(
+            [
+                op.Mul(key_transposed, key_scale),
+                op.Div(key_transposed, key_scale),
+                key_transposed,
+            ],
+            tag_var="key_scaling",
+            tag_values=["Mul", "Div", "None"],
+        )
 
         attn_score = op.MatMul(query, key_transposed)
 
         # Some implementations scale the dot product.
-        attn_score = pattern.OrValues ([
-            op.Mul(attn_score, qk_scale),
-            op.Div(attn_score, qk_scale),
-            attn_score,
-        ], tag_var="qk_scaling", tag_values=["Mul", "Div", "None"])
+        attn_score = pattern.OrValue(
+            [
+                op.Mul(attn_score, qk_scale),
+                op.Div(attn_score, qk_scale),
+                attn_score,
+            ],
+            tag_var="qk_scaling",
+            tag_values=["Mul", "Div", "None"],
+        )
 
         # Some implementations add a mask to the dot product.
         masked_attn_score = op.Add(attn_score, mask)
-        attn_score = pattern.OrValue([masked_attn_score, attn_score], tag_var="has_mask", tag_values=[True, False])
+        attn_score = pattern.OrValue(
+            [masked_attn_score, attn_score], tag_var="has_mask", tag_values=[True, False]
+        )
 
         attn_weight = op.Softmax(attn_score, axis=-1)
         attn_output = op.MatMul(attn_weight, value)
         return attn_output
 
     def check(
-        self, op, query, key_transposed, value, mask, query_scaling, query_scale, key_scaling, key_scale, qk_scale, **_
+        self,
+        op,
+        query,
+        key_transposed,
+        value,
+        mask,
+        query_scaling,
+        query_scale,
+        key_scaling,
+        key_scale,
+        qk_scaling,
+        qk_scale,
+        **_,
     ):
         check_result = pattern.MatchResult()
-        
+
         if query_scaling == "None":
             query_scale_value = 1.0
         elif query_scaling == "Mul":
-            if (query_scale_value := _ir_utils.get_singleton_value(query_scale, rank=0)) is None:
+            if (
+                query_scale_value := _ir_utils.get_singleton_value(query_scale, rank=0)
+            ) is None:
                 return check_result.fail(
                     "Query scale is not a scalar.",
                     query_scale,
                 )
         else:
             assert query_scaling == "Div", "Unexpected query scaling operation"
-            if (query_scale_value := _ir_utils.get_singleton_value(query_scale, rank=0)) is None:
+            if (
+                query_scale_value := _ir_utils.get_singleton_value(query_scale, rank=0)
+            ) is None:
                 return check_result.fail(
                     "Query scale is not a scalar.",
                     query_scale,
@@ -114,16 +119,16 @@ class SDPA(pattern.RewriteRuleClassBase):
                 )
             key_scale_value = 1.0 / key_scale_value
 
-        if qk_scale == "None":
+        if qk_scaling == "None":
             qk_scale_value = 1.0
-        elif qk_scale == "Mul":
+        elif qk_scaling == "Mul":
             if (qk_scale_value := _ir_utils.get_singleton_value(qk_scale, rank=0)) is None:
                 return check_result.fail(
                     "QK scale is not a scalar.",
                     qk_scale,
                 )
         else:
-            assert qk_scale == "Div", "Unexpected QK scaling operation"
+            assert qk_scaling == "Div", "Unexpected QK scaling operation"
             if (qk_scale_value := _ir_utils.get_singleton_value(qk_scale, rank=0)) is None:
                 return check_result.fail(
                     "QK scale is not a scalar.",
@@ -131,7 +136,7 @@ class SDPA(pattern.RewriteRuleClassBase):
                 )
             qk_scale_value = 1.0 / qk_scale_value
 
-        self._scale = query_scale_value * key_scale_value * qk_scale_value            
+        self._scale = query_scale_value * key_scale_value * qk_scale_value
 
         # If the scaling factor is the default one, we can skip passing it to SDPA.
 
@@ -141,13 +146,13 @@ class SDPA(pattern.RewriteRuleClassBase):
         if not isinstance(hidden_size, int):
             return
 
-        default_scaling_factor = math.sqrt(hidden_size)
+        default_scaling_factor = 1.0 / math.sqrt(hidden_size)
 
-        if self._scale == default_scaling_factor:
+        if math.isclose(self._scale, default_scaling_factor, rel_tol=1e-5, abs_tol=1e-8):
             # Pass no scaling factor to SDPA, SDPA will use the default scaling factor
             self._scale = None
 
-        # check ranks/shapes
+        # TODO: check ranks/shapes
 
         return check_result
 
@@ -158,61 +163,16 @@ class SDPA(pattern.RewriteRuleClassBase):
         key_transposed,
         value,
         mask,
-        query_scale,
-        key_scale,
-        qk_scale,
-        query_reshape=None,
         **_,
     ):
-        if self._pre_scale and self._pre_scale_q:
-            if self._use_mul:
-                query_mul = op.Mul(query, qk_scale)
-            else:
-                query_mul = op.Div(query, qk_scale)
-            # Reshape and transpose 3D input of shape (B, S, D)
-            # to 4D input of shape (B, N, S, H)
-            if self._has_3d_query:
-                queryBNSH = op.Reshape(query_mul, query_reshape)
-                query = op.Transpose(queryBNSH, perm=[0, 2, 1, 3])
-            else:
-                query = query_mul
-
         sdpa_args = [query, key_transposed, value]
-        if self._use_mask:
+        if mask is not None:
             sdpa_args.append(mask)
         return op.SDPA(*sdpa_args, scale=self._scale, _domain="ai.onnxruntime.fusion")
 
 
-parameter_combinations = [
-    {
-        "name": f"sdpa_{'masked_' if use_mask else 'unmasked_'}{'pre_' if pre_scale else 'post_'}{'only_q_' if pre_scale_q else ''}{'mul' if use_mul else 'div'}{'_3d_query' if has_3d_query else ''}",
-        "use_mask": use_mask,
-        "pre_scale": pre_scale,
-        "pre_scale_q": pre_scale_q,
-        "use_mul": use_mul,
-        "has_3d_query": has_3d_query,
-    }
-    for use_mask in [False, True]
-    for pre_scale in [False, True]
-    for pre_scale_q in [False, True]
-    for use_mul in [False, True]
-    for has_3d_query in [False, True]
-]
-
 # Dynamically create the rules
-sdpa_rules = pattern.RewriteRuleSet(
-    [
-        SDPA.rule(
-            params["name"],
-            use_mask=params["use_mask"],
-            pre_scale=params["pre_scale"],
-            pre_scale_q=params["pre_scale_q"],
-            use_mul=params["use_mul"],
-            has_3d_query=params["has_3d_query"],
-        )
-        for params in parameter_combinations
-    ]
-)
+sdpa_rules = pattern.RewriteRuleSet([SDPA.rule()])
 
 
 fuse_sdpa = _fusion_utils.apply_fusion_rules(sdpa_rules)

--- a/onnxscript/rewriter/ort_fusions/sdpa_test.py
+++ b/onnxscript/rewriter/ort_fusions/sdpa_test.py
@@ -26,7 +26,12 @@ SCALE_FACTOR = math.sqrt(H)
 MUL_SCALE_FACTOR = 1.0 / SCALE_FACTOR
 SQRT_SCALE_FACTOR = math.sqrt(SCALE_FACTOR)
 SQRT_MUL_SCALE_FACTOR = math.sqrt(MUL_SCALE_FACTOR)
-CUSTOM_SCALE_FACTOR = 2.0
+# Custom scale factors for testing
+CUSTOM_SCALE_FACTOR = 1.0 / math.sqrt(80)
+CUSTOM_MUL_SCALE_FACTOR = CUSTOM_SCALE_FACTOR
+CUSTOM_DIV_SCALE_FACTOR = 1.0 / CUSTOM_SCALE_FACTOR
+SQRT_CUSTOM_MUL_SCALE_FACTOR = math.sqrt(CUSTOM_MUL_SCALE_FACTOR)
+SQRT_CUSTOM_DIV_SCALE_FACTOR = math.sqrt(CUSTOM_DIV_SCALE_FACTOR)
 
 
 @script()
@@ -78,7 +83,7 @@ def _unmasked_post_mul_sdpa_script(query, key, value):
 @script()
 def _custom_scale_pre_div_sdpa_script(query, key, value):
     key_transposed = op.Transpose(key, perm=[0, 1, 3, 2])
-    divisor = op.Constant(value_float=CUSTOM_SCALE_FACTOR)
+    divisor = op.Constant(value_float=SQRT_CUSTOM_DIV_SCALE_FACTOR)
     scaled_query = op.Div(query, divisor)
     scaled_key = op.Div(key_transposed, divisor)
     attn_score = op.MatMul(scaled_query, scaled_key)
@@ -90,7 +95,7 @@ def _custom_scale_pre_div_sdpa_script(query, key, value):
 @script()
 def _custom_scale_pre_mul_sdpa_script(query, key, value):
     key_transposed = op.Transpose(key, perm=[0, 1, 3, 2])
-    multiplier = op.Constant(value_float=CUSTOM_SCALE_FACTOR)
+    multiplier = op.Constant(value_float=SQRT_CUSTOM_MUL_SCALE_FACTOR)
     scaled_query = op.Mul(query, multiplier)
     scaled_key = op.Mul(key_transposed, multiplier)
     attn_score = op.MatMul(scaled_query, scaled_key)
@@ -102,8 +107,8 @@ def _custom_scale_pre_mul_sdpa_script(query, key, value):
 @script()
 def _custom_multi_scale_pre_mul_sdpa_script(query, key, value):
     key_transposed = op.Transpose(key, perm=[0, 1, 3, 2])
-    multiplier_q = op.Constant(value_float=CUSTOM_SCALE_FACTOR)
-    multiplier_k = op.Constant(value_float=CUSTOM_SCALE_FACTOR)
+    multiplier_q = op.Constant(value_float=SQRT_CUSTOM_MUL_SCALE_FACTOR)
+    multiplier_k = op.Constant(value_float=SQRT_CUSTOM_MUL_SCALE_FACTOR)
     scaled_query = op.Mul(query, multiplier_q)
     scaled_key = op.Mul(key_transposed, multiplier_k)
     attn_score = op.MatMul(scaled_query, scaled_key)
@@ -115,7 +120,7 @@ def _custom_multi_scale_pre_mul_sdpa_script(query, key, value):
 @script()
 def _custom_scale_post_div_sdpa_script(query, key, value):
     key_transposed = op.Transpose(key, perm=[0, 1, 3, 2])
-    divisor = op.Constant(value_float=CUSTOM_SCALE_FACTOR)
+    divisor = op.Constant(value_float=CUSTOM_DIV_SCALE_FACTOR)
     attn_score = op.MatMul(query, key_transposed)
     scaled_attn_score = op.Div(attn_score, divisor)
     attn_weight = op.Softmax(scaled_attn_score, axis=-1)
@@ -126,7 +131,7 @@ def _custom_scale_post_div_sdpa_script(query, key, value):
 @script()
 def _custom_scale_post_mul_sdpa_script(query, key, value):
     key_transposed = op.Transpose(key, perm=[0, 1, 3, 2])
-    multiplier = op.Constant(value_float=CUSTOM_SCALE_FACTOR)
+    multiplier = op.Constant(value_float=CUSTOM_MUL_SCALE_FACTOR)
     attn_score = op.MatMul(query, key_transposed)
     scaled_attn_score = op.Mul(attn_score, multiplier)
     attn_weight = op.Softmax(scaled_attn_score, axis=-1)
@@ -187,7 +192,7 @@ def _masked_post_mul_sdpa_script(query, key, value, mask):
 @script()
 def _custom_scale_pre_div_sdpa_script(query, key, value, mask):
     key_transposed = op.Transpose(key, perm=[0, 1, 3, 2])
-    divisor = op.Constant(value_float=CUSTOM_SCALE_FACTOR)
+    divisor = op.Constant(value_float=SQRT_CUSTOM_DIV_SCALE_FACTOR)
     scaled_query = op.Div(query, divisor)
     scaled_key = op.Div(key_transposed, divisor)
     attn_score = op.MatMul(scaled_query, scaled_key)
@@ -200,7 +205,7 @@ def _custom_scale_pre_div_sdpa_script(query, key, value, mask):
 @script()
 def _custom_scale_pre_mul_sdpa_script(query, key, value, mask):
     key_transposed = op.Transpose(key, perm=[0, 1, 3, 2])
-    multiplier = op.Constant(value_float=CUSTOM_SCALE_FACTOR)
+    multiplier = op.Constant(value_float=SQRT_CUSTOM_MUL_SCALE_FACTOR)
     scaled_query = op.Mul(query, multiplier)
     scaled_key = op.Mul(key_transposed, multiplier)
     attn_score = op.MatMul(scaled_query, scaled_key)
@@ -213,7 +218,7 @@ def _custom_scale_pre_mul_sdpa_script(query, key, value, mask):
 @script()
 def _custom_scale_post_div_sdpa_script(query, key, value, mask):
     key_transposed = op.Transpose(key, perm=[0, 1, 3, 2])
-    divisor = op.Constant(value_float=CUSTOM_SCALE_FACTOR)
+    divisor = op.Constant(value_float=CUSTOM_DIV_SCALE_FACTOR)
     attn_score = op.MatMul(query, key_transposed)
     scaled_attn_score = op.Div(attn_score, divisor)
     masked_attn_score = op.Add(scaled_attn_score, mask)
@@ -225,7 +230,7 @@ def _custom_scale_post_div_sdpa_script(query, key, value, mask):
 @script()
 def _custom_scale_post_mul_sdpa_script(query, key, value, mask):
     key_transposed = op.Transpose(key, perm=[0, 1, 3, 2])
-    multiplier = op.Constant(value_float=CUSTOM_SCALE_FACTOR)
+    multiplier = op.Constant(value_float=CUSTOM_MUL_SCALE_FACTOR)
     attn_score = op.MatMul(query, key_transposed)
     scaled_attn_score = op.Mul(attn_score, multiplier)
     masked_attn_score = op.Add(scaled_attn_score, mask)
@@ -307,11 +312,7 @@ class TestSDPAFusion(unittest.TestCase):
         if "custom" in name:
             self.assertIsNotNone(sdpa_node.attributes.get("scale"))
             scale_factor = sdpa_node.attributes["scale"].value
-            self.assertIsNotNone(scale_factor)
-            if "pre" in name:
-                self.assertEqual(scale_factor, CUSTOM_SCALE_FACTOR * CUSTOM_SCALE_FACTOR)
-            elif "post" in name:
-                self.assertEqual(scale_factor, CUSTOM_SCALE_FACTOR)
+            self.assertAlmostEqual(scale_factor, CUSTOM_SCALE_FACTOR, delta=1e-8)
         else:
             # These tests are for the default scaling factors, no scale factor is passed to SDPA
             # pattern rewriting check functions should be sufficient to check if expected value


### PR DESCRIPTION
Remove the need for many different rules for SDPA fusion by (a) Using pattern-disjunction, and (b) Simplifying the handling of scaling factors which can occur in several forms (using either multiplication or division, either separately to query and/or key, or to the product of query and key). 