### PR TITLE
[torchlib] Fix unbind.int if num_outputs=1

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -8958,9 +8958,10 @@ def aten_unbind(self: TTensor, dim: int = 0) -> Sequence[TTensor]:
         # We can create a definitive split op if the input shape is static
         # Only torch>=2.7 supports correctly generating the correct number of outputs for Split
         num_outputs = self.shape[dim]
-        outputs = op.Split(self, axis=dim, num_outputs=num_outputs)
-        if num_outputs == 1:
-            outputs = [outputs]
+        if num_outputs != 1:
+            outputs = op.Split(self, axis=dim, num_outputs=num_outputs)
+        else:
+            outputs = [self]
 
         return [op.Squeeze(out, [dim]) for out in outputs]
 


### PR DESCRIPTION
This fixes the issue of 
```
  return [op.Squeeze(out, [dim]) for out in outputs]
                                              ^^^^^^^
TypeError: 'SymbolicTensor' object is not iterable
```
when trying to export LSTM modules in `torch`.
This also already appeared in torch issues in https://github.com/pytorch/pytorch/issues/126339


The core seems to be the changes in #2597.
To my understanding the split returns a single `SymbolicTensor` instead of a sequence when `dim=1`.
The fix implemented here is the casting of the return type to a list.


I struggled with writing a test that reproduces this nicely in here, any guidance on that would be welcome.