### PR TITLE
Update torch api error message to include value names 

### DIFF
--- a/onnxscript/_framework_apis/torch_2_5.py
+++ b/onnxscript/_framework_apis/torch_2_5.py
@@ -67,12 +67,14 @@ def save_model_with_external_data(model: ir.Model, model_path: str | os.PathLike
     """Save the model with external data. The model is unchanged after saving."""
 
     # TODO(#1835): Decide if we want to externalize large attributes as well
-    for value in model.graph.initializers.values():
-        if value.const_value is None:
-            raise ValueError(
-                "The model contains uninitialized initializer values. "
-                "Please make sure all initializer values are initialized."
-            )
+    uninitialized_values = [
+        value.name for value in model.graph.initializers.values() if value.const_value is None
+    ]
+    if uninitialized_values:
+        raise ValueError(
+            f"The model contains uninitialized initializer values ({uninitialized_values}). "
+            "Please make sure all initializer values are initialized."
+        )
     destination_path = pathlib.Path(model_path)
     data_path = f"{destination_path.name}.data"
 


### PR DESCRIPTION
Update torch api error message to include value names when raising error on uninitialized values