### PR TITLE
fix: pattern match gelu from contrib and onnx ops🐛

### DIFF
--- a/onnxscript/rewriter/ort_fusions/bias_gelu.py
+++ b/onnxscript/rewriter/ort_fusions/bias_gelu.py
@@ -31,8 +31,8 @@ class BiasGeluFusion(pattern.RewriteRuleClassBase):
 
     def check(self, op, gelu, **_) -> pattern.MatchResult:
         check_result = pattern.MatchResult()
-        approximate = gelu.producer().attributes.get("approximate", None)
-        if approximate is not None and approximate.value == "tanh":
+        approximate = gelu.producer().attributes.get_string("approximate")
+        if approximate is not None and approximate == "tanh":
             return check_result.fail(
                 "Gelu operator with 'approximate' set to 'tanh' is not supported."
             )

--- a/onnxscript/rewriter/ort_fusions/bias_gelu.py
+++ b/onnxscript/rewriter/ort_fusions/bias_gelu.py
@@ -6,17 +6,33 @@ from onnxscript.rewriter import _fusion_utils, pattern
 
 
 class BiasGeluFusion(pattern.RewriteRuleClassBase):
+    def __init__(
+        self,
+        name,
+        *,
+        has_contrib_op: bool,
+    ):
+        super().__init__(name)
+        self._has_contrib_op = has_contrib_op
+
     def pattern(self, op, x, y):
         gelu_add = op.Add(x, y)
-        return op.Gelu(gelu_add, _domain="com.microsoft")
+        # see: gh-2362. Match against Gelu from onnx op or contrib ops.
+        if self._has_contrib_op:
+            return op.Gelu(gelu_add, _domain="com.microsoft")
+        else:
+            return op.Gelu(gelu_add)
 
     def rewrite(self, op, x, y):
         return op.BiasGelu(x, y, _domain="com.microsoft")
 
 
-_rule = BiasGeluFusion.rule()
-
-bias_gelu_rules = pattern.RewriteRuleSet([_rule])
+bias_gelu_rules = pattern.RewriteRuleSet(
+    [
+        BiasGeluFusion.rule("gelu_onnx_op", has_contrib_op=False),
+        BiasGeluFusion.rule("gelu_contrib_op", has_contrib_op=True),
+    ]
+)
 
 
 fuse_bias_gelu = _fusion_utils.apply_fusion_rules(bias_gelu_rules)

--- a/onnxscript/rewriter/ort_fusions/bias_gelu.py
+++ b/onnxscript/rewriter/ort_fusions/bias_gelu.py
@@ -27,6 +27,7 @@ class BiasGeluFusion(pattern.RewriteRuleClassBase):
         if self._contrib_op:
             return op.Gelu(gelu_add, _domain="com.microsoft")
         else:
+            # match behavior of onnxruntime fusion_biasgelu.py
             return op.Gelu(gelu_add)
 
     def rewrite(self, op, x, y):

--- a/onnxscript/rewriter/ort_fusions/bias_gelu.py
+++ b/onnxscript/rewriter/ort_fusions/bias_gelu.py
@@ -10,7 +10,7 @@ class BiasGeluFusion(pattern.RewriteRuleClassBase):
 
     Attributes:
         contrib_op (bool): If True, matches the Gelu operator from the 'com.microsoft' domain.
-                           If False, matches the standard ONNX Gelu operator.
+            If False, matches the standard ONNX Gelu operator.
     """
 
     def __init__(

--- a/onnxscript/rewriter/ort_fusions/bias_gelu_test.py
+++ b/onnxscript/rewriter/ort_fusions/bias_gelu_test.py
@@ -30,15 +30,13 @@ class BiasGeluFusionTest(unittest.TestCase):
             @script()
             def bias_gelu_model(x, y):
                 gelu_add = op.Add(x, y)
-                gelu = msft_op.Gelu(gelu_add)
-                return gelu
+                return msft_op.Gelu(gelu_add)
         else:
 
             @script()
             def bias_gelu_model(x, y):
                 gelu_add = op.Add(x, y)
-                gelu = op.Gelu(gelu_add)
-                return gelu
+                return op.Gelu(gelu_add)
 
         model_proto = bias_gelu_model.to_model_proto(
             input_types=[FLOAT[10], FLOAT[10]],


### PR DESCRIPTION
Previously the domain for Gelu in the [rules implementation](https://github.com/microsoft/onnxscript/blob/main/onnxscript/rewriter/ort_fusions/bias_gelu.py#L11) was restricted to the [contributor ops implementation](https://github.com/microsoft/onnxruntime/blob/rel-1.20.0/docs/ContribOperators.md#com.microsoft.Gelu) and does not fuse Gelu from onnx ops ([introduced with opset 20](https://onnx.ai/onnx/operators/onnx__Gelu.html#l-onnx-doc-gelu)). 

This pr introduces pattern matching + tests for both variants.

closes #2362 .

@shubhambhokare1 @justinchuby Could you please review? Any feedback is greatly appreciated.