### PR TITLE
[torchlib] Simplify linalg_vector_norm to remove the redundant Abs

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/linalg.py
+++ b/onnxscript/function_libs/torch_lib/ops/linalg.py
@@ -347,7 +347,7 @@ def aten_linalg_vector_norm(
         return op.ReduceL2(self, dim, keepdims=keepdim)
     else:
         if ord < 0 or ord % 2 != 0:
-            # Not-even integer, use abs
+            # Not an even integer (could be odd, fractional or negative), use Abs
             self = op.Abs(self)
         self_pow = op.Pow(self, ord)
         exp = op.CastLike(1 / ord, self)


### PR DESCRIPTION
This happens in some of the LORA models. When we use ReduceL1/ReduceL2 or when ord is an even number, we don't need to take Abs of the input

Signed-off-by: Justin Chu <justinchuby@users.noreply.github.com>