### PR TITLE
[torchlib] Improve pixel_shuffle

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6711,7 +6711,7 @@ def aten_pixel_shuffle(self: TReal, upscale_factor: int) -> TReal:
     return op.Reshape(depth_to_space, output_shape, allowzero=True)
 
 
-@torch_op("aten::pixel_unshuffle")
+@torch_op("aten::pixel_unshuffle" trace_only=True)
 def aten_pixel_unshuffle(self: TReal, downscale_factor: int) -> TReal:
     """pixel_unshuffle(Tensor self, int downscale_factor) -> Tensor"""
     if len(self.shape) == 4:


### PR DESCRIPTION
Simplify the graph when input rank is 4, in which case we don't need to do any shape manipulation.

Fix https://github.com/pytorch/pytorch/issues/162061