### PR TITLE
Add reproduction test case for incorrect slice rewrite and add potential fix

### DIFF
--- a/onnxscript/rewriter/collapse_slices.py
+++ b/onnxscript/rewriter/collapse_slices.py
@@ -6,6 +6,7 @@ import logging
 
 from onnxscript import ir
 from onnxscript.rewriter._rewrite_rule import RewriteRule, RewriteRuleSet
+from onnxscript.rewriter._ir_utils import is_singleton_value
 
 logger = logging.getLogger(__name__)
 _INT64_MAX = 9223372036854775807
@@ -81,7 +82,7 @@ def _same_shape(op, data: ir.Value, slice_output: ir.Value, steps: ir.Value, **_
     if data.shape is None or slice_output.shape is None:
         return False
 
-    if not (steps.const_value.numpy() == 1).all():
+    if not is_singleton_value(steps, 1):
         return False
 
     return data.shape == slice_output.shape

--- a/onnxscript/rewriter/collapse_slices.py
+++ b/onnxscript/rewriter/collapse_slices.py
@@ -76,10 +76,14 @@ def _potential_redundant_slice(op, data, starts, ends, axes, steps):
     return op.Slice(data, starts, ends, axes, steps, _outputs=["slice_output"])
 
 
-def _same_shape(op, data: ir.Value, slice_output: ir.Value, **_):
+def _same_shape(op, data: ir.Value, slice_output: ir.Value, steps: ir.Value, **_):
     """Check if the shape of the slice output is the same as the data."""
     if data.shape is None or slice_output.shape is None:
         return False
+
+    if not (steps.const_value.numpy() == 1).all():
+        return False
+
     return data.shape == slice_output.shape
 
 

--- a/onnxscript/rewriter/collapse_slices.py
+++ b/onnxscript/rewriter/collapse_slices.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import logging
 
 from onnxscript import ir
-from onnxscript.rewriter._rewrite_rule import RewriteRule, RewriteRuleSet
 from onnxscript.rewriter._ir_utils import is_singleton_value
+from onnxscript.rewriter._rewrite_rule import RewriteRule, RewriteRuleSet
 
 logger = logging.getLogger(__name__)
 _INT64_MAX = 9223372036854775807


### PR DESCRIPTION
This adds a reproduction of the rule introduced in f42c2bbfd31edc99a849e0381ae4992da32479de leading to an incorrect rewrite of the graph.

The original rule does not consider the step parameter, which can influence the result of a `Slice` to be the identity even when input and output shape are equivalent.

The potential fix seems to be to not apply the rule on `step != 1`, therefore the second commit adds this to the original rule implementation.