### PR TITLE
More robust checks for FLOAT8E8M0

### DIFF
--- a/onnxscript/type_annotation.py
+++ b/onnxscript/type_annotation.py
@@ -70,11 +70,11 @@ ALL_TENSOR_TYPE_STRINGS = tuple(
         # TODO(after onnx requirement bump): Remove this check
         if (
             not (
-                hasattr(onnx.TensorProto, "FLOAT4E2M1")
+                not hasattr(onnx.TensorProto, "FLOAT4E2M1")
                 and tensor_type == onnx_types.FLOAT4E2M1
             )
             and not (
-                hasattr(onnx.TensorProto, "FLOAT8E8M0")
+                not hasattr(onnx.TensorProto, "FLOAT8E8M0")
                 and tensor_type == onnx_types.FLOAT8E8M0
             )
         )


### PR DESCRIPTION
Use hasattr instead of version checks to ensure existence of the FLOAT8E8M0 type.