### PR TITLE
[torchlib] Support integers in logical_and/or ops and update other logical ops

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -166,6 +166,9 @@ def aten_add(self: TTensor, other: TTensor, alpha: float = 1.0) -> TTensor:
     """add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"""
 
     if self.dtype == ir.DataType.BOOL:
+        # alpha can also be bool
+        if alpha == 0:
+            return op.Identity(self)
         return op.Or(self, other)
 
     if alpha != 1.0:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5022,10 +5022,7 @@ def aten_logdet(self: TFloat) -> TFloat:
     return op.Log(op.Det(self))
 
 
-@torch_op(
-    ("aten::logical_and")
-    trace_only=True,
-)
+@torch_op(("aten::logical_and"), trace_only=True)
 def aten_logical_and(self: TTensor, other: TTensor) -> BOOL:
     """logical_and(Tensor self, Tensor other) -> Tensor"""
 
@@ -5045,14 +5042,7 @@ def aten_logical_not(self: BOOL) -> BOOL:
     return op.Not(op.Cast(self, to=BOOL.dtype))
 
 
-@torch_op(
-    (
-        "aten::logical_or",
-        "aten::add.Tensor",
-        "aten::add.Scalar"
-    ),
-    trace_only=True,
-)
+@torch_op(("aten::logical_or", "aten::add.Tensor", "aten::add.Scalar"), trace_only=True)
 def aten_logical_or(self: BOOL, other: BOOL) -> BOOL:
     """logical_or(Tensor self, Tensor other) -> Tensor"""
 
@@ -5063,10 +5053,7 @@ def aten_logical_or(self: BOOL, other: BOOL) -> BOOL:
     return op.Or(op.Cast(self, to=BOOL.dtype), op.Cast(other, to=BOOL.dtype))
 
 
-@torch_op(
-    ("aten::logical_xor")
-    trace_only=True,
-)
+@torch_op(("aten::logical_xor"), trace_only=True)
 def aten_logical_xor(self: BOOL, other: BOOL) -> BOOL:
     """logical_xor(Tensor self, Tensor other) -> Tensor"""
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5034,7 +5034,7 @@ def aten_logical_and(self: TTensor, other: TTensor) -> BOOL:
 
 
 @torch_op(("aten::logical_not", "aten::bitwise_not"), trace_only=True)
-def aten_logical_not(self: BOOL) -> BOOL:
+def aten_logical_not(self: TTensor) -> BOOL:
     """logical_not(Tensor self) -> Tensor"""
 
     if self.dtype == ir.DataType.BOOL:
@@ -5043,7 +5043,7 @@ def aten_logical_not(self: BOOL) -> BOOL:
 
 
 @torch_op(("aten::logical_or", "aten::add.Tensor", "aten::add.Scalar"), trace_only=True)
-def aten_logical_or(self: BOOL, other: BOOL) -> BOOL:
+def aten_logical_or(self: TTensor, other: TTensor) -> BOOL:
     """logical_or(Tensor self, Tensor other) -> Tensor"""
 
     assert self.dtype == other.dtype
@@ -5054,7 +5054,7 @@ def aten_logical_or(self: BOOL, other: BOOL) -> BOOL:
 
 
 @torch_op(("aten::logical_xor"), trace_only=True)
-def aten_logical_xor(self: BOOL, other: BOOL) -> BOOL:
+def aten_logical_xor(self: TTensor, other: TTensor) -> BOOL:
     """logical_xor(Tensor self, Tensor other) -> Tensor"""
 
     assert self.dtype == other.dtype

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -162,9 +162,12 @@ def aten_acosh(self: TFloat) -> TFloat:
 
 
 @torch_op(("aten::add.Tensor", "aten::add.Scalar", "_operator::add"), trace_only=True)
-def aten_add(self: TReal, other: TReal, alpha: float = 1.0) -> TReal:
+def aten_add(self: TTensor, other: TTensor, alpha: float = 1.0) -> TTensor:
     """add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"""
-    # TODO(microsoft/onnxruntime#15977): Improve fp16 precision
+
+    if self.dtype == ir.DataType.BOOL:
+        return op.Or(self, other)
+
     if alpha != 1.0:
         alpha = op.CastLike(alpha, other)
         other = op.Mul(other, alpha)
@@ -5045,7 +5048,7 @@ def aten_logical_not(self: TTensor) -> BOOL:
     return op.Not(op.Cast(self, to=BOOL.dtype))
 
 
-@torch_op(("aten::logical_or", "aten::add.Tensor", "aten::add.Scalar"), trace_only=True)
+@torch_op(("aten::logical_or"), trace_only=True)
 def aten_logical_or(self: TTensor, other: TTensor) -> BOOL:
     """logical_or(Tensor self, Tensor other) -> Tensor"""
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5025,7 +5025,7 @@ def aten_logdet(self: TFloat) -> TFloat:
     return op.Log(op.Det(self))
 
 
-@torch_op(("aten::logical_and"), trace_only=True)
+@torch_op("aten::logical_and", trace_only=True)
 def aten_logical_and(self: TTensor, other: TTensor) -> BOOL:
     """logical_and(Tensor self, Tensor other) -> Tensor"""
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -1333,11 +1333,14 @@ def aten_bitwise_left_shift_int8(self: INT8, other: INT8) -> INT8:
 
 
 @torch_op("aten::bitwise_not", trace_only=True)
-def aten_bitwise_not(self: TInt) -> TInt:
+def aten_bitwise_not(self: TTensor) -> TTensor:
     """bitwise_not(Tensor self) -> Tensor"""
-    # logical_not implements the BOOL variant
 
