### PR TITLE
Increase DEFAULT_CONSTANT_FOLD_INPUT_SIZE_LIMIT

### DIFF
--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -19,7 +19,7 @@ import onnx_ir as ir
 import onnxscript.utils.utils as utils
 from onnxscript.ir import _tape
 
-DEFAULT_CONSTANT_FOLD_INPUT_SIZE_LIMIT = 512
+DEFAULT_CONSTANT_FOLD_INPUT_SIZE_LIMIT = 8192
 
 DEFAULT_CONSTANT_FOLD_OUTPUT_SIZE_LIMIT = 512 * 512
 


### PR DESCRIPTION
I have seen graphs like `Add(bias, 1)` in gemma3 where bias is an initializer. (Why?) This PR increases the default input limit so these bias initializers can be folded