### PR TITLE
[torch api] Support down conversion of opsets

### DIFF
--- a/onnxscript/_framework_apis/torch_2_8.py
+++ b/onnxscript/_framework_apis/torch_2_8.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-"""Stable APIs for PyTorch 2.7."""
+"""Stable APIs for PyTorch 2.8."""
 
 from __future__ import annotations
 

--- a/onnxscript/_framework_apis/torch_2_9.py
+++ b/onnxscript/_framework_apis/torch_2_9.py
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Stable APIs for PyTorch 2.9."""
+
+from __future__ import annotations
+
+__all__ = [
+    "check_model",
+    "convert_version",
+    "get_torchlib_ops",
+    "optimize",
+    "save_model_with_external_data",
+]
+
+from typing import TYPE_CHECKING
+
+import onnx_ir as ir
+
+from onnxscript import version_converter
+from onnxscript._framework_apis.torch_2_8 import (
+    check_model,
+    get_torchlib_ops,
+    optimize,
+    save_model_with_external_data,
+)
+
+if TYPE_CHECKING:
+    from onnxscript import ir
+
+
+def convert_version(model: ir.Model, target_version: int) -> ir.Model:
+    """Convert the model to the specified ONNX opset version.
+
+    Starting from PyTorch 2.9, down conversion is turned on and supported.
+    """
+    version_converter.convert_version(model, target_version, fallback=True)
+    return model

--- a/onnxscript/version_converter/__init__.py
+++ b/onnxscript/version_converter/__init__.py
@@ -107,6 +107,13 @@ class _ConvertVersionPassRequiresInline(ir.passes.InPlacePass):
                 self.target_version,
             )
             return ir.passes.PassResult(model, False)
+        else:
+            logger.warning(
+                "The model version conversion is not supported by the onnxscript version converter "
+                "and fallback is enabled. The model will be converted using the onnx C API "
+                "(target version: %d).",
+                self.target_version,
+            )
 
         # If the onnxscript version converter does not support the conversion,
         # we can use the onnx C API to convert the model


### PR DESCRIPTION
Starting from PyTorch 2.9, down conversion is turned on and supported.