### PR TITLE
Fix {lstm,gru}: slice hidden/cell state with sequence

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -4254,7 +4254,7 @@ def aten_gru(
         # Extract hidden state for this layer
         layer_start = layer_idx * num_directions
         layer_end = (layer_idx + 1) * num_directions
-        layer_h = op.Slice(hx, layer_start, layer_end, axes=[0])
+        layer_h = op.Slice(hx, [layer_start], [layer_end], axes=[0])
 
         # Extract parameters for this layer
         # Parameter layout: [W_ih, W_hh, b_ih, b_hh] for each direction


### PR DESCRIPTION
Per the spec, these two fields should be 1D-tensors:

> - starts (heterogeneous) - Tind:  
>   1-D tensor of starting indices of corresponding axis in axes
>
> - ends (heterogeneous) - Tind:  
>   1-D tensor of ending indices (exclusive) of corresponding axis in axes

With the original code; the output is like this when printing the graph:
```
   <snip> int64 val_1 =  {1}, int64 val_3 =  {0}, <snip>

   [node_Slice_5] val_5 = Slice (transpose_1, val_3, val_1, val_4)
   [node_Slice_6] val_6 = Slice (transpose_2, val_3, val_1, val_4)
```
With the changes:
```
   <snip> int64[1] val_3 =  {0}, int64[1] val_4 =  {1}, <snip>

   [node_Slice_5] val_5 = Slice (transpose_1, val_3, val_4, val_3)
   [node_Slice_6] val_6 = Slice (transpose_2, val_3, val_4, val_3)
```
This being scalar was seemingly accepted by the ONNX reference evaluator and potentially other runtimes, but not in [tract](https://github.com/sonos/tract). 