### PR TITLE
Fix GQA fusion to produce present key/value

### DIFF
--- a/onnxscript/rewriter/rules/fusion/_gqa.py
+++ b/onnxscript/rewriter/rules/fusion/_gqa.py
@@ -52,7 +52,7 @@ class OnnxGroupQueryAttention(pattern.RewriteRuleClassBase):
             _outputs=["attention_BHSDh"],
         )
 
-        return attention_BHSDh
+        return attention_BHSDh, present_key_BHkvStD, present_value_BHkvStD
 
     def check(
         self,
@@ -103,6 +103,7 @@ class OnnxGroupQueryAttention(pattern.RewriteRuleClassBase):
             past_key_BHkvSpD,
             past_value_BHkvSpD,
             **original_attrs,
+            _outputs=3,
         )
 
 


### PR DESCRIPTION
Output present key value from the Attention op because past key value is provided. Previously the Attention op created would consume past key/value but not produce present key/value, which is not correct for ORT.

<img width="1377" height="1225" alt="image" src="https://github.com/user-attachments/assets/118958b4-bc27-4912-b70b-000549887c0f" />

Replaces https://github.com/microsoft/onnxscript/pull/2632