### PR TITLE
Remove unused function before version converter

### DIFF
--- a/onnxscript/version_converter/__init__.py
+++ b/onnxscript/version_converter/__init__.py
@@ -49,7 +49,7 @@ class ConvertVersionPass(ir.passes.InPlacePass):
             target_version=target_version,
             fallback=fallback,
         )
-        self._cleanup_passes_after = ir.passes.Sequential(
+        self._cleanup_passes = ir.passes.Sequential(
             common_passes.RemoveUnusedNodesPass(),
             common_passes.RemoveUnusedFunctionsPass(),
             common_passes.RemoveUnusedOpsetsPass(),


### PR DESCRIPTION
In old torch versions, until 2.9, the converted models include unused Rank onnx function which blocks version converter to function.