### PR TITLE
Remove redundant registration of operator::add and fix sub.Scalar

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -132,7 +132,7 @@ def aten_acosh(self: TFloat) -> TFloat:
     return op.Acosh(self)
 
 
-@torch_op(("aten::add.Tensor", "aten::add.Scalar"), trace_only=True)
+@torch_op("aten::add.Tensor", trace_only=True)
 def aten_add(self: TTensor, other: TTensor, alpha: float = 1.0) -> TTensor:
     """add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"""
 
@@ -146,6 +146,14 @@ def aten_add(self: TTensor, other: TTensor, alpha: float = 1.0) -> TTensor:
         alpha = op.CastLike(alpha, other)
         other = op.Mul(other, alpha)
     return op.Add(self, other)
+
+
+@torch_op("aten::add.Scalar", trace_only=True)
+def aten_add_scalar(self: TTensor, other: float, alpha: float = 1.0) -> TTensor:
+    """add.Scalar(Tensor self, Scalar other, Scalar alpha=1) -> Tensor"""
+
+    other = op.Constant(value=ir.tensor(other, dtype=self.dtype))
+    return aten_add(self, other, alpha=alpha)
 
 
 @torch_op("_operator::add", trace_only=True)
@@ -8113,9 +8121,7 @@ def aten_std_mean_correction(
 @torch_op(
     (
         "aten::sub.Tensor",
-        "aten::sub.Scalar",
         "aten::subtract.Tensor",
-        "aten::subtract.Scalar",
         "_operator::sub",
     ),
     trace_only=True,
@@ -8126,6 +8132,14 @@ def aten_sub(self: TReal, other: TReal, alpha: float = 1.0) -> TReal:
         alpha = op.CastLike(alpha, other)
         other = op.Mul(other, alpha)
     return op.Sub(self, other)
+
+
+@torch_op(("aten::sub.Scalar", "aten::subtract.Scalar"), trace_only=True)
+def aten_sub_scalar(self: TTensor, other: float, alpha: float = 1.0) -> TTensor:
+    """sub.Scalar(Tensor self, Scalar other, Scalar alpha=1) -> Tensor"""
+
+    other = op.Constant(value=ir.tensor(other, dtype=self.dtype))
+    return aten_sub(self, other, alpha=alpha)
 
 
 @torch_op(


### PR DESCRIPTION
I forgot to remove the previous registration. Also fix aten.sub.Scalar.

Although I don't think we see the Scalar overload for these ops because we run the FX type promotion pass.