### PR TITLE
Fix test names for pytest

### DIFF
--- a/onnxscript/rewriter/ort_fusions/cos_sin_cache_test.py
+++ b/onnxscript/rewriter/ort_fusions/cos_sin_cache_test.py
@@ -9,12 +9,7 @@ from parameterized import parameterized
 import onnxscript.optimizer
 from onnxscript.rewriter.ort_fusions._test_utils import assert_allclose, ort_run
 from onnxscript.rewriter.ort_fusions.cos_sin_cache import fuse_cos_sin_cache
-from onnxscript.rewriter.ort_fusions.models._rotary_embedding_models import (
-    partial_rotary_test_case,
-    test_case_1,
-    test_case_2,
-)
-from onnxscript.rewriter.ort_fusions.models._smollm_1 import smollm_test_1
+from onnxscript.rewriter.ort_fusions.models import _rotary_embedding_models, _smollm_1
 from onnxscript.rewriter.ort_fusions.rotary_embedding import (
     fuse_partial_rotary_embedding,
     fuse_rotary_embedding,
@@ -26,19 +21,19 @@ class TestCosSinCacheTransform(unittest.TestCase):
         [
             (
                 "smollm_test_1",
-                smollm_test_1,
+                _smollm_1.smollm_test_1,
             ),
             (
                 "test_case_1",
-                test_case_1,
+                _rotary_embedding_models.test_case_1,
             ),
             (
                 "test_case_2",
-                test_case_2,
+                _rotary_embedding_models.test_case_2,
             ),
             (
                 "partial_rotary_test_case",
-                partial_rotary_test_case,
+                _rotary_embedding_models.partial_rotary_test_case,
             ),
         ]
     )
@@ -56,7 +51,7 @@ class TestCosSinCacheTransform(unittest.TestCase):
         assert_allclose(new_outputs, original_outputs)
 
     def test_partial_rotary_fusion(self):
-        test = partial_rotary_test_case()
+        test = _rotary_embedding_models.partial_rotary_test_case()
         model = test.get_onnx_model()
         onnxscript.optimizer.optimize(model)
         inputs = test.get_ort_inputs()

--- a/onnxscript/rewriter/ort_fusions/rotary_embedding_test.py
+++ b/onnxscript/rewriter/ort_fusions/rotary_embedding_test.py
@@ -7,9 +7,8 @@ import unittest
 from parameterized import parameterized
 
 import onnxscript.optimizer
-from onnxscript.rewriter.ort_fusions.models._rotary_embedding_models import test_case_1
-from onnxscript.rewriter.ort_fusions.models._smollm_1 import smollm_test_1
-from onnxscript.rewriter.ort_fusions.rotary_embedding import fuse_rotary_embedding
+from onnxscript.rewriter.ort_fusions import rotary_embedding
+from onnxscript.rewriter.ort_fusions.models import _rotary_embedding_models, _smollm_1
 
 
 class TestRotaryEmbedding(unittest.TestCase):
@@ -17,19 +16,19 @@ class TestRotaryEmbedding(unittest.TestCase):
         [
             (
                 "test_case_1",
-                test_case_1,
+                _rotary_embedding_models.test_case_1,
             ),
             (
                 "smollm_test_1",
-                smollm_test_1,
+                _smollm_1.smollm_test_1,
             ),
         ]
     )
-    def test_rotary_embedding_fusion(self, name, test_data_constructor):
+    def test_rotary_embedding_fusion(self, _: str, test_data_constructor):
         test = test_data_constructor()
         model = test.get_onnx_model()
         onnxscript.optimizer.optimize(model)
-        fuse_rotary_embedding(model)
+        rotary_embedding.fuse_rotary_embedding(model)
         op_types = [n.op_type for n in model.graph]
         self.assertIn("RotaryEmbedding", op_types)
 


### PR DESCRIPTION
With the latest version of pytest we get 

> onnxscript/rewriter/ort_fusions/cos_sin_cache_test.py::test_case_1 - Failed: Expected None, but test returned <onnxscript.rewriter.ort_fusions.models._rotary_embedding_models._TestCase1 object at 0x117c920d0>. Did you mean to use `assert` instead of `return`?

This is because the imported functions `test_case_1` and `test_case_2` are not really test cases but were treated as such by pytest. This PR hides them from the test module so they are not triggered.