### PR TITLE
Fix fusion ordering for partial rotary embedding

### DIFF
--- a/onnxscript/rewriter/ort_fusions/_core.py
+++ b/onnxscript/rewriter/ort_fusions/_core.py
@@ -81,8 +81,9 @@ def fuse_xformers(model: ir.Model, debug: bool = False) -> tuple[ir.Model, dict[
     fusion_count["skip_layer_normalization"] = fuse(fuse_skip_layer_normalization)
     fusion_count["skip_rms_normalization"] = fuse(fuse_skip_rms_normalization)
     fusion_count["rotary_embedding"] = fuse(fuse_rotary_embedding)
-    fusion_count["partial_rotary_embedding"] = fuse(fuse_partial_rotary_embedding)
     fusion_count["cos_sin_cache"] = fuse(fuse_cos_sin_cache)
+    fusion_count["partial_rotary_embedding"] = fuse(fuse_partial_rotary_embedding)
+
     # We apply shape inference after the SDPA fusion as new nodes are added
     # in the rewrite rule for certain patterns of SDPA.
     fusion_count["sdpa"] = fuse(fuse_sdpa, apply_shape_inference=True)


### PR DESCRIPTION
The partial-rotary-embedding fusion depends on the cos-sin-cache fusion. Fix the fusion ordering. This is necessary for GQA fusion in models like Phi4 (with partial-rotary-embedding).

TODO: Add test-case. The one I have is huge. Need to create a smaller test-case.