### PR TITLE
Remove creation of duplicate value

### DIFF
--- a/onnxscript/_internal/converter.py
+++ b/onnxscript/_internal/converter.py
@@ -1271,13 +1271,12 @@ class Converter:
             # TODO: retrieve the annotation for variable pv is any is specified.
             # typeinfo = self._eval_constant_expr(pv.annotation)
             typeinfo = None
-            self._current_fn.append_parameter(
-                make_value(onnx_var_name, typeinfo, self._source_of(loop_stmt))
-            )
+            parameter = make_value(onnx_var_name, typeinfo, self._source_of(loop_stmt))
+            self._current_fn.append_parameter(parameter)
             self._bind(
                 pv,
                 values.SymbolValue(
-                    ir.Value(name=onnx_var_name),
+                    parameter,
                     self._source_of(loop_stmt),
                 ),
             )


### PR DESCRIPTION
Remove creation of duplicate value when processing variables defined within a loop.