### PR TITLE
Reorder optimization passes

### DIFF
--- a/onnxscript/optimizer/_function_folding_test.py
+++ b/onnxscript/optimizer/_function_folding_test.py
@@ -151,7 +151,7 @@ class FunctionFoldingTest(unittest.TestCase):
         optimized = optimizer.optimize(model, onnx_shape_inference=False, inline=True)
 
         self.assertEqual(len(optimized.functions), 0)
-        self.assertEqual(len(optimized.graph), 2)
+        self.assertEqual(len(optimized.graph), 1)
         self.assertNotIn("If", {n.op_type for n in optimized.graph})
 
 

--- a/onnxscript/optimizer/_optimizer.py
+++ b/onnxscript/optimizer/_optimizer.py
@@ -53,10 +53,10 @@ def optimize_ir(
             early_stop=stop_if_no_change,
         ),
         common_passes.RemoveUnusedNodesPass(),
-        common_passes.CommonSubexpressionEliminationPass(),
-        common_passes.LiftConstantsToInitializersPass(),
+        common_passes.LiftConstantsToInitializersPass(lift_all_constants=True, size_limit=0),
         common_passes.LiftSubgraphInitializersToMainGraphPass(),
         common_passes.DeduplicateInitializersPass(),
+        common_passes.CommonSubexpressionEliminationPass(),
     ]
     if inline:
         # Inline all functions first before optimizing


### PR DESCRIPTION
CSE benefits from lifting constants to initializers, and from initializer deduplication. Hence, it is better to have CSE after the other two. Furthermore, we want this to apply to all constants, including `Constant(value_int=1)` etc., so set those options for lifting constants.