### PR TITLE
Fix unused initializer check

### DIFF
--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -1419,7 +1419,7 @@ def _clear_unused_initializers(values: Sequence[ir.Value]) -> None:
         if value is None or not value.is_initializer():
             continue
 
-        if not value.uses():
+        if (not value.uses()) and (not value.is_graph_output()):
             assert value.is_initializer()
             assert value.graph is not None
             assert value.name is not None


### PR DESCRIPTION
The check for removing unused initializers in the constant-folder was not handling the case where the initializer is a graph output.

Fix #2728 