### PR TITLE
Extend GQA fusion for Qwen

### DIFF
--- a/onnxscript/rewriter/ort_fusions/gqa.py
+++ b/onnxscript/rewriter/ort_fusions/gqa.py
@@ -309,7 +309,6 @@ class GroupQueryAttention(pattern.RewriteRuleClassBase):
         # and bindings["H"] * bindings["Dh"] == bindings["H*Dh"]:
         # or check Reshape's shape-input value
 
-        
         num_heads = _ir_utils.get_dim(query_BSHDh, 2)
         kv_num_heads = _ir_utils.get_dim(key_BSHkvDh, 2)
         if not isinstance(num_heads, int):


### PR DESCRIPTION
A couple of extensions to the GQA fusion pattern:

* Support the case where there is no past key/value cache, and
* Normalization and Transpose occur in the opposite order in Qwen (which has the same behavior). Support this pattern variation.

TODO: add test-cases to cover and validate this