### PR TITLE
A couple of minor fixes on rewrite rules

### DIFF
--- a/onnxscript/rewriter/fuse_relus_clips.py
+++ b/onnxscript/rewriter/fuse_relus_clips.py
@@ -7,6 +7,8 @@
 - Clip(Clip(X)) -> Clip
 """
 
+from __future__ import annotations
+
 import abc
 
 import numpy as np

--- a/onnxscript/rewriter/redundant_scatter_nd.py
+++ b/onnxscript/rewriter/redundant_scatter_nd.py
@@ -29,6 +29,9 @@ def fail(*args):
 
 
 class ScatterAllDynamic(orp.RewriteRuleClassBase):
+    def __init__(self):
+        super().__init__(remove_nodes=False)
+
     def pattern(self, op, data, axis, transposed_data, updates):
         # Construct update-indices spanning an entire axis:
         shape = op.Shape(data, start=0)


### PR DESCRIPTION
* The recently introduced scatter-nd elimination optimization requires the `remove_nodes=False` option to be more effective (which was somehow lost in the initial implementation).
* Add a missing import statement for future annotations in the `fuse_relus_clips.py` file