### PR TITLE
Implement `__repr__` for MatchResult

### DIFF
--- a/onnxscript/rewriter/_basics.py
+++ b/onnxscript/rewriter/_basics.py
@@ -42,7 +42,9 @@ class MatchResult:
         """Returns a string representation of the match result."""
         if not self._partial_matches:
             return "MatchResult()"
-        return f"MatchResult(success={bool(self)}, reason={self.reason!r}, nodes={self.nodes!r})"
+        return (
+            f"MatchResult(success={bool(self)}, reason={self.reason!r}, nodes={self.nodes!r})"
+        )
 
     @property
     def _current_match(self) -> PartialMatchResult:

--- a/onnxscript/rewriter/_basics.py
+++ b/onnxscript/rewriter/_basics.py
@@ -38,6 +38,12 @@ class MatchResult:
         # We use a stack of partial matches to handle OR patterns that require backtracking.
         self._partial_matches: list[PartialMatchResult] = [PartialMatchResult()]
 
+    def __repr__(self) -> str:
+        """Returns a string representation of the match result."""
+        if not self._partial_matches:
+            return "MatchResult()"
+        return f"MatchResult(success={bool(self)}, reason={self.reason!r}, nodes={self.nodes!r})"
+
     @property
     def _current_match(self) -> PartialMatchResult:
         """Returns the current match result."""


### PR DESCRIPTION
This pull request adds a `__repr__` method to the `MatchResult` class in `onnxscript/rewriter/_basics.py`. The new method provides a string representation of the match result, improving debugging and readability.