### PR TITLE
Add a verbose mode to torch api for external data save

### DIFF
--- a/onnxscript/_framework_apis/torch_2_5.py
+++ b/onnxscript/_framework_apis/torch_2_5.py
@@ -85,7 +85,7 @@ def save_model_with_external_data(
     use_tqdm = verbose and importlib.util.find_spec("tqdm") is not None
 
     if use_tqdm:
-        import tqdm
+        import tqdm  # pylint: disable=import-outside-toplevel
 
         with tqdm.tqdm() as pbar:
             total_set = False


### PR DESCRIPTION
Show progress bar with tqdm when verbose is True.

It will be enabled in PyTorch 2.10

<img width="2261" height="171" alt="image" src="https://github.com/user-attachments/assets/3184a813-d6d3-4bbc-93ef-78fec481a36c" />
