### PR TITLE
Fix SlicesSplit rewrite rule

### DIFF
--- a/onnxscript/rewriter/rules/common/_basic_rules.py
+++ b/onnxscript/rewriter/rules/common/_basic_rules.py
@@ -178,11 +178,11 @@ class SlicesSplit(RewriteRuleClassBase):
         axes = axes0.const_value.numpy().tolist()
         if len(axes) != 1:
             return check_result.fail("Axes has more than one dimension.")
-        if x.shape:
-            rk = len(x.shape)
+        if x.shape is not None:
+            rank = len(x.shape)
         else:
             return check_result.fail("Input rank is not known.")
-        if axes[0] != -1 and axes[0] != rk - 1:
+        if axes[0] != -1 and axes[0] != rank - 1:
             return check_result.fail("Axes is not -1 or last dimension.")
         if (
             begin0.const_value is None


### PR DESCRIPTION
The logic was incorrectly trying to access an attribute that does not exist.