-    return op.BitwiseNot(self)
+    if self.dtype == ir.DataType.BOOL:
+        return op.Not(self)
+    if self.dtype.is_integer():
+        return op.BitwiseNot(self)
+    raise NotImplementedError(f"Not implemented for type {self.dtype}")
 
 
 @torch_op(
@@ -1348,7 +1351,7 @@ def aten_bitwise_not(self: TInt) -> TInt:
     ),
     trace_only=True,
 )
-def aten_bitwise_or(self: TInt, other: TInt) -> TInt:
+def aten_bitwise_or(self: TTensor, other: TTensor) -> TTensor:
     """bitwise_or.Tensor(Tensor self, Tensor other) -> Tensor"""
 
     assert self.dtype == other.dtype
@@ -1495,7 +1498,7 @@ def aten_bitwise_right_shift_int8(self: INT8, other: INT8) -> INT8:
     ),
     trace_only=True,
 )
-def aten_bitwise_xor(self: TInt, other: TInt) -> TInt:
+def aten_bitwise_xor(self: TTensor, other: TTensor) -> TTensor:
     """bitwise_xor.Tensor(Tensor self, Tensor other) -> Tensor"""
     assert self.dtype == other.dtype
 
@@ -5033,7 +5036,7 @@ def aten_logical_and(self: TTensor, other: TTensor) -> BOOL:
     return op.And(op.Cast(self, to=BOOL.dtype), op.Cast(other, to=BOOL.dtype))
 
 
-@torch_op(("aten::logical_not", "aten::bitwise_not"), trace_only=True)
+@torch_op("aten::logical_not", trace_only=True)
 def aten_logical_not(self: TTensor) -> BOOL:
     """logical_not(Tensor self) -> Tensor"""
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5033,9 +5033,7 @@ def aten_logical_and(self: TTensor, other: TTensor) -> BOOL:
 
     if self.dtype == ir.DataType.BOOL:
         return op.And(self, other)
-    if self.dtype.is_integer():
-        return op.And(op.Cast(self, to=BOOL.dtype), op.Cast(other, to=BOOL.dtype))
-    raise NotImplementedError(f"Not implemented for dtype {self.dtype} and {other.dtype}")
+    return op.And(op.Cast(self, to=BOOL.dtype), op.Cast(other, to=BOOL.dtype))
 
 
 @torch_op(("aten::logical_not", "aten::bitwise_not"), trace_only=True)
@@ -5044,9 +5042,7 @@ def aten_logical_not(self: BOOL) -> BOOL:
 
     if self.dtype == ir.DataType.BOOL:
         return op.Not(self)
-    if self.dtype.is_integer():
-        return op.Not(op.Cast(self, to=BOOL.dtype))
-    raise NotImplementedError(f"Not implemented for dtype {self.dtype}")
+    return op.Not(op.Cast(self, to=BOOL.dtype))
 
 
 @torch_op(
@@ -5064,9 +5060,7 @@ def aten_logical_or(self: BOOL, other: BOOL) -> BOOL:
 
     if self.dtype == ir.DataType.BOOL:
         return op.Or(self, other)
-    if self.dtype.is_integer():
-        return op.Or(op.Cast(self, to=BOOL.dtype), op.Cast(other, to=BOOL.dtype))
-    raise NotImplementedError(f"Not implemented for dtype {self.dtype} and {other.dtype}")
+    return op.Or(op.Cast(self, to=BOOL.dtype), op.Cast(other, to=BOOL.dtype))
 
 
 @torch_op(
@@ -5080,9 +5074,7 @@ def aten_logical_xor(self: BOOL, other: BOOL) -> BOOL:
 
     if self.dtype == ir.DataType.BOOL:
         return op.Xor(self, other)
-    if self.dtype.is_integer():
-        return op.Xor(op.Cast(self, to=BOOL.dtype), op.Cast(other, to=BOOL.dtype))
-    raise NotImplementedError(f"Not implemented for dtype {self.dtype} and {other.dtype}")
+    return op.Xor(op.Cast(self, to=BOOL.dtype), op.Cast(other, to=BOOL.dtype))
 
 
 @torch_op("aten::logit", private=True)

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5056,7 +5056,7 @@ def aten_logical_or(self: TTensor, other: TTensor) -> BOOL:
     return op.Or(op.Cast(self, to=BOOL.dtype), op.Cast(other, to=BOOL.dtype))
 
 
-@torch_op(("aten::logical_xor"), trace_only=True)
+@torch_op("aten::logical_xor", trace_only=True)
 def aten_logical_xor(self: TTensor, other: TTensor) -> BOOL:
     """logical_xor(Tensor self, Tensor other) -> Tensor"""
 

--- a/tests/function_libs/torch_lib/ops_test_data.py
+++ b/tests/function_libs/torch_lib/ops_test_data.py
@@ -1631,6 +1631,10 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         dtypes=(torch.float32 if sys.platform != "linux" else torch.complex64,),
         reason="fixme: test is unstable on macosx, windows",
     ),
+    TorchLibOpInfo("logical_and", core_ops.aten_logical_and),
+    TorchLibOpInfo("logical_not", core_ops.aten_logical_not),
+    TorchLibOpInfo("logical_or", core_ops.aten_logical_or),
+    TorchLibOpInfo("logical_xor", core_ops.aten_logical_xor),
     TorchLibOpInfo("logit", core_ops.aten_logit, tolerance={torch.float16: (1e-1, 7e-4)}),
     TorchLibOpInfo("max_dim", core_ops.aten_max_dim)
     .xfail(


### PR DESCRIPTION
This PR

1. Consolidates logic for `bitwise_*` functions so that the `logical_*` functions are no longer handling bool overloads of the bitwise ops.
2. Adds support for integer inputs in the `logical_*` implementations.

Replacement of #2579. 