### PR TITLE
Support aten::scatter.src

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -7592,7 +7592,7 @@ def aten_scalar_tensor_sym_number(
     return common_ops.cast_to(s, dtype=dtype)
 
 
-@torch_op("aten::scatter.value", trace_only=True)
+@torch_op(("aten::scatter.value", "aten::scatter.src"), trace_only=True)
 def aten_scatter(
     self: TReal,
     dim: int,  # we have to use int here because ScatterElements() will use this attribute


### PR DESCRIPTION
They are different ATen ops in terms of index type: Scalar or Tensor. The implementation in ONNX should be the same.

https://github.com/pytorch/pytorch/blame/8d6d3246316e1767a57d5e855acd6208da753b75/aten/src/ATen/native/native_functions.yaml#L8275-L8278

https://github.com/pytorch/pytorch/blame/8d6d3246316e1767a57d5e855acd6208da753b75/aten/src/ATen/native/native_functions.yaml#L8291-L8294