### PR TITLE
[torchlib] Fix torchvision::roi_align lowering to accept 7-arg schema

### DIFF
--- a/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/tests/function_libs/torch_lib/extra_opinfo.py
@@ -1474,13 +1474,17 @@ def sample_inputs_roi_align(op_info, device, dtype, requires_grad, **kwargs):
     del op_info, kwargs
 
     def make_x():
-        return torch.rand(1, 1, 10, 10, dtype=dtype, device=device, requires_grad=requires_grad)
+        return torch.rand(
+            1, 1, 10, 10, dtype=dtype, device=device, requires_grad=requires_grad
+        )
 
     # rois is [K, 5] = [batch_idx, x1, y1, x2, y2]
     roi_a = torch.tensor([[0, 1.5, 1.5, 3.0, 3.0]], dtype=dtype, device=device)
     roi_b = torch.tensor([[0, 0.2, 0.3, 4.5, 3.5]], dtype=dtype, device=device)
     roi_int = torch.tensor([[0, 0.0, 0.0, 4.0, 4.0]], dtype=dtype, device=device)
-    roi_malformed = torch.tensor([[0, 2.0, 0.3, 1.5, 1.5]], dtype=dtype, device=device)  # x1 > x2-ish
+    roi_malformed = torch.tensor(
+        [[0, 2.0, 0.3, 1.5, 1.5]], dtype=dtype, device=device
+    )  # x1 > x2-ish
 
     # (rois, spatial_scale, pooled_h, pooled_w, sampling_ratio, aligned)
     cases = [

--- a/tests/function_libs/torch_lib/ops_test_data.py
+++ b/tests/function_libs/torch_lib/ops_test_data.py
@@ -448,6 +448,7 @@ def _where_input_wrangler(
     args[0], args[1] = args[1], args[0]
     return args, kwargs
 
+
 # Ops to be tested for numerical consistency between onnx and pytorch
 # Find the names of the OpInfos in torch/testing/_internal/common_methods_invocations.py
 TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (


### PR DESCRIPTION
Dynamo ONNX export calls torchvision::roi_align with (input, rois, spatial_scale,
pooled_h, pooled_w, sampling_ratio, aligned), but torchlib’s lowering expected
output_size and rejected the extra args.

Update torchvision_roi_align to take pooled_h/pooled_w directly and add an OpInfo
input_wrangler to adapt wrapper-style roi_align(input, boxes, output_size, ...).

Refs pytorch/pytorch#175732
Test: pytest tests/function_libs/torch_lib/ops_test.py -k roi_align -v