### PR TITLE
Update autocast.py to fix attribute creation error

### DIFF
--- a/onnxscript/_internal/autocast.py
+++ b/onnxscript/_internal/autocast.py
@@ -45,7 +45,7 @@ def pyvalue_to_onnx_attribute(
     key: str,
     value: Any,
     name_generator: Callable[[], str],
-    attr_type: Optional[onnx.AttributeProto.AttributeType] = None,
+    attr_type: onnx.AttributeProto.AttributeType | None = None,
 ) -> onnx.AttributeProto:
     """Helper function to create an ONNX AttributeProto.
 
@@ -63,10 +63,10 @@ def pyvalue_to_onnx_attribute(
             raise ValueError("Attribute type must be specified for empty list value.")
         if attr_type not in _REPEATED_ATTRIBUTE_TYPES:
             raise ValueError("Empty list value is only allowed for repeated attribute types.")
-        return onnx.AttributeProto(name=key, type=attr_type)
+        return onnx.AttributeProto(name=key, type=int(attr_type))
     elif attr_type == onnx.AttributeProto.TENSOR and not isinstance(value, onnx.TensorProto):
         return onnx.AttributeProto(
-            name=key, type=attr_type, t=pyvalue_to_onnx_tensor(name_generator(), value)
+            name=key, type=int(attr_type), t=pyvalue_to_onnx_tensor(name_generator(), value)
         )
     else:
         # When the value is a subgraph, ONNX IR will complain that some values are

--- a/onnxscript/_internal/autocast.py
+++ b/onnxscript/_internal/autocast.py
@@ -63,10 +63,10 @@ def pyvalue_to_onnx_attribute(
             raise ValueError("Attribute type must be specified for empty list value.")
         if attr_type not in _REPEATED_ATTRIBUTE_TYPES:
             raise ValueError("Empty list value is only allowed for repeated attribute types.")
-        return onnx.AttributeProto(name=key, type=int(attr_type))
+        return onnx.AttributeProto(name=key, type=attr_type)
     elif attr_type == onnx.AttributeProto.TENSOR and not isinstance(value, onnx.TensorProto):
         return onnx.AttributeProto(
-            name=key, type=int(attr_type), t=pyvalue_to_onnx_tensor(name_generator(), value)
+            name=key, type=attr_type, t=pyvalue_to_onnx_tensor(name_generator(), value)
         )
     else:
         # When the value is a subgraph, ONNX IR will complain that some values are

--- a/onnxscript/converter.py
+++ b/onnxscript/converter.py
@@ -298,7 +298,7 @@ class Converter:
         return r
 
     def _make_onnx_attr(
-        self, attrname: str, attrval: Any, attrtype: Optional[int] = None
+        self, attrname: str, attrval: Any, attrtype: int | None = None
     ) -> irbuilder.IRAttributeValue:
         def tensor_name_generator() -> str:
             """Return name to be used for tensor, if we need to create one."""
@@ -518,8 +518,8 @@ class Converter:
             if attr_meta and attr_meta.required:
                 self.fail(expr, f"Attribute '{attr_name}' is required.")
             return None
-        attr_type = attr_meta.type if attr_meta else None
-        attr = self._make_onnx_attr(attr_name, val, attr_type)
+        attr_type = int(attr_meta.type) if attr_meta else None
+        attr = self._make_onnx_attr(attr_name, val, attrtype=attr_type)
         if attr_meta and (attr.type != attr_meta.type):
             self.fail(
                 expr,

--- a/onnxscript/evaluator.py
+++ b/onnxscript/evaluator.py
@@ -420,7 +420,7 @@ def _prepare_model_and_inputs_for_eager(
             return f"attr_{key}"
 
         return autocast.pyvalue_to_onnx_attribute(
-            key, value, make_tensor_name, schema.attributes[key].type
+            key, value, make_tensor_name, int(schema.attributes[key].type)
         )
 
     # Construct ONNX model with a single op call:


### PR DESCRIPTION
This change should fix the type of errors like below (reported in https://github.com/pytorch/pytorch/issues/153214#issuecomment-2941500656):

```pytb
  File "/usr/local/lib/python3.12/dist-packages/google/protobuf/internal/python_message.py", line 589, in init
    _ReraiseTypeErrorWithFieldName(message_descriptor.name, field_name)
  File "/usr/local/lib/python3.12/dist-packages/google/protobuf/internal/python_message.py", line 478, in _ReraiseTypeErrorWithFieldName
    raise exc.with_traceback(sys.exc_info()[2])
  File "/usr/local/lib/python3.12/dist-packages/google/protobuf/internal/python_message.py", line 587, in init
    setattr(self, field_name, field_value)
  File "/usr/local/lib/python3.12/dist-packages/google/protobuf/internal/python_message.py", line 730, in field_setter
    raise TypeError(
TypeError: Cannot set onnx.AttributeProto.type to <AttrType.TENSOR: 4>: <AttrType.TENSOR: 4> has type <class 'onnx.onnx_cpp2py_export.defs.OpSchema.AttrType'>, but expected one of: (<class 'int'>,) for field AttributeProto.type
```