### PR TITLE
Cast-cast elimination

### DIFF
--- a/onnxscript/rewriter/_fusion_utils.py
+++ b/onnxscript/rewriter/_fusion_utils.py
@@ -53,14 +53,14 @@ def apply_fusion_rules(rules: pattern.RewriteRule | pattern.RewriteRuleSet) -> C
     """
 
     def apply_to(
-        model: ir.Model, debug: bool = False, apply_shape_inference: bool = False
+        model: ir.Model, debug: bool = False, apply_shape_inference: bool = False, **kwargs
     ) -> int:
-        count = rules.apply_to_model(model)
+        count = rules.apply_to_model(model, **kwargs)
         if apply_shape_inference:
             common_passes.ShapeInferencePass()(model)
         if count == 0 and debug:
             tracer = pattern.MatchingTracer()
-            rules.apply_to_model(model, tracer=tracer)
+            rules.apply_to_model(model, tracer=tracer, **kwargs)
             tracer.report()
         return count
 

--- a/onnxscript/rewriter/_rewrite_rule.py
+++ b/onnxscript/rewriter/_rewrite_rule.py
@@ -15,6 +15,7 @@ from typing import (
 
 import onnxscript.optimizer
 import onnxscript.rewriter._basics as _basics
+import onnxscript.rewriter._ir_utils as _ir_utils
 import onnxscript.rewriter._matcher as _matcher
 import onnxscript.rewriter._pattern_ir as _pattern_ir
 from onnxscript import ir
@@ -529,6 +530,15 @@ class RewriteRuleSet:
                     )
                     f = ir.Function(domain, name, overload, graph=graph, attributes=())
                     model.functions[f.identifier()] = f
+
+                if verbose:
+                    name = f"{rule.name}: " if rule.name else ""
+                    print(f"----{name}Matched Nodes----")
+                    _ir_utils.display_nodes(delta.match.nodes)
+                    print("++++Replacement Nodes++++")
+                    _ir_utils.display_nodes(delta.new_nodes)
+                    print("++++End Replacement Nodes++++")
+
                 convenience.replace_nodes_and_values(
                     graph_or_function,
                     node,

--- a/onnxscript/rewriter/ort_fusions/_core.py
+++ b/onnxscript/rewriter/ort_fusions/_core.py
@@ -74,8 +74,8 @@ def fuse_xformers(model: ir.Model, debug: bool = False) -> tuple[ir.Model, dict[
 
     model = _pre_optimize(model)
 
-    def fuse(func, apply_shape_inference: bool = False):
-        return func(model, debug=debug, apply_shape_inference=apply_shape_inference)
+    def fuse(func, **kwargs):
+        return func(model, debug=debug, **kwargs)
 
     fusion_count["erf_gelu"] = fuse(fuse_erfgelu)
     fusion_count["rms_normalization"] = fuse(fuse_rms_normalization)


### PR DESCRIPTION
Enable the cast-cast simplification to a single cast in a couple of cases where it is valid. This shows up in examples like SmolLM (FP16) and is needed for fusion-pattern to work.

Also: add display of replaced and replacing nodes in fusion in verbose mode.