### PR TITLE
Avoid initializer name collision in _fuse_batchnorm.py

### DIFF
--- a/onnxscript/rewriter/rules/common/_fuse_batchnorm.py
+++ b/onnxscript/rewriter/rules/common/_fuse_batchnorm.py
@@ -69,7 +69,8 @@ class _FuseBatchNormBase(RewriteRuleClassBase, ABC):
         else:
             original_bias = np.zeros_like(input_mean)
             # Use inbound input 1 (should be weight) to derive a name for the bias
-            # to avoid name collision on initializer creation.
+            # to avoid name collision on initializer creation when there are multiple patterns
+            # sharing the same parent nodes.
             bias_name = inbound_node.inputs[1].name + "_bias"
         fused_bias = ir.tensor((original_bias - input_mean) * scale_factor + beta)
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/166797

The original naming collides when there are multiple matched patterns sharing the same parent node. This PR changes the naming to depend on their own Conv weight name, which should be non-duplicated identifier.

~~NOTE: I don't know if my understanding is correct. It seems x is an input of the pattern, which x.name + "_bias" collides with `max_pool` bias (see the pic in the original issue)? If we check the output model after _fuse_batchnorm.py, the bias would be correct with a name `val_17` (the name may be collided and given by NameAuthority?). However, when the following rule _remove_optional_bias tries to fetch the bias, it would see all zero for some reasons.~~