### PR TITLE
Add constant folding of Split with all constant inputs

### DIFF
--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -563,18 +563,18 @@ def split(node: ir.Node, op, _):
     # Option A: Sizes per split
     if len(node.inputs) == 2:
         # Skip non-constant splits
-        if (_split := ir.convenience.get_const_tensor(node.inputs[1])) is None:
+        if (split_ := ir.convenience.get_const_tensor(node.inputs[1])) is None:
             return None
         # Numpy expects splits as starting indices for each section
-        _split = np.cumsum(_split.numpy()[:-1])
+        split_ = np.cumsum(split_.numpy()[:-1])
 
     # Option B: Number of (even) splits
     elif (num_outputs := node.attributes.get("num_outputs")) is not None:
         # Numpy accepts single integer of (even) splits as well
-        _split = num_outputs.as_int()
+        split_ = num_outputs.as_int()
 
     # Unable to determine split configuration, skip optimization
-    if _split is None:
+    if split_ is None:
         return None
 
     # Default split axis is 0, according to ONNX operators reference:
@@ -583,7 +583,7 @@ def split(node: ir.Node, op, _):
         axis = ir.Attr("axis", ir.AttributeType.INT, 0)
 
     # Split constant tensor and wrap a list of Constant operators
-    splits = np.array_split(x.numpy(), _split, axis.as_int())
+    splits = np.array_split(x.numpy(), split_, axis.as_int())
     return [op.Constant(value=ir.tensor(x)) for x in splits]
 
 

--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -574,7 +574,7 @@ def split(node: ir.Node, op, _):
         # Numpy accepts single integer of (even) splits as well
         _split = num_outputs.as_int()
 
-    # Hm, something must be terribly wrong...
+    # Unable to determine split configuration, skip optimization
     if _split is None:
         return None
 

--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -558,7 +558,7 @@ def split(node: ir.Node, op, _):
     if (x := ir.convenience.get_const_tensor(node.inputs[0])) is None:
         return None
 
-    _split = None
+    split_ = None
 
     # Option A: Sizes per split
     if len(node.inputs) == 2:

--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -547,10 +547,9 @@ def sequence_construct(node: ir.Node, op, state: OptimizerState) -> ReturnValue:
     return None
 
 
-# Replaces Split operators with all constant inputs by a list of Constant
-# operators
 @register("Split")
 def split(node: ir.Node, op, _):
+    """Replaces Split operators with all constant inputs by a list of Constant operators."""
     # Replace single output split by Identity(x)
     if len(node.outputs) == 1:
         return op.Identity(node.inputs[0])

--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -569,7 +569,7 @@ def split(node: ir.Node, op, _):
         _split = np.cumsum(_split.numpy()[:-1])
 
     # Option B: Number of (even) splits
-    if (num_outputs := node.attributes.get("num_outputs")) is not None:
+    elif (num_outputs := node.attributes.get("num_outputs")) is not None:
         # Numpy accepts single integer of (even) splits as well
         _split = num_outputs.as_int()
 

