### PR TITLE
[DRAFT] Add support for onnx fusions

### DIFF
--- a/onnxscript/rewriter/onnx_fusions/_core.py
+++ b/onnxscript/rewriter/onnx_fusions/_core.py
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+from __future__ import annotations
+
+import onnx_ir as ir
+from onnxscript.rewriter.onnx_fusions import rms_normalization
+
+
+def _get_onnx_opset_version(model: ir.Model) -> int | None:
+    """Get the ONNX opset version imported by the model."""
+    model_version1 = model.opset_imports.get("")
+    model_version2 = model.opset_imports.get("ai.onnx")
+    if model_version1 is not None and model_version2 is not None:
+        if model_version1 != model_version2:
+            raise ValueError(
+                f"Model imports multiple onnx opsets: {model_version1} and {model_version2}."
+            )
+    return model_version1 or model_version2
+
+
+def _opset_23_fuse(model: ir.Model, *, debug: bool = False) -> dict[str, int]:
+    """
+    Apply fusions targetting ONNX opset 23.
+    """
+    counts: dict[str, int] = {}
+    counts["RMSNormalization"] = rms_normalization.fuse(
+        model, debug=debug
+    )
+
+
+def fuse(model: ir.Model, *, debug: bool = False) -> dict[str, int]:
+    """
+    Apply fusions targetting ONNX ops.
+    """
+    model_opset_version = _get_onnx_opset_version(model)
+    if model_opset_version == 23:
+        return _opset_23_fuse(model, debug=debug)

--- a/onnxscript/rewriter/onnx_fusions/rms_normalization.py
+++ b/onnxscript/rewriter/onnx_fusions/rms_normalization.py
@@ -6,16 +6,16 @@ import onnxscript.ir as ir
 from onnxscript.rewriter import _fusion_utils, _ir_utils, pattern
 
 """
-RMS Normalization: This is referred to as SimplifiedLayerNormalization in the ORT codebase.
-See https://github.com/microsoft/onnxruntime/blob/6d9636f07cccdb6e4ac453087ad54c3bc9854d50/onnxruntime/core/graph/contrib_ops/contrib_defs.cc#L2981
+RMS Normalization: ONNX Opset 23 op
+See: https://onnx.ai/onnx/operators/onnx__RMSNormalization.html#l-onnx-doc-rmsnormalization
+
 
 Key points for the fusion optimization:
 * Input and scale are allowed to be of different types.
 * The normalization of the input can be done in a different precision than the input type,
-which is also the precision of reciprocal_rms returned by operation.
+indicated by stash_type.
 * Input (x) must be: float or double or float16 or bfloat16
 * Scale must be: float or double or float16 or bfloat16
-* Normalization precision must be float or double
 """
 
 float_types = [
@@ -39,9 +39,7 @@ class RmsNormFusion(pattern.RewriteRuleClassBase):
         normalized = pattern.OrValue([op.Cast(normalized, to=target_dtype), normalized])
         return op.Mul(scale, normalized)
 
-    def check(
-        self, op, x, scale, epsilon, compute_dtype, target_dtype, **_
-    ) -> pattern.MatchResult:  # type: ignore[name-defined]
+    def check(self, op, x, scale, epsilon, compute_dtype, target_dtype, **_) -> pattern.MatchResult:  # type: ignore[name-defined]
         """Check if the pattern matches conditions for use of SimplifiedLayerNormalization op."""
         check_result = pattern.MatchResult()
         # epsilon must be a scalar
@@ -49,11 +47,13 @@ class RmsNormFusion(pattern.RewriteRuleClassBase):
         if not isinstance(epsilon_value, float):  # TODO: support other types
             return check_result.fail("Epsilon is not a float value.", epsilon)
         if x.dtype not in float_types:
-            return check_result.fail("Input is not a float type.", x)
+            return check_result.fail("Input is not a supported float type.", x)
         if scale.dtype not in float_types:
-            return check_result.fail("Scale is not a float type.", scale)
+            return check_result.fail("Scale is not a supported float type.", scale)
         self._stash_dtype = compute_dtype.as_int() if compute_dtype is not None else x.dtype
         if self._stash_dtype not in fp_float_types:
+            # TODO: ONNX documentation does not specify restrictions on stash_type, though
+            # ORT's SimplifiedLayerNormalization requires it to be float or double.
             return check_result.fail("Normalization precision is not a float or double type.")
         # target_dtype is guaranteed to be the same as scale type in a well-typed input
         # for Mul(scale, normalized) to work. There is no need to check it here for a well-typed input.
@@ -63,7 +63,7 @@ class RmsNormFusion(pattern.RewriteRuleClassBase):
     def rewrite(self, op, x, scale, epsilon, **_):
         # Note: ORT's SimplifiedLayerNormalization was placed in onnx domain by mistake.
         # No need to use com.microsoft domain here; but this is a custom op in ORT.
-        return op.SimplifiedLayerNormalization(
+        return op.RMSNormalization(
             x,
             scale,
             axis=-1,


### PR DESCRIPTION
* Add basic infrastructure support for fusions targeting ONNX opset 23, with RMSNormalization as one target op.
* Cleanup existing RMSNormalization fusion targetting ORT's contrib op (using pattern-disjunction to simplify rules).
