### PR TITLE
Fix Issue #2736

### DIFF
--- a/onnxscript/optimizer/_constant_folding.py
+++ b/onnxscript/optimizer/_constant_folding.py
@@ -495,7 +495,7 @@ def reshape(node: ir.Node, op, state: OptimizerState) -> ReturnValue:
     for i, dim in enumerate(shape_value.dims):
         if isinstance(dim, ir.SymbolicDim) and dim.value is None:
             dynamic_indices.append(i)
-    
+
     if len(dynamic_indices) == 1:
         # Verify all other dimensions are concrete integers
         all_others_static = True
@@ -504,7 +504,7 @@ def reshape(node: ir.Node, op, state: OptimizerState) -> ReturnValue:
                 if not isinstance(dim, int):
                     all_others_static = False
                     break
-        
+
         if all_others_static:
             # Build new shape: replace dynamic dim with -1
             new_shape_list = []
@@ -513,16 +513,16 @@ def reshape(node: ir.Node, op, state: OptimizerState) -> ReturnValue:
                     new_shape_list.append(-1)
                 else:
                     new_shape_list.append(dim)
-            
+
             # Create a Constant node with static shape
             new_shape_const = op.Constant(value_ints=new_shape_list)
-            
+
             logger.debug(
                 "Reshape: eliminating dynamic shape subgraph, "
                 "replacing shape %s with static shape %s",
                 shape_value.dims, new_shape_list
             )
-            
+
             # Return new reshape with static shape
             return op.Reshape(input, new_shape_const)
 

--- a/onnxscript/optimizer/_constant_folding_test.py
+++ b/onnxscript/optimizer/_constant_folding_test.py
@@ -616,7 +616,7 @@ func (float[1,M] x, int64[3] split) => (float[1,M] return_val) {
 
     def test_reshape_eliminates_dynamic_shape_subgraph(self):
         """Test that Reshape with one dynamic dim is optimized to use -1.
-        
+
         Pattern: Shape -> Gather -> Concat -> Reshape
         When the resulting shape has exactly one dynamic dimension and all other
         dimensions are static integers, the optimizer should replace the dynamic
@@ -636,7 +636,7 @@ func (float[1,M] x, int64[3] split) => (float[1,M] return_val) {
             }
         """
         optimized = self._fold(model)
-        
+
         # Assert: No Shape, Gather, or Concat nodes remain in the graph
         for op_type in ["Shape", "Gather", "Concat"]:
             nodes = [n for n in optimized.graph if n.op_type == op_type]
@@ -644,7 +644,7 @@ func (float[1,M] x, int64[3] split) => (float[1,M] return_val) {
                 len(nodes), 0,
                 f"Expected no {op_type} nodes after optimization, found {len(nodes)}"
             )
-        
+
         # Assert: Graph contains either one Reshape or one Identity
         reshape_nodes = [n for n in optimized.graph if n.op_type == "Reshape"]
         identity_nodes = [n for n in optimized.graph if n.op_type == "Identity"]
@@ -652,14 +652,14 @@ func (float[1,M] x, int64[3] split) => (float[1,M] return_val) {
             len(reshape_nodes) == 1 or len(identity_nodes) == 1,
             f"Expected one Reshape or Identity node, found {len(reshape_nodes)} Reshape and {len(identity_nodes)} Identity"
         )
-        
+
         # If Reshape exists, assert its shape input is a Constant with exactly one -1
         if len(reshape_nodes) == 1:
             reshape_node = reshape_nodes[0]
             shape_input = reshape_node.inputs[1]
             self.assertIsNotNone(shape_input, "Reshape shape input should not be None")
             self.assertIsNotNone(shape_input.const_value, "Shape input should be a constant")
-            
+
             shape_array = shape_input.const_value.numpy()
             count_minus_one = np.count_nonzero(shape_array == -1)
             self.assertEqual(


### PR DESCRIPTION
### Fix Issue #2736

This change extends constant folding for `Reshape` to eliminate dynamic shape
subgraphs of the form `Shape → Gather → Concat → Reshape` when the target shape
contains exactly one dynamic dimension. The optimizer rewrites the reshape to
use a static `-1` dimension, relying on ONNX Reshape semantics to infer the
dynamic value from the input element count. This removes runtime shape
evaluation and enables further canonicalization.

### **Key Changes**

- **`onnxscript/optimizer/_constant_folding.py`**  
  Updated the `reshape` optimizer to detect reshape targets with exactly one
  dynamic dimension and replace the dynamic shape computation with a static
  shape containing `-1`.

- **`onnxscript/optimizer/_constant_folding_test.py`**  
  Added a unit test to verify that dynamic shape subgraphs (`Shape`, `Gather`,
  `Concat`) are eliminated and that the reshape is either rewritten with `-1`
  or folded away entirely.



