### PR TITLE
Update constant folding behavior for large tensors

### DIFF
--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -824,6 +824,10 @@ def _merge_shapes(shape1: ir.Shape | None, shape2: ir.Shape | None) -> ir.Shape 
 class FoldConstantsPass(ir.passes.InPlacePass):
     """A pass that folds constant expressions in the model.
 
+    .. NOTE::
+        ``ConstantOfShape`` will not be replaced unless explicitly specified in
+        ``always_fold_ops``.
+
     Attributes:
         shape_inference: Whether to perform shape inference.
         input_size_limit: Maximum size of input tensors to fold.


### PR DESCRIPTION
Suggested by https://github.com/microsoft/onnxscript/issues/2466, I updated the constant folder logic to 

1. Include an `allow_bloat` option. 
2. When `allow_bloat` and operator is in always fold list, we will fold the value
3. When `ConstantOfShape` is in the always fold list, we will replace it with Constant
4. When `allow_bloat` is False and operator is in always fold list, we will only fold if the large tensor has only one consumer.