### PR TITLE
Expose OpBuilder as onnxscript.OpBuilder

### DIFF
--- a/onnxscript/__init__.py
+++ b/onnxscript/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     "OnnxFunction",
     "TracedOnnxFunction",
     "GraphBuilder",
+    "OpBuilder",
     "proto2python",
     "external_tensor",
     "BFLOAT16",
@@ -129,7 +130,7 @@ from .onnx_types import (
 # isort: on
 
 from . import ir, nn, optimizer, rewriter, version_converter
-from ._internal.builder import GraphBuilder
+from ._internal.builder import GraphBuilder, OpBuilder
 from ._internal.utils import external_tensor
 from ._internal.values import OnnxFunction, TracedOnnxFunction
 


### PR DESCRIPTION
Add OpBuilder to __all__ and import it from _internal.builder in the top-level onnxscript package.