--- a/onnxscript/optimizer/_constant_folding_test.py
+++ b/onnxscript/optimizer/_constant_folding_test.py
@@ -403,6 +403,98 @@ func (float[1,3] x) => (float[1,3] return_val) {
         ops = [node.op_type for node in nodes]
         self.assertEqual(ops, ["Identity", "Shape", "ConstantOfShape"])
 
+    def test_split_identity_num_outputs(self):
+        model = """
+            <ir_version: 8, opset_import: [ "" : 18]>
+            agraph (float[N] x) => (float[N] z)
+            {
+                z = Split <axis=-1, num_outputs=1> (x)
+            }
+        """
+
+        optimized = self._fold(model)
+        self.assertEqual(len(optimized.graph), 1)
+        self.assertEqual(len(optimized.graph[-1].outputs), 1)
+        self.assertEqual(optimized.graph[-1].op_type, "Identity")
+
+    def test_split_identity_splits(self):
+        model = """
+            <ir_version: 8, opset_import: [ "" : 18]>
+            agraph (float[N] x, float[1] split) => (float[N] z)
+            {
+                z = Split <axis=-1> (x, split)
+            }
+        """
+
+        optimized = self._fold(model)
+        self.assertEqual(len(optimized.graph), 1)
+        self.assertEqual(len(optimized.graph[-1].outputs), 1)
+        self.assertEqual(optimized.graph[-1].op_type, "Identity")
+
+
+    def test_split_constant_num_outputs_even(self):
+        model = """
+            <ir_version: 8, opset_import: [ "" : 18]>
+            agraph () => (float[N] z1, float[N] z2)
+            {
+                x = Constant <value: tensor = float[6] const {0,1,2,3,4,5}> ()
+                z1, z2 = Split <axis=-1, num_outputs=2> (x)
+            }
+        """
+
+        optimized = self._fold(model)
+        self.assertEqual(len(optimized.graph), 2)
+        self.assertEqual(len(optimized.graph[-2].outputs), 1)
+        self.assertEqual(len(optimized.graph[-1].outputs), 1)
+        self.assertEqual(optimized.graph[-2].outputs[0].shape, [3])
+        self.assertEqual(optimized.graph[-1].outputs[0].shape, [3])
+        self.assertEqual(optimized.graph[-2].op_type, "Constant")
+        self.assertEqual(optimized.graph[-1].op_type, "Constant")
+
+    def test_split_constant_num_outputs_odd(self):
+        model = """
+            <ir_version: 8, opset_import: [ "" : 18]>
+            agraph () => (float[N] z1, float[M] z2)
+            {
+                x = Constant <value: tensor = float[7] const {0,1,2,3,4,5,6}> ()
+                z1, z2 = Split <axis=-1, num_outputs=2> (x)
+            }
+        """
+
+        optimized = self._fold(model)
+        self.assertEqual(len(optimized.graph), 2)
+        self.assertEqual(len(optimized.graph[-2].outputs), 1)
+        self.assertEqual(len(optimized.graph[-1].outputs), 1)
+        self.assertEqual(optimized.graph[-2].outputs[0].shape, [4])
+        self.assertEqual(optimized.graph[-1].outputs[0].shape, [3])
+        self.assertEqual(optimized.graph[-2].op_type, "Constant")
+        self.assertEqual(optimized.graph[-1].op_type, "Constant")
+
+    def test_split_constant_splits(self):
+        model = """
+            <ir_version: 8, opset_import: [ "" : 18]>
+            agraph () => (float[N] z1, float[M] z2, float[L] z3, float[K] z4)
+            {
+                x = Constant <value: tensor = float[7] const {0,1,2,3,4,5,6}> ()
+                split = Constant <value_ints = [2, 3, 1, 1]> ()
+                z1, z2, z3, z4 = Split <axis=-1> (x, split)
+            }
+        """
+
+        optimized = self._fold(model)
+        self.assertEqual(len(optimized.graph), 4)
+        self.assertEqual(len(optimized.graph[-3].outputs), 1)
+        self.assertEqual(len(optimized.graph[-2].outputs), 1)
+        self.assertEqual(len(optimized.graph[-1].outputs), 1)
+        self.assertEqual(optimized.graph[-4].outputs[0].shape, [2])
+        self.assertEqual(optimized.graph[-3].outputs[0].shape, [3])
+        self.assertEqual(optimized.graph[-2].outputs[0].shape, [1])
+        self.assertEqual(optimized.graph[-1].outputs[0].shape, [1])
+        self.assertEqual(optimized.graph[-4].op_type, "Constant")
+        self.assertEqual(optimized.graph[-3].op_type, "Constant")
+        self.assertEqual(optimized.graph[-2].op_type, "Constant")
+        self.assertEqual(optimized.graph[-1].op_type, "Constant")
+
     def test_concat_identity(self):
         model = """
             <ir_version: 7, opset_import: [ "" : 17]>


### PR DESCRIPTION
Adds constant folding of Split with all constant inputs as well as replacing single-output Splits by Identity via the registry. Also adds 5 simple test cases covering both options: Second input specifying the sizes per split as well as nearly even splits into `num_outputs`  via the attribute. 