### PR TITLE
Enhanced type annotations and simplified implementation of scatter.value

### DIFF
--- a/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/tests/function_libs/torch_lib/extra_opinfo.py
@@ -1407,9 +1407,9 @@ def sample_inputs_scatter_value(op_info, device, dtype, requires_grad, **kwargs)
         # (self_shape, index_shape, dim, value)
         ((5, 5), (2, 3), 0, 1.0),  # 2D scatter on dim=0 with scalar value
         ((5, 5), (3, 2), 1, -2.5),  # 2D scatter on dim=1 with scalar value
-        ((3, 4, 5), (2, 2, 3), 0, 0.0),  # 3D scatter on dim=0 with scalar value
+        ((3, 4, 5), (2, 2, 3), 0, False),  # 3D scatter on dim=0 with scalar value
         ((3, 4, 5), (2, 2, 3), 1, 3.14),  # 3D scatter on dim=1 with scalar value
-        ((3, 4, 5), (2, 2, 3), 2, -1.0),  # 3D scatter on dim=2 with scalar value
+        ((3, 4, 5), (2, 2, 3), 2, -1),  # 3D scatter on dim=2 with scalar value
         ((10,), (3,), 0, 5.0),  # 1D scatter with scalar value
     ]
 

--- a/tests/function_libs/torch_lib/ops_test_data.py
+++ b/tests/function_libs/torch_lib/ops_test_data.py
@@ -2109,7 +2109,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ),
     TorchLibOpInfo("ops.aten.slice_scatter", core_ops.aten_slice_scatter),
     TorchLibOpInfo("ops.aten.scatter.src", core_ops.aten_scatter_src),
-    TorchLibOpInfo("ops.aten.scatter.value", core_ops.aten_scatter_value),
+    TorchLibOpInfo("ops.aten.scatter.value", core_ops.aten_scatter_value_impl),
     TorchLibOpInfo("slice", core_ops.aten_slice),
     TorchLibOpInfo("slice", core_ops.aten_slice_complex, complex=True),
     TorchLibOpInfo(


### PR DESCRIPTION
follow #2605 

For the `value` argument in `aten::scatter.value`, since it is a `Scalar` type, it can accept `int`, `float`, and `bool`. However, type annotations using `Union` caused errors from Torch, so I implemented this using overloaded function signatures instead.
