### PR TITLE
Make TransposeIdentity more robust

### DIFF
--- a/onnxscript/rewriter/basic_rules.py
+++ b/onnxscript/rewriter/basic_rules.py
@@ -206,8 +206,8 @@ class TransposeIdentity(RewriteRuleClassBase):
         if perm.is_ref():
             return check_result.fail("Permutation is a reference attribute.")
         if perm.type == ir.AttributeType.INTS:
-            perm_ints = perm.as_ints()
-            if perm_ints == list(range(len(perm_ints))):
+            perm_ints = tuple(perm.as_ints())
+            if perm_ints == tuple(range(len(perm_ints))):
                 return check_result
         return check_result.fail("Permutation is not identity.")
 


### PR DESCRIPTION
A quick change to make the `TransposeIdentity` rule more robust. Since `as_ints` returns a Sequence we cannot assume it is a list.