### PR TITLE
fix: check for rank of bias in bias-gelu fusion🐛

### DIFF
--- a/onnxscript/rewriter/ort_fusions/bias_gelu_test.py
+++ b/onnxscript/rewriter/ort_fusions/bias_gelu_test.py
@@ -18,27 +18,39 @@ msft_op = onnxscript.values.Opset("com.microsoft", 1)
 
 
 @script()
-def _test_script_onnx_default(x: FLOAT[10], y: FLOAT[10]) -> FLOAT[10]:
+def _test_script_onnx_default(x: FLOAT[10, 10], y: FLOAT[10]) -> FLOAT[10]:
     gelu_add = op.Add(x, y)
     return op.Gelu(gelu_add)
 
 
 @script()
-def _test_script_onnx_none(x: FLOAT[10], y: FLOAT[10]) -> FLOAT[10]:
+def _test_script_onnx_none(x: FLOAT[10, 10], y: FLOAT[10]) -> FLOAT[10]:
     gelu_add = op.Add(x, y)
     return op.Gelu(gelu_add, approximate="none")
 
 
 @script()
-def _test_script_onnx_unsupported(x: FLOAT[10], y: FLOAT[10]) -> FLOAT[10]:
+def _test_script_msft_op(x: FLOAT[10, 10], y: FLOAT[10]) -> FLOAT[10]:
+    gelu_add = op.Add(x, y)
+    return msft_op.Gelu(gelu_add)
+
+
+@script()
+def _test_script_onnx_unsupported(x: FLOAT[10, 10], y: FLOAT[10]) -> FLOAT[10]:
     gelu_add = op.Add(x, y)
     return op.Gelu(gelu_add, approximate="tanh")
 
 
 @script()
-def _test_script_msft_op(x: FLOAT[10], y: FLOAT[10]) -> FLOAT[10]:
-    gelu_add = op.Add(x, y)
-    return msft_op.Gelu(gelu_add)
+def _test_script_shape_unsupported(x: FLOAT[10, 10], y: FLOAT[10]) -> FLOAT[10]:
+    gelu_add = op.Add(x, x)
+    return op.Gelu(gelu_add)
+
+
+@script()
+def _test_script_reversed_order(x: FLOAT[10, 10], y: FLOAT[10]) -> FLOAT[10]:
+    gelu_add = op.Add(y, x)
+    return op.Gelu(gelu_add)
 
 
 class BiasGeluFusionTest(unittest.TestCase):
@@ -54,7 +66,7 @@ class BiasGeluFusionTest(unittest.TestCase):
         optimize(model)
 
         input = {
-            "x": np.random.randn(10).astype(np.float32),
+            "x": np.random.randn(10, 10).astype(np.float32),
             "y": np.random.randn(10).astype(np.float32),
         }
         original_output = test_utils.ort_run("Original", model, input)
@@ -87,6 +99,8 @@ class BiasGeluFusionTest(unittest.TestCase):
     @parameterized.parameterized.expand(
         [
             ("approximate_tanh", _test_script_onnx_unsupported, 2, "Add"),
+            ("unsupported_shape", _test_script_shape_unsupported, 2, "Add"),
+            ("reversed_order", _test_script_reversed_order, 2, "Add"),
         ]
     )
     def test_bias_gelu_fusion_unsupported_attr(


### PR DESCRIPTION
Follow-up to #2364.

I  noticed that the current implementation `BiasGeluFusion` from #2364 does not check for the dimensions of the bias term, which can lead to errors, as the bias input for `BiasGelu(...)` is expected to be 1D (see [here]https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#commicrosoftbiasgelu). 

This pr adds:
- additional checks for dim of bias
- additional test cases

Sorry for the inconvenience.

@justinchuby @titaiwangms