### PR TITLE
Add op test for torch.unique_consecutive

### DIFF
--- a/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/tests/function_libs/torch_lib/extra_opinfo.py
@@ -2270,6 +2270,16 @@ def sample_inputs_unique_dim(op_info, device, dtype, requires_grad, **kwargs):
             yield sample
 
 
+def sample_inputs_unique_consecutive(op_info, device, dtype, requires_grad, **kwargs):
+    for sample in common_methods_invocations.sample_inputs_unique(
+        op_info, device, dtype, requires_grad, **kwargs
+    ):
+        # unique_consecutive only supports dim=None or (dim=0 with rank=1)
+        # So filter out samples with dim != None
+        if sample.kwargs.get("dim") is None:
+            yield sample
+
+
 def sample_inputs_upsample_trilinear3d_vec(op_info, device, dtype, requires_grad, **kwargs):
     del op_info
     del kwargs
@@ -2875,6 +2885,14 @@ OP_DB: List[opinfo_core.OpInfo] = [
         aten_name="unique_dim.default",
         dtypes=common_dtype.floating_types_and(torch.float16, torch.int64, torch.int8),
         sample_inputs_func=sample_inputs_unique_dim,
+        supports_out=False,
+        supports_autograd=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.unique_consecutive",
+        aten_name="unique_consecutive",
+        dtypes=common_dtype.integral_types(),
+        sample_inputs_func=sample_inputs_unique_consecutive,
         supports_out=False,
         supports_autograd=False,
     ),

--- a/tests/function_libs/torch_lib/ops_test_data.py
+++ b/tests/function_libs/torch_lib/ops_test_data.py
@@ -1865,6 +1865,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
             "Our implementation is based on that for CUDA"
         ),
     ),
+    TorchLibOpInfo("ops.aten.unique_consecutive", core_ops.aten_unique_consecutive),
     TorchLibOpInfo("ops.prims.broadcast_in_dim.default", prims_ops.prims_broadcast_in_dim),
     TorchLibOpInfo(
         "ops.prims.var.default", prims_ops.prims_var, tolerance={torch.float16: (1e-3, 5e-2)}


### PR DESCRIPTION
## Summary
- Adds OpInfo-based test for `torch.unique_consecutive` operator
- Addresses issue #2695

## Changes
- Added `sample_inputs_unique_consecutive` function in `extra_opinfo.py` that filters samples from `common_methods_invocations.sample_inputs_unique` to only include cases with `dim=None` (as the implementation has limited dim support)
- Added `OpInfo` entry for `ops.aten.unique_consecutive` with `integral_types` dtypes (matching the implementation which only supports int32/int64)
- Added `TorchLibOpInfo` entry in `ops_test_data.py` to enable the test

## Testing
The test follows the same pattern as other unique operator tests (`_unique`, `_unique2`, `unique_dim`) and reuses PyTorch's standard test infrastructure.

Fixes #2695