### PR TITLE
Handling initializers in GraphBuilder

### DIFF
--- a/onnxscript/_internal/builder.py
+++ b/onnxscript/_internal/builder.py
@@ -129,13 +129,10 @@ def lift_initializers_to_constants(graph: ir.Graph) -> None:
 # :meth:`GraphBuilder.subgraph`.  Can be an already-resolved
 # :class:`ir.TypeAndShape`, or a
 # :class:`~onnxscript.onnx_types.TensorType` subclass such as ``FLOAT[1024]``.
+#
+# .. deprecated::
+#     Use ``ir.Value`` with name/type/shape directly instead.
 TypeSpec = Union[ir.TypeAndShape, Any]
-
-# Acceptable collection forms for *inputs* / *outputs* in
-# :meth:`GraphBuilder.subgraph`.  A :class:`Sequence` of :data:`TypeSpec`
-# auto-names entries (``input_0``, ``input_1``, …), while a :class:`Mapping`
-# from :class:`str` to :data:`TypeSpec` uses the keys as explicit names.
-InputOutputSpec = Union[Sequence[TypeSpec], Mapping[str, TypeSpec]]
 
 
 def _resolve_type_spec(spec: TypeSpec) -> ir.TypeAndShape:
@@ -145,6 +142,9 @@ def _resolve_type_spec(spec: TypeSpec) -> ir.TypeAndShape:
     ``to_ir_type_and_shape()`` method (e.g. a
     :class:`~onnxscript.onnx_types.TensorType` subclass such as
     ``FLOAT[1024]`` or ``FLOAT['M', 'N']``).
+
+    .. deprecated::
+        Use :func:`make_input` or construct ``ir.Value`` directly instead.
     """
     if isinstance(spec, ir.TypeAndShape):
         return spec
@@ -162,24 +162,64 @@ def _resolve_type_spec(spec: TypeSpec) -> ir.TypeAndShape:
     )
 
 
-def _normalize_io_spec(
-    spec: InputOutputSpec, default_prefix: str
-) -> list[tuple[str, ir.TypeAndShape]]:
-    """Normalize an *InputOutputSpec* into a list of ``(name, TypeAndShape)`` pairs.
+def make_input(name: str, type_spec: TypeSpec | None = None) -> ir.Value:
+    """Create an :class:`ir.Value` from a name and optional :data:`TypeSpec`.
 
-    When *spec* is a :class:`Mapping`, the keys are used as names.  When it is
-    a plain :class:`Sequence`, names are generated as
-    ``{default_prefix}_0``, ``{default_prefix}_1``, etc.
+    This is a convenience for constructing graph/function inputs without
+    manually building ``ir.TensorType`` and ``ir.Shape`` objects.
+
+    Example::
+
+        x = make_input("x", FLOAT[3, 4])
+        y = make_input("y")  # untyped
+
+    Args:
+        name: The input name.
+        type_spec: Optional type specification.  Accepts an
+            :class:`ir.TypeAndShape`, or a
+            :class:`~onnxscript.onnx_types.TensorType` subclass
+            (e.g. ``FLOAT[3, 4]``).
+
+    Returns:
+        A fresh :class:`ir.Value` with the given name and optional type/shape.
     """
-    if isinstance(spec, Mapping):
-        return [(name, _resolve_type_spec(ts)) for name, ts in spec.items()]
-    return [(f"{default_prefix}_{i}", _resolve_type_spec(ts)) for i, ts in enumerate(spec)]
+    if type_spec is not None:
+        ts = _resolve_type_spec(type_spec)
+        return ir.Value(name=name, type=ts.type, shape=ts.shape)
+    return ir.Value(name=name)
+
+
+def _split_optional_inputs(
+    inputs: Sequence[ir.Value | None],
+) -> tuple[list[ir.Value | None], list[ir.Value]]:
+    """Split an input list into trace args and graph inputs.
+
+    Returns:
+        A tuple of (trace_args, graph_inputs) where trace_args preserves
+        ``None`` holes and graph_inputs contains only non-``None`` values.
+
+    Raises:
+        ValueError: If any non-None input already has a producer or is
+            already attached to a graph.
+    """
+    trace_args: list[ir.Value | None] = list(inputs)
+    graph_inputs: list[ir.Value] = []
+    for v in trace_args:
+        if v is None:
+            continue
+        if v.producer() is not None:
+            raise ValueError(
+                f"Input {v.name!r} already has a producer node. "
+                f"Pass freshly created ir.Value objects."
+            )
+        graph_inputs.append(v)
+    return trace_args, graph_inputs
 
 
 def build_graph(
     trace_function: Callable,
-    inputs: InputOutputSpec,
-    outputs: InputOutputSpec,
+    inputs: Sequence[ir.Value | None],
+    outputs: Sequence[ir.Value],
     *,
     opset_imports: dict[str, int] | None = None,
     name: str = "subgraph",
@@ -195,24 +235,24 @@ def build_graph(
 
         body = build_graph(
             lambda op, x, y: op.Add(x, y),
-            inputs={"x": FLOAT[...], "y": FLOAT[...]},
-            outputs={"sum": FLOAT[...]},
+            inputs=[make_input("x", FLOAT[3, 4]), make_input("y", FLOAT[3, 4])],
+            outputs=[make_input("sum", FLOAT[3, 4])],
         )
 
     Args:
         trace_function: A callable with signature
-            ``(op: OpBuilder, *inputs: ir.Value) -> ir.Value | Sequence[ir.Value]``.
+            ``(op: OpBuilder, *inputs: ir.Value | None) -> ir.Value | Sequence[ir.Value]``.
             It is called once with freshly created placeholder inputs to record the
-            graph topology.
-        inputs: Types (and optionally names) for each graph input.  May be a
-            :class:`Sequence` of :data:`TypeSpec` values (names are auto-generated
-            as ``input_0``, ``input_1``, …) **or** a :class:`Mapping` from
-            :class:`str` names to :data:`TypeSpec` values.  Each :data:`TypeSpec`
-            can be an :class:`ir.TypeAndShape` or a
-            :class:`~onnxscript.onnx_types.TensorType` subclass (e.g.
-            ``FLOAT[1024]`` or ``FLOAT['M', 'N']``).
-        outputs: Types (and optionally names) for each graph output, in the
-            same format as *inputs*.
+            graph topology.  ``None`` entries in *inputs* are passed through as ``None``
+            to support optional inputs.
+        inputs: A :class:`Sequence` of :class:`ir.Value` (or ``None`` for
+            absent optional inputs).  Each ``ir.Value`` should be freshly
+            created with a name and optional type/shape.  ``None`` entries
+            are excluded from the graph inputs but passed as ``None`` to
+            *trace_function*.
+        outputs: A :class:`Sequence` of :class:`ir.Value` objects declaring
+            the expected outputs.  After tracing, the name and type of each
+            declared output are applied to the corresponding returned value.
         opset_imports: Opset version map for the subgraph (e.g.
             ``{"": 23}``).  Defaults to ``{"": 23}`` when *None*.
         name: Name of the resulting :class:`ir.Graph`.
@@ -229,38 +269,140 @@ def build_graph(
     """
     if opset_imports is None:
         opset_imports = {"": 23}
-    resolved_inputs = _normalize_io_spec(inputs, "input")
-    resolved_outputs = _normalize_io_spec(outputs, "output")
+
+    trace_args, graph_inputs = _split_optional_inputs(inputs)
 
     subgraph = ir.Graph(
         name=name,
-        inputs=[],
+        inputs=graph_inputs,
         outputs=[],
         nodes=[],
         opset_imports=opset_imports,
     )
 
-    for input_name, ts in resolved_inputs:
-        subgraph.inputs.append(ir.Value(name=input_name, type=ts.type, shape=ts.shape))
-
     sub_builder = GraphBuilder(subgraph, parent=parent)
     if parent is not None:
         sub_builder._scope_stack = list(parent._scope_stack)
-    trace_outputs = trace_function(sub_builder.op, *subgraph.inputs)
+    trace_outputs = trace_function(sub_builder.op, *trace_args)
     if not isinstance(trace_outputs, Sequence):
         trace_outputs = [trace_outputs]
-    if len(trace_outputs) != len(resolved_outputs):
+    if len(trace_outputs) != len(outputs):
         raise ValueError(
             f"trace_function returned {len(trace_outputs)} output(s), "
-            f"but {len(resolved_outputs)} were declared in outputs."
+            f"but {len(outputs)} were declared in outputs."
         )
-    for output, (output_name, ts) in zip(trace_outputs, resolved_outputs):
-        output.name = output_name
-        output.type = ts.type
-        output.merge_shapes(ts.shape)
+    for returned_val, declared_val in zip(trace_outputs, outputs):
+        if declared_val.name:
+            returned_val.name = declared_val.name
+        if declared_val.type is not None:
+            if returned_val.type is not None and returned_val.type != declared_val.type:
+                raise ValueError(
+                    f"Output {declared_val.name!r}: traced type "
+                    f"{returned_val.type} conflicts with declared type "
+                    f"{declared_val.type}."
+                )
+            returned_val.type = declared_val.type
+        if declared_val.shape is not None:
+            returned_val.merge_shapes(declared_val.shape)
 
     subgraph.outputs.extend(trace_outputs)
     return subgraph
+
+
+def build_function(
+    trace_function: Callable,
+    inputs: Sequence[ir.Value | None],
+    *,
+    domain: str,
+    name: str,
+    attributes: Mapping[str, ir.Attr] | Sequence[ir.Attr] | None = None,
+    opset_imports: dict[str, int] | None = None,
+) -> ir.Function:
+    """Build an :class:`ir.Function` by tracing *trace_function*.
+
+    This utility handles all boilerplate for constructing an ``ir.Function``:
+    graph creation, input/output wiring, initializer lifting (so that Python
+    literals work correctly inside function bodies), and attribute packaging.
+
+    Example::
+
+        fn = build_function(
+            lambda op, x, y: op.Add(x, y),
+            [make_input("x"), make_input("y")],
+            domain="com.example",
+            name="MyAdd",
+        )
+
+    Args:
+        trace_function: A callable with signature
+            ``(op: OpBuilder, *inputs: ir.Value | None) -> ir.Value | Sequence[ir.Value] | None``.
+            It is called once to trace the function body.  Return value(s)
+            become function outputs.  If ``None`` is returned, the function
+            uses whatever outputs were appended to ``graph.outputs`` by the
+            trace function directly.
+        inputs: A :class:`Sequence` of :class:`ir.Value` (or ``None`` for
+            absent optional inputs).  ``None`` entries are excluded from the
+            function's formal inputs but passed as ``None`` to
+            *trace_function* so the body can branch with ``if x is None``.
+        domain: Function domain (e.g. ``"com.microsoft"``).
+        name: Function name (e.g. ``"LinearAttention"``).
+        attributes: Function-level attributes.  Accepts a
+            :class:`Mapping` from name to :class:`ir.Attr`, a
+            :class:`Sequence` of :class:`ir.Attr`, or ``None``.
+        opset_imports: Opset version map.  Defaults to ``{"": 23}``.
+
+    Returns:
+        An :class:`ir.Function` with initializers automatically lifted to
+        ``Constant`` nodes.
+    """
+    if opset_imports is None:
+        opset_imports = {"": 23}
+
+    trace_args, graph_inputs = _split_optional_inputs(inputs)
+
+    graph = ir.Graph(
+        inputs=graph_inputs,
+        outputs=[],
+        nodes=[],
+        name=f"{name}_body",
+        opset_imports=opset_imports,
+    )
+
+    gb = GraphBuilder(graph)  # No parent — function is self-contained
+    trace_outputs = trace_function(gb.op, *trace_args)
+
+    # Normalize outputs: either returned or appended directly, not both.
+    if trace_outputs is not None:
+        if not isinstance(trace_outputs, Sequence):
+            trace_outputs = [trace_outputs]
+        if graph.outputs:
+            raise ValueError(
+                "trace_function both returned output values and appended "
+                "to graph.outputs. Use one approach, not both."
+            )
+        graph.outputs.extend(trace_outputs)
+    elif not graph.outputs:
+        raise ValueError(
+            "trace_function returned None and did not append any outputs to graph.outputs."
+        )
+
+    # Lift initializers → Constant nodes (required for ir.Function bodies).
+    lift_initializers_to_constants(graph)
+
+    # Build attributes dict.
+    if attributes is None:
+        attr_dict: dict[str, ir.Attr] = {}
+    elif isinstance(attributes, Mapping):
+        attr_dict = dict(attributes)
+    else:
+        attr_dict = {a.name: a for a in attributes}
+
+    return ir.Function(
+        domain=domain,
+        name=name,
+        graph=graph,
+        attributes=attr_dict,
+    )
 
 
 class GraphBuilder:
@@ -590,8 +732,8 @@ class GraphBuilder:
     def subgraph(
         self,
         trace_function: Callable,
-        inputs: InputOutputSpec,
-        outputs: InputOutputSpec,
+        inputs: Sequence[ir.Value | None],
+        outputs: Sequence[ir.Value],
         *,
         name: str = "subgraph",
     ) -> ir.Graph:
@@ -605,33 +747,20 @@ class GraphBuilder:
 
             body = graph_builder.subgraph(
                 lambda op, x, y: op.Add(x, y),
-                inputs=[FLOAT[...], FLOAT[...]],
-                outputs=[FLOAT[...]],
-            )
-
-        Inputs and outputs can also be given as a :class:`dict` to assign
-        explicit names::
-
-            body = graph_builder.subgraph(
-                lambda op, x, y: op.Add(x, y),
-                inputs={"x": FLOAT[...], "y": FLOAT[...]},
-                outputs={"sum": FLOAT[...]},
+                inputs=[make_input("x", FLOAT[...]), make_input("y", FLOAT[...])],
+                outputs=[make_input("sum", FLOAT[...])],
             )
 
         Args:
             trace_function: A callable with signature
-                ``(op: OpBuilder, *inputs: ir.Value) -> ir.Value | Sequence[ir.Value]``.
+                ``(op: OpBuilder, *inputs: ir.Value | None) -> ir.Value | Sequence[ir.Value]``.
                 It is called once with freshly created placeholder inputs to record the
                 graph topology.
-            inputs: Types (and optionally names) for each graph input.  May be a
-                :class:`Sequence` of :data:`TypeSpec` values (names are auto-generated
-                as ``input_0``, ``input_1``, …) **or** a :class:`Mapping` from
-                :class:`str` names to :data:`TypeSpec` values.  Each :data:`TypeSpec`
-                can be an :class:`ir.TypeAndShape` or a
-                :class:`~onnxscript.onnx_types.TensorType` subclass (e.g.
-                ``FLOAT[1024]`` or ``FLOAT['M', 'N']``).
-            outputs: Types (and optionally names) for each graph output, in the
-                same format as *inputs*.
+            inputs: A :class:`Sequence` of :class:`ir.Value` (or ``None``
+                for absent optional inputs).  Each ``ir.Value`` should be
+                freshly created with a name and optional type/shape.
+            outputs: A :class:`Sequence` of :class:`ir.Value` objects
+                declaring the expected outputs.
             name: Name of the resulting :class:`ir.Graph`.
 
         Returns:

--- a/onnxscript/_internal/builder.py
+++ b/onnxscript/_internal/builder.py
@@ -112,6 +112,7 @@ def lift_initializers_to_constants(graph: ir.Graph) -> None:
             attributes=[ir.Attr("value", ir.AttributeType.TENSOR, tensor)],
             outputs=[value],
             version=opset_version,
+            name=f"initializer_{value.name}",
         )
         graph.initializers.pop(value.name)
         new_nodes.append(node)

--- a/onnxscript/_internal/builder.py
+++ b/onnxscript/_internal/builder.py
@@ -221,6 +221,11 @@ def _split_optional_inputs(
                     f"Input {v.name!r} already has a producer node. "
                     f"Pass freshly created ir.Value objects."
                 )
+            if v.graph is not None:
+                raise ValueError(
+                    f"Input {v.name!r} is already attached to a graph. "
+                    f"Pass freshly created ir.Value objects."
+                )
             graph_inputs.append(v)
     return trace_args, graph_inputs
 
@@ -257,9 +262,10 @@ def build_graph(
             to support optional inputs.
         inputs: A :class:`Sequence` of :class:`ir.Value` (or ``None`` for
             absent optional inputs).  Each ``ir.Value`` should be freshly
-            created with a name and optional type/shape.  ``None`` entries
-            are excluded from the graph inputs but passed as ``None`` to
-            *trace_function*.
+            created with a name and optional type/shape.  For ``None``
+            entries, placeholder values are declared as formal graph inputs,
+            while ``None`` is passed to *trace_function* for the
+            corresponding argument position.
         outputs: A :class:`Sequence` of :class:`ir.Value` objects declaring
             the expected outputs.  After tracing, the name and type of each
             declared output are applied to the corresponding returned value.
@@ -349,9 +355,11 @@ def build_function(
             uses whatever outputs were appended to ``graph.outputs`` by the
             trace function directly.
         inputs: A :class:`Sequence` of :class:`ir.Value` (or ``None`` for
-            absent optional inputs).  ``None`` entries are excluded from the
-            function's formal inputs but passed as ``None`` to
-            *trace_function* so the body can branch with ``if x is None``.
+            absent optional inputs).  ``None`` entries are represented by
+            placeholder formal inputs in the generated function signature,
+            while ``None`` is passed through to *trace_function* in the
+            corresponding positions so the body can branch with
+            ``if x is None``.
         domain: Function domain (e.g. ``"com.microsoft"``).
         name: Function name (e.g. ``"LinearAttention"``).
         attributes: Function-level attributes.  Accepts a

--- a/onnxscript/_internal/builder.py
+++ b/onnxscript/_internal/builder.py
@@ -230,7 +230,7 @@ def build_graph(
     inputs: Sequence[ir.Value | None],
     outputs: Sequence[ir.Value],
     *,
-    opset_imports: dict[str, int] | None = None,
+    opset_imports: dict[str, int],
     name: str = "subgraph",
     parent: GraphBuilder | None = None,
 ) -> ir.Graph:
@@ -246,6 +246,7 @@ def build_graph(
             lambda op, x, y: op.Add(x, y),
             inputs=[make_value("x", FLOAT[3, 4]), make_value("y", FLOAT[3, 4])],
             outputs=[make_value("sum", FLOAT[3, 4])],
+            opset_imports={"": 23},
         )
 
     Args:
@@ -263,7 +264,7 @@ def build_graph(
             the expected outputs.  After tracing, the name and type of each
             declared output are applied to the corresponding returned value.
         opset_imports: Opset version map for the subgraph (e.g.
-            ``{"": 23}``).  Defaults to ``{"": 23}`` when *None*.
+            ``{"": 23}``).
         name: Name of the resulting :class:`ir.Graph`.
         parent: Optional parent :class:`GraphBuilder`.  When provided, the
             sub-builder's ``_root`` points to the root builder of the parent,
@@ -276,9 +277,6 @@ def build_graph(
         passed directly as a graph-valued attribute (e.g. the ``body`` attribute of
         a ``Scan`` or ``Loop`` node).
     """
-    if opset_imports is None:
-        opset_imports = {"": 23}
-
     trace_args, graph_inputs = _split_optional_inputs(inputs)
 
     subgraph = ir.Graph(
@@ -325,7 +323,7 @@ def build_function(
     domain: str,
     name: str,
     attributes: Mapping[str, ir.Attr] | Sequence[ir.Attr] | None = None,
-    opset_imports: dict[str, int] | None = None,
+    opset_imports: dict[str, int],
 ) -> ir.Function:
     """Build an :class:`ir.Function` by tracing *trace_function*.
 
@@ -340,6 +338,7 @@ def build_function(
             [make_value("x"), make_value("y")],
             domain="com.example",
             name="MyAdd",
+            opset_imports={"": 23},
         )
 
     Args:
@@ -358,15 +357,12 @@ def build_function(
         attributes: Function-level attributes.  Accepts a
             :class:`Mapping` from name to :class:`ir.Attr`, a
             :class:`Sequence` of :class:`ir.Attr`, or ``None``.
-        opset_imports: Opset version map.  Defaults to ``{"": 23}``.
+        opset_imports: Opset version map (e.g. ``{"": 23}``).
 
     Returns:
         An :class:`ir.Function` with initializers automatically lifted to
         ``Constant`` nodes.
     """
-    if opset_imports is None:
-        opset_imports = {"": 23}
-
     trace_args, graph_inputs = _split_optional_inputs(inputs)
 
     graph = ir.Graph(

--- a/onnxscript/_internal/builder.py
+++ b/onnxscript/_internal/builder.py
@@ -75,6 +75,56 @@ def _constant_name(
     return f"const_1d_{num}"
 
 
+def lift_initializers_to_constants(graph: ir.Graph) -> None:
+    """Replace every initializer in *graph* with a ``Constant`` node.
+
+    ONNX ``ir.Function`` bodies do not support initializers — all values
+    must be produced by nodes.  Call this on the function-body graph
+    **before** wrapping it in :class:`ir.Function` so that any constant
+    initializers (e.g. from Python literals promoted by
+    :class:`GraphBuilder`) become valid ``Constant`` nodes.
+
+    The function preserves ``ir.Value`` identity: it reuses each existing
+    ``ir.Value`` object as the output of the new ``Constant`` node so that
+    all downstream references remain valid.
+
+    Graph inputs that are *also* registered as initializers (the standard
+    ONNX pattern for optional inputs with default values) are skipped
+    because they are explicit function parameters, not embedded constants.
+    """
+    graph_input_set = set(id(v) for v in graph.inputs)
+    to_lift: list[ir.Value] = [
+        v
+        for v in list(graph.initializers.values())
+        if id(v) not in graph_input_set
+    ]
+    opset_version = graph.opset_imports.get("", 1)
+    new_nodes: list[ir.Node] = []
+    for value in to_lift:
+        tensor = value.const_value
+        assert tensor is not None, f"Initializer {value.name!r} has no const_value"
+        # Build a Constant node whose output is the *same* ir.Value so
+        # that every existing reference keeps working.
+        node = ir.Node(
+            "",
+            "Constant",
+            inputs=[],
+            attributes=[ir.Attr("value", ir.AttributeType.TENSOR, tensor)],
+            outputs=[value],
+            version=opset_version,
+        )
+        graph.initializers.pop(value.name)
+        new_nodes.append(node)
+    # Insert all Constant nodes at the beginning of the graph.
+    if new_nodes:
+        first_existing = graph.node(0) if graph.num_nodes() > 0 else None
+        if first_existing is not None:
+            graph.insert_before(first_existing, new_nodes)
+        else:
+            for n in new_nodes:
+                graph.append(n)
+
+
 # Type accepted as an element of *inputs* / *outputs* by
 # :meth:`GraphBuilder.subgraph`.  Can be an already-resolved
 # :class:`ir.TypeAndShape`, or a
@@ -234,10 +284,13 @@ class GraphBuilder:
         # class_name is the qualified class name (e.g. "Gemma3DecoderLayer").
         self._scope_stack: list[tuple[str, str]] = []
 
-        # Cache for constant initializers (scalars and sequences), keyed by (value, dtype).
-        # This avoids creating duplicate initializers for the same constant
-        # and allows sharing them across different layers/contexts.
-        self._constant_cache: dict[tuple[Any, ir.DataType | None], ir.Value] = {}
+        # Cache for constant initializers (scalars and sequences), keyed by
+        # (value, dtype).  Only the **root** builder owns a cache; child
+        # builders delegate to ``self._root`` so that all constant
+        # initializers live in the root graph (outer-scope initializers are
+        # visible to subgraphs per the ONNX spec).
+        if parent is None:
+            self._constant_cache: dict[tuple[Any, ir.DataType | None], ir.Value] = {}
 
     def opset(self, domain: str, version: int = 1) -> OpBuilder:
         """Create an OpBuilder bound to the given domain and version."""
@@ -324,6 +377,53 @@ class GraphBuilder:
             value.name = name
         self._graph.outputs.append(value)
 
+    def _get_or_create_constant(
+        self, value: VALUE_LIKE, dtype: ir.DataType | None
+    ) -> ir.Value:
+        """Materialise a constant as an initializer in the **root** graph.
+
+        Child builders delegate to the root so that all constant initializers
+        live in the root graph.  For subgraphs this is correct because ONNX
+        allows inner scopes to reference outer-scope initializers.  For
+        function bodies (which cannot reference outer initializers) callers
+        should apply :func:`lift_initializers_to_constants` before wrapping
+        the graph in :class:`ir.Function`.
+        """
+        root = self._root
+        if isinstance(value, (int, float, bool, str)):
+            if dtype is None:
+                dtype = _PYTHON_TYPE_TO_DTYPE.get(type(value))
+            cache_key = (value, dtype)
+            if cache_key in root._constant_cache:
+                return root._constant_cache[cache_key]
+            type_suffix = _dtype_suffix(dtype) if dtype is not None else ""
+            name = _constant_name(value, type_suffix, len(root._constant_cache))
+            tensor = ir.tensor(value, dtype=dtype, name=name)
+            ir_value = root.initializer(tensor, name=name, qualify=False)
+            root._constant_cache[cache_key] = ir_value
+            return ir_value
+        if (
+            isinstance(value, (list, tuple))
+            and value
+            and all(isinstance(v, type(value[0])) for v in value)
+            and isinstance(value[0], (int, float, bool, str))
+        ):
+            if dtype is None:
+                dtype = _PYTHON_TYPE_TO_DTYPE.get(type(value[0]))
+            cache_key = (tuple(value), dtype)
+            if cache_key in root._constant_cache:
+                return root._constant_cache[cache_key]
+            type_suffix = _dtype_suffix(dtype) if dtype is not None else ""
+            name = _constant_name(value, type_suffix, len(root._constant_cache))
+            tensor = ir.tensor(list(value), dtype=dtype, name=name)
+            ir_value = root.initializer(tensor, name=name, qualify=False)
+            root._constant_cache[cache_key] = ir_value
+            return ir_value
+        # For other types (TensorProtocol, numpy arrays, torch tensors, etc.),
+        # ir.tensor() handles the conversion.
+        # TODO(rama): Consider caching for other tensor values.
+        return root.initializer(ir.tensor(value, dtype=dtype))
+
     def _input_to_ir_value(
         self, value: VALUE_LIKE, like_type: ir.Value | None = None
     ) -> ir.Value | None:
@@ -343,48 +443,11 @@ class GraphBuilder:
             else None
         )
         needs_dynamic_cast = like_type is not None and dtype is None
-        # For simple scalar/sequence constants, use a cache to avoid duplicate initializers.
-        # These are shared across layers, so we don't qualify the name with context prefix.
-        if isinstance(value, (int, float, bool, str)):
-            # Normalize dtype: when None, use the default ONNX type for the
-            # Python scalar so that (value, None) and (value, default_dtype)
-            # share one cache entry and one initializer name.
-            if dtype is None:
-                dtype = _PYTHON_TYPE_TO_DTYPE.get(type(value))
-            cache_key = (value, dtype)
-            if cache_key in self._constant_cache:
-                ir_value = self._constant_cache[cache_key]
-            else:
-                type_suffix = _dtype_suffix(dtype) if dtype is not None else ""
-                name = _constant_name(value, type_suffix, len(self._constant_cache))
-                tensor = ir.tensor(value, dtype=dtype, name=name)
-                ir_value = self.initializer(tensor, name=name, qualify=False)
-                self._constant_cache[cache_key] = ir_value
-        elif (
-            isinstance(value, (list, tuple))
-            and value
-            and all(isinstance(v, type(value[0])) for v in value)
-            and isinstance(value[0], (int, float, bool, str))
-        ):
-            # Same normalization for sequences of scalars.
-            if dtype is None:
-                dtype = _PYTHON_TYPE_TO_DTYPE.get(type(value[0]))
-            cache_key = (tuple(value), dtype)
-            if cache_key in self._constant_cache:
-                ir_value = self._constant_cache[cache_key]
-            else:
-                type_suffix = _dtype_suffix(dtype) if dtype is not None else ""
-                name = _constant_name(value, type_suffix, len(self._constant_cache))
-                tensor = ir.tensor(list(value), dtype=dtype, name=name)
-                ir_value = self.initializer(tensor, name=name, qualify=False)
-                self._constant_cache[cache_key] = ir_value
-        else:
-            # For other types (TensorProtocol, numpy arrays, torch tensors, etc.),
-            # ir.tensor() handles the conversion.
-            # TODO(rama): Consider caching for other tensor values.
-            ir_value = self.initializer(ir.tensor(value, dtype=dtype))
+        ir_value = self._get_or_create_constant(value, dtype)
         # If like_type is provided but its type is unknown, insert a dynamic CastLike
         # so the constant is cast to match like_type's type at runtime.
+        # The CastLike node is created in THIS builder's graph (not root),
+        # so that it lives in the correct scope (subgraph or function body).
         if needs_dynamic_cast:
             ir_value = self.op.CastLike(ir_value, like_type)
         return ir_value

--- a/onnxscript/_internal/builder.py
+++ b/onnxscript/_internal/builder.py
@@ -144,7 +144,7 @@ def _resolve_type_spec(spec: TypeSpec) -> ir.TypeAndShape:
     ``FLOAT[1024]`` or ``FLOAT['M', 'N']``).
 
     .. deprecated::
-        Use :func:`make_input` or construct ``ir.Value`` directly instead.
+        Use :func:`make_value` or construct ``ir.Value`` directly instead.
     """
     if isinstance(spec, ir.TypeAndShape):
         return spec
@@ -162,19 +162,19 @@ def _resolve_type_spec(spec: TypeSpec) -> ir.TypeAndShape:
     )
 
 
-def make_input(name: str, type_spec: TypeSpec | None = None) -> ir.Value:
+def make_value(name: str, type_spec: TypeSpec | None = None) -> ir.Value:
     """Create an :class:`ir.Value` from a name and optional :data:`TypeSpec`.
 
-    This is a convenience for constructing graph/function inputs without
-    manually building ``ir.TensorType`` and ``ir.Shape`` objects.
+    Similar to :func:`onnx_ir.val` but accepts a :data:`TypeSpec` (e.g.
+    ``FLOAT[3, 4]``) instead of separate *dtype* and *shape* arguments.
 
     Example::
 
-        x = make_input("x", FLOAT[3, 4])
-        y = make_input("y")  # untyped
+        x = make_value("x", FLOAT[3, 4])
+        y = make_value("y")  # untyped
 
     Args:
-        name: The input name.
+        name: The value name.
         type_spec: Optional type specification.  Accepts an
             :class:`ir.TypeAndShape`, or a
             :class:`~onnxscript.onnx_types.TensorType` subclass
@@ -235,8 +235,8 @@ def build_graph(
 
         body = build_graph(
             lambda op, x, y: op.Add(x, y),
-            inputs=[make_input("x", FLOAT[3, 4]), make_input("y", FLOAT[3, 4])],
-            outputs=[make_input("sum", FLOAT[3, 4])],
+            inputs=[make_value("x", FLOAT[3, 4]), make_value("y", FLOAT[3, 4])],
+            outputs=[make_value("sum", FLOAT[3, 4])],
         )
 
     Args:
@@ -328,7 +328,7 @@ def build_function(
 
         fn = build_function(
             lambda op, x, y: op.Add(x, y),
-            [make_input("x"), make_input("y")],
+            [make_value("x"), make_value("y")],
             domain="com.example",
             name="MyAdd",
         )
@@ -747,8 +747,8 @@ class GraphBuilder:
 
             body = graph_builder.subgraph(
                 lambda op, x, y: op.Add(x, y),
-                inputs=[make_input("x", FLOAT[...]), make_input("y", FLOAT[...])],
-                outputs=[make_input("sum", FLOAT[...])],
+                inputs=[make_value("x", FLOAT[...]), make_value("y", FLOAT[...])],
+                outputs=[make_value("sum", FLOAT[...])],
             )
 
         Args:

--- a/onnxscript/_internal/builder.py
+++ b/onnxscript/_internal/builder.py
@@ -102,7 +102,8 @@ def lift_initializers_to_constants(graph: ir.Graph) -> None:
     new_nodes: list[ir.Node] = []
     for value in to_lift:
         tensor = value.const_value
-        assert tensor is not None, f"Initializer {value.name!r} has no const_value"
+        if tensor is None:
+            raise ValueError(f"Initializer {value.name!r} has no const_value")
         # Build a Constant node whose output is the *same* ir.Value so
         # that every existing reference keeps working.
         node = ir.Node(
@@ -320,9 +321,12 @@ class GraphBuilder:
     ) -> ir.Value:
         """Register a tensor as a graph initializer in the **root** graph.
 
-        All initializers are stored in the root graph so that inner scopes
-        (subgraphs) can reference them via ONNX's outer-scope visibility
-        rules.  For function bodies (which cannot have initializers), apply
+        Initializers created through this method are stored in the root graph
+        so that inner scopes (subgraphs) can reference them via ONNX's
+        outer-scope visibility rules.  This does not apply to the ONNX
+        default-input pattern created via :meth:`input` with ``const_value``,
+        which registers an initializer on the owning graph.  For function
+        bodies (which cannot have initializers), apply
         :func:`lift_initializers_to_constants` before wrapping in
         :class:`ir.Function`.
         """
@@ -430,7 +434,7 @@ class GraphBuilder:
         # For other types (TensorProtocol, numpy arrays, torch tensors, etc.),
         # ir.tensor() handles the conversion.
         # TODO(rama): Consider caching for other tensor values.
-        return root.initializer(ir.tensor(value, dtype=dtype))
+        return self.initializer(ir.tensor(value, dtype=dtype))
 
     def _input_to_ir_value(
         self, value: VALUE_LIKE, like_type: ir.Value | None = None

--- a/onnxscript/_internal/builder.py
+++ b/onnxscript/_internal/builder.py
@@ -318,7 +318,14 @@ class GraphBuilder:
     def initializer(
         self, tensor: ir.TensorProtocol, name: str | None = None, *, qualify: bool = True
     ) -> ir.Value:
-        """Register a tensor as a graph initializer, returning the corresponding ir.Value."""
+        """Register a tensor as a graph initializer in the **root** graph.
+
+        All initializers are stored in the root graph so that inner scopes
+        (subgraphs) can reference them via ONNX's outer-scope visibility
+        rules.  For function bodies (which cannot have initializers), apply
+        :func:`lift_initializers_to_constants` before wrapping in
+        :class:`ir.Function`.
+        """
         if name is None:
             name = tensor.name
         if qualify:
@@ -327,7 +334,7 @@ class GraphBuilder:
         value = ir.Value(
             name=name, shape=shape, type=ir.TensorType(tensor.dtype), const_value=tensor
         )
-        self._graph.register_initializer(value)
+        self._root._graph.register_initializer(value)
         return value
 
     def input(

--- a/onnxscript/_internal/builder.py
+++ b/onnxscript/_internal/builder.py
@@ -194,9 +194,16 @@ def _split_optional_inputs(
 ) -> tuple[list[ir.Value | None], list[ir.Value]]:
     """Split an input list into trace args and graph inputs.
 
+    For each ``None`` entry, a placeholder :class:`ir.Value` with a generated
+    name (``input_0``, ``input_1``, …) is created and added to
+    *graph_inputs* so that the function/graph signature declares the formal
+    parameter.  The corresponding *trace_args* entry remains ``None`` so that
+    the trace function can branch with ``if x is None:``.
+
     Returns:
         A tuple of (trace_args, graph_inputs) where trace_args preserves
-        ``None`` holes and graph_inputs contains only non-``None`` values.
+        ``None`` holes and graph_inputs includes placeholders for absent
+        optional inputs.
 
     Raises:
         ValueError: If any non-None input already has a producer or is
@@ -204,15 +211,17 @@ def _split_optional_inputs(
     """
     trace_args: list[ir.Value | None] = list(inputs)
     graph_inputs: list[ir.Value] = []
-    for v in trace_args:
+    for i, v in enumerate(trace_args):
         if v is None:
-            continue
-        if v.producer() is not None:
-            raise ValueError(
-                f"Input {v.name!r} already has a producer node. "
-                f"Pass freshly created ir.Value objects."
-            )
-        graph_inputs.append(v)
+            # Placeholder: declared in function signature but unused in body.
+            graph_inputs.append(ir.Value(name=f"input_{i}"))
+        else:
+            if v.producer() is not None:
+                raise ValueError(
+                    f"Input {v.name!r} already has a producer node. "
+                    f"Pass freshly created ir.Value objects."
+                )
+            graph_inputs.append(v)
     return trace_args, graph_inputs
 
 

--- a/onnxscript/_internal/builder.py
+++ b/onnxscript/_internal/builder.py
@@ -92,11 +92,9 @@ def lift_initializers_to_constants(graph: ir.Graph) -> None:
     ONNX pattern for optional inputs with default values) are skipped
     because they are explicit function parameters, not embedded constants.
     """
-    graph_input_set = set(id(v) for v in graph.inputs)
+    graph_input_set = {id(v) for v in graph.inputs}
     to_lift: list[ir.Value] = [
-        v
-        for v in list(graph.initializers.values())
-        if id(v) not in graph_input_set
+        v for v in list(graph.initializers.values()) if id(v) not in graph_input_set
     ]
     opset_version = graph.opset_imports.get("", 1)
     new_nodes: list[ir.Node] = []

--- a/onnxscript/_internal/builder_test.py
+++ b/onnxscript/_internal/builder_test.py
@@ -16,6 +16,9 @@ from onnxscript.onnx_types import DOUBLE, FLOAT, INT64
 
 _default_opset_version = 23
 
+# Convenience alias for tests — creates an ir.Value from (name, TypeSpec).
+_input = builder.make_input
+
 
 def _resolve_type_spec(spec: builder.TypeSpec) -> ir.TypeAndShape:
     """Convert a *TypeSpec* to an :class:`ir.TypeAndShape`.
@@ -24,8 +27,7 @@ def _resolve_type_spec(spec: builder.TypeSpec) -> ir.TypeAndShape:
     :class:`~onnxscript.onnx_types.TensorType` subclass (e.g. ``FLOAT[1024]``
     or ``FLOAT['M', 'N']``).
 
-    NOTE: This is a local copy of :func:`builder._resolve_type_spec` so that
-    tests do not reference a private helper directly.
+    NOTE: This is a local helper used by the legacy ``_build()`` test utility.
     """
     from onnxscript.onnx_types import TensorType  # pylint: disable=import-outside-toplevel
 
@@ -37,9 +39,9 @@ def _resolve_type_spec(spec: builder.TypeSpec) -> ir.TypeAndShape:
 
 
 def _build(
-    input_types: Sequence[builder.TypeSpec],
+    input_types: Sequence,
     trace_function=None,
-    output_types: Sequence[builder.TypeSpec] | None = None,
+    output_types: Sequence | None = None,
 ) -> ir.Graph:
     graph = ir.Graph(
         name="test_model",
@@ -1061,8 +1063,8 @@ class BuildSubgraphTest(unittest.TestCase):
         gb = self._make_builder()
         graph = gb.subgraph(
             _add,
-            inputs=[FLOAT[3, 4], FLOAT[3, 4]],
-            outputs=[FLOAT[3, 4]],
+            inputs=[_input("x", FLOAT[3, 4]), _input("y", FLOAT[3, 4])],
+            outputs=[_input("sum", FLOAT[3, 4])],
         )
         self.assertIsInstance(graph, ir.Graph)
         self.assertEqual(len(graph.inputs), 2)
@@ -1075,23 +1077,39 @@ class BuildSubgraphTest(unittest.TestCase):
         gb = self._make_builder(opset_version=17)
         graph = gb.subgraph(
             lambda op, x: op.Identity(x),
-            inputs=[FLOAT[...]],
-            outputs=[FLOAT[...]],
+            inputs=[_input("x", FLOAT[...])],
+            outputs=[_input("y", FLOAT[...])],
         )
         self.assertEqual(graph.opset_imports[""], 17)
 
     def test_subgraph_with_ir_type_and_shape(self):
-        """Subgraph also accepts ir.TypeAndShape directly."""
+        """Subgraph also accepts ir.Value with ir.TypeAndShape-derived types."""
 
         def _mul(op, x, y):
             return op.Mul(x, y)
 
-        float_2d = ir.TypeAndShape(ir.TensorType(ir.DataType.FLOAT), ir.Shape([2, 3]))
         gb = self._make_builder()
         graph = gb.subgraph(
             _mul,
-            inputs=[float_2d, float_2d],
-            outputs=[float_2d],
+            inputs=[
+                ir.Value(
+                    name="x",
+                    type=ir.TensorType(ir.DataType.FLOAT),
+                    shape=ir.Shape([2, 3]),
+                ),
+                ir.Value(
+                    name="y",
+                    type=ir.TensorType(ir.DataType.FLOAT),
+                    shape=ir.Shape([2, 3]),
+                ),
+            ],
+            outputs=[
+                ir.Value(
+                    name="z",
+                    type=ir.TensorType(ir.DataType.FLOAT),
+                    shape=ir.Shape([2, 3]),
+                ),
+            ],
         )
         self.assertIsInstance(graph, ir.Graph)
         self.assertEqual(len(list(graph)), 1)
@@ -1103,12 +1121,11 @@ class BuildSubgraphTest(unittest.TestCase):
         def _add_and_mul(op, x, y):
             return op.Add(x, y), op.Mul(x, y)
 
-        ts = FLOAT[...]
         gb = self._make_builder()
         graph = gb.subgraph(
             _add_and_mul,
-            inputs=[ts, ts],
-            outputs=[ts, ts],
+            inputs=[_input("x", FLOAT[...]), _input("y", FLOAT[...])],
+            outputs=[_input("sum", FLOAT[...]), _input("prod", FLOAT[...])],
         )
         self.assertEqual(len(graph.outputs), 2)
 
@@ -1122,8 +1139,11 @@ class BuildSubgraphTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             gb.subgraph(
                 _returns_one,
-                inputs=[FLOAT[...], FLOAT[...]],
-                outputs=[FLOAT[...], FLOAT[...]],  # expects 2, gets 1
+                inputs=[_input("x", FLOAT[...]), _input("y", FLOAT[...])],
+                outputs=[
+                    _input("a", FLOAT[...]),
+                    _input("b", FLOAT[...]),
+                ],  # expects 2, gets 1
             )
 
     def test_subgraph_custom_name(self):
@@ -1135,28 +1155,32 @@ class BuildSubgraphTest(unittest.TestCase):
         gb = self._make_builder()
         graph = gb.subgraph(
             _id,
-            inputs=[DOUBLE[...]],
-            outputs=[DOUBLE[...]],
+            inputs=[_input("x", DOUBLE[...])],
+            outputs=[_input("y", DOUBLE[...])],
             name="scan_body",
         )
         self.assertEqual(graph.name, "scan_body")
 
-    def test_invalid_type_spec_raises(self):
-        """Subgraph raises TypeError for an unrecognised type specification."""
+    def test_subgraph_input_with_producer_raises(self):
+        """Subgraph raises ValueError for inputs that already have a producer."""
 
         def _id(op, x):
             return op.Identity(x)
 
         gb = self._make_builder()
-        with self.assertRaises(TypeError):
+        # Create a value with a producer node
+        node = ir.Node("", "Dummy", inputs=[], num_outputs=1)
+        used_value = node.outputs[0]
+        used_value.name = "bad_input"
+        with self.assertRaises(ValueError):
             gb.subgraph(
                 _id,
-                inputs=["not_a_type_spec"],
-                outputs=["not_a_type_spec"],
+                inputs=[used_value],
+                outputs=[_input("y", FLOAT[...])],
             )
 
-    def test_subgraph_dict_inputs_outputs(self):
-        """Subgraph accepts a dict to name inputs and outputs."""
+    def test_subgraph_named_inputs_outputs(self):
+        """Subgraph accepts ir.Value objects with names."""
 
         def _add(op, x, y):
             return op.Add(x, y)
@@ -1164,8 +1188,8 @@ class BuildSubgraphTest(unittest.TestCase):
         gb = self._make_builder()
         graph = gb.subgraph(
             _add,
-            inputs={"x": FLOAT[3, 4], "y": FLOAT[3, 4]},
-            outputs={"sum": FLOAT[3, 4]},
+            inputs=[_input("x", FLOAT[3, 4]), _input("y", FLOAT[3, 4])],
+            outputs=[_input("sum", FLOAT[3, 4])],
         )
         self.assertIsInstance(graph, ir.Graph)
         self.assertEqual(len(graph.inputs), 2)
@@ -1174,8 +1198,8 @@ class BuildSubgraphTest(unittest.TestCase):
         self.assertEqual(len(graph.outputs), 1)
         self.assertEqual(graph.outputs[0].name, "sum")
 
-    def test_subgraph_list_auto_names(self):
-        """List-based inputs/outputs get auto-generated names."""
+    def test_subgraph_untyped_inputs(self):
+        """Subgraph accepts ir.Value objects without type/shape."""
 
         def _id(op, x):
             return op.Identity(x)
@@ -1183,11 +1207,11 @@ class BuildSubgraphTest(unittest.TestCase):
         gb = self._make_builder()
         graph = gb.subgraph(
             _id,
-            inputs=[FLOAT[...]],
-            outputs=[FLOAT[...]],
+            inputs=[ir.Value(name="x")],
+            outputs=[ir.Value(name="y")],
         )
-        self.assertEqual(graph.inputs[0].name, "input_0")
-        self.assertEqual(graph.outputs[0].name, "output_0")
+        self.assertEqual(graph.inputs[0].name, "x")
+        self.assertEqual(graph.outputs[0].name, "y")
 
 
 class BuildGraphFunctionTest(unittest.TestCase):
@@ -1197,8 +1221,8 @@ class BuildGraphFunctionTest(unittest.TestCase):
         """build_graph works without a parent GraphBuilder."""
         graph = builder.build_graph(
             lambda op, x, y: op.Add(x, y),
-            inputs={"x": FLOAT[3, 4], "y": FLOAT[3, 4]},
-            outputs={"sum": FLOAT[3, 4]},
+            inputs=[_input("x", FLOAT[3, 4]), _input("y", FLOAT[3, 4])],
+            outputs=[_input("sum", FLOAT[3, 4])],
             opset_imports={"": 20},
         )
         self.assertIsInstance(graph, ir.Graph)
@@ -1211,8 +1235,8 @@ class BuildGraphFunctionTest(unittest.TestCase):
         """build_graph passes name to the ir.Graph."""
         graph = builder.build_graph(
             lambda op, x: op.Identity(x),
-            inputs=[FLOAT[...]],
-            outputs=[FLOAT[...]],
+            inputs=[_input("x", FLOAT[...])],
+            outputs=[_input("y", FLOAT[...])],
             name="loop_body",
         )
         self.assertEqual(graph.name, "loop_body")
@@ -1235,8 +1259,8 @@ class BuildGraphFunctionTest(unittest.TestCase):
 
         builder.build_graph(
             body,
-            inputs=[FLOAT[3]],
-            outputs=[FLOAT[3]],
+            inputs=[_input("x", FLOAT[3])],
+            outputs=[_input("y", FLOAT[3])],
             parent=parent_builder,
         )
 
@@ -1256,7 +1280,11 @@ class BuildGraphFunctionTest(unittest.TestCase):
             self.assertIs(op.builder.root, parent_builder)
             return op.Identity(x)
 
-        parent_builder.subgraph(body, inputs=[FLOAT[3]], outputs=[FLOAT[3]])
+        parent_builder.subgraph(
+            body,
+            inputs=[_input("x", FLOAT[3])],
+            outputs=[_input("y", FLOAT[3])],
+        )
 
     def test_build_graph_inherits_parent_scope_stack(self):
         """build_graph copies the parent's scope stack so nodes in the subgraph carry scoped names."""
@@ -1273,8 +1301,8 @@ class BuildGraphFunctionTest(unittest.TestCase):
 
         subgraph = builder.build_graph(
             lambda op, x: op.Relu(x),
-            inputs={"x": FLOAT[3, 4]},
-            outputs={"y": FLOAT[3, 4]},
+            inputs=[_input("x", FLOAT[3, 4])],
+            outputs=[_input("y", FLOAT[3, 4])],
             parent=parent_builder,
         )
 
@@ -1458,7 +1486,11 @@ class RootInitializerTest(unittest.TestCase):
         def body(op, x):
             return op.Add(x, 1.0)
 
-        sub = root_builder.subgraph(body, inputs=[FLOAT[3]], outputs=[FLOAT[3]])
+        sub = root_builder.subgraph(
+            body,
+            inputs=[_input("x", FLOAT[3])],
+            outputs=[_input("y", FLOAT[3])],
+        )
         # Initializer should be in the root graph, not in the subgraph.
         self.assertTrue(
             any("const_1.0" in name for name in root_graph.initializers),
@@ -1487,8 +1519,16 @@ class RootInitializerTest(unittest.TestCase):
         def body2(op, x):
             return op.Mul(x, 2.0)
 
-        root_builder.subgraph(body1, inputs=[FLOAT[3]], outputs=[FLOAT[3]])
-        root_builder.subgraph(body2, inputs=[FLOAT[3]], outputs=[FLOAT[3]])
+        root_builder.subgraph(
+            body1,
+            inputs=[_input("x", FLOAT[3])],
+            outputs=[_input("y", FLOAT[3])],
+        )
+        root_builder.subgraph(
+            body2,
+            inputs=[_input("x", FLOAT[3])],
+            outputs=[_input("y", FLOAT[3])],
+        )
 
         # Only one initializer should exist (shared via cache).
         const_names = [n for n in root_graph.initializers if "const_2.0" in n]
@@ -1512,7 +1552,11 @@ class RootInitializerTest(unittest.TestCase):
             bias = op.builder.initializer(tensor, name="my_bias")
             return op.Add(x, bias)
 
-        sub = root_builder.subgraph(body, inputs=[FLOAT[3]], outputs=[FLOAT[3]])
+        sub = root_builder.subgraph(
+            body,
+            inputs=[_input("x", FLOAT[3])],
+            outputs=[_input("y", FLOAT[3])],
+        )
         # Initializer should be in root, not subgraph
         self.assertIn("my_bias", root_graph.initializers)
         self.assertEqual(len(sub.initializers), 0)
@@ -1629,6 +1673,212 @@ class RootInitializerTest(unittest.TestCase):
         # Should have a Constant node
         const_nodes = [n for n in func.graph if n.op_type == "Constant"]
         self.assertEqual(len(const_nodes), 1)
+
+
+class BuildFunctionTest(unittest.TestCase):
+    """Tests for the module-level build_function() utility."""
+
+    def test_build_function_basic(self):
+        """build_function creates an ir.Function with correct domain/name."""
+        fn = builder.build_function(
+            lambda op, x, y: op.Add(x, y),
+            [_input("x", FLOAT[3, 4]), _input("y", FLOAT[3, 4])],
+            domain="com.test",
+            name="MyAdd",
+        )
+        self.assertIsInstance(fn, ir.Function)
+        self.assertEqual(fn.domain, "com.test")
+        self.assertEqual(fn.name, "MyAdd")
+        self.assertEqual(len(fn.graph.inputs), 2)
+        self.assertEqual(fn.graph.inputs[0].name, "x")
+        self.assertEqual(fn.graph.inputs[1].name, "y")
+        self.assertEqual(len(fn.graph.outputs), 1)
+
+    def test_build_function_multiple_outputs(self):
+        """build_function handles multiple return values."""
+
+        def body(op, x, y):
+            return op.Add(x, y), op.Mul(x, y)
+
+        fn = builder.build_function(
+            body,
+            [_input("x"), _input("y")],
+            domain="com.test",
+            name="AddAndMul",
+        )
+        self.assertEqual(len(fn.graph.outputs), 2)
+
+    def test_build_function_with_attributes(self):
+        """build_function passes attributes to ir.Function."""
+        fn = builder.build_function(
+            lambda op, x: op.Identity(x),
+            [_input("x")],
+            domain="com.test",
+            name="WithAttr",
+            attributes=[
+                ir.Attr("scale", ir.AttributeType.FLOAT, 0.5),
+                ir.Attr("mode", ir.AttributeType.STRING, "fast"),
+            ],
+        )
+        self.assertIn("scale", fn.attributes)
+        self.assertIn("mode", fn.attributes)
+
+    def test_build_function_attributes_as_dict(self):
+        """build_function accepts attributes as Mapping[str, ir.Attr]."""
+        attr = ir.Attr("scale", ir.AttributeType.FLOAT, 1.0)
+        fn = builder.build_function(
+            lambda op, x: op.Identity(x),
+            [_input("x")],
+            domain="com.test",
+            name="DictAttr",
+            attributes={"scale": attr},
+        )
+        self.assertIn("scale", fn.attributes)
+
+    def test_build_function_lifts_initializers(self):
+        """build_function lifts initializers to Constant nodes automatically."""
+        fn = builder.build_function(
+            lambda op, x: op.Add(x, 1.5),
+            [_input("x", FLOAT[3])],
+            domain="com.test",
+            name="WithLiteral",
+        )
+        # No initializers in function body
+        self.assertEqual(len(fn.graph.initializers), 0)
+        # Should have a Constant node for the literal
+        const_nodes = [n for n in fn.graph if n.op_type == "Constant"]
+        self.assertGreater(len(const_nodes), 0)
+
+    def test_build_function_optional_inputs_none(self):
+        """build_function passes None for absent optional inputs."""
+
+        def body(op, x, y, z):
+            self.assertIsNotNone(x)
+            self.assertIsNone(y)
+            self.assertIsNotNone(z)
+            return op.Add(x, z)
+
+        fn = builder.build_function(
+            body,
+            [_input("x", FLOAT[3]), None, _input("z", FLOAT[3])],
+            domain="com.test",
+            name="OptionalInputs",
+        )
+        # Graph should have only 2 inputs (x and z), not 3
+        self.assertEqual(len(fn.graph.inputs), 2)
+        self.assertEqual(fn.graph.inputs[0].name, "x")
+        self.assertEqual(fn.graph.inputs[1].name, "z")
+
+    def test_build_function_trace_appends_outputs(self):
+        """build_function supports trace functions that append outputs directly."""
+
+        def body(op, x):
+            result = op.Identity(x)
+            result.name = "result"
+            op.builder._graph.outputs.append(result)
+            return None
+
+        fn = builder.build_function(
+            body,
+            [_input("x")],
+            domain="com.test",
+            name="AppendOutputs",
+        )
+        self.assertEqual(len(fn.graph.outputs), 1)
+        self.assertEqual(fn.graph.outputs[0].name, "result")
+
+    def test_build_function_mixed_output_raises(self):
+        """build_function raises if trace both returns and appends outputs."""
+
+        def body(op, x):
+            result = op.Identity(x)
+            op.builder._graph.outputs.append(result)
+            return op.Identity(x)  # also returns — should raise
+
+        with self.assertRaises(ValueError):
+            builder.build_function(
+                body,
+                [_input("x")],
+                domain="com.test",
+                name="MixedOutputs",
+            )
+
+    def test_build_function_no_outputs_raises(self):
+        """build_function raises if trace returns None and appends nothing."""
+
+        def body(op, x):
+            op.Identity(x)
+            return None
+
+        with self.assertRaises(ValueError):
+            builder.build_function(
+                body,
+                [_input("x")],
+                domain="com.test",
+                name="NoOutputs",
+            )
+
+    def test_build_function_input_with_producer_raises(self):
+        """build_function raises for inputs that already have a producer."""
+        node = ir.Node("", "Dummy", inputs=[], num_outputs=1)
+        used_value = node.outputs[0]
+        used_value.name = "bad"
+
+        with self.assertRaises(ValueError):
+            builder.build_function(
+                lambda op, x: op.Identity(x),
+                [used_value],
+                domain="com.test",
+                name="BadInput",
+            )
+
+    def test_build_function_custom_opset(self):
+        """build_function passes custom opset_imports to the graph."""
+        fn = builder.build_function(
+            lambda op, x: op.Identity(x),
+            [_input("x")],
+            domain="com.test",
+            name="CustomOpset",
+            opset_imports={"": 20},
+        )
+        self.assertEqual(fn.graph.opset_imports[""], 20)
+
+    def test_build_function_no_parent_isolation(self):
+        """build_function has no parent — literals stay in the function graph."""
+        fn = builder.build_function(
+            lambda op, x: op.Mul(x, 2.0),
+            [_input("x", FLOAT[3])],
+            domain="com.test",
+            name="Isolated",
+        )
+        # After lifting, there should be a Constant node and no initializers
+        self.assertEqual(len(fn.graph.initializers), 0)
+        const_nodes = [n for n in fn.graph if n.op_type == "Constant"]
+        self.assertGreater(len(const_nodes), 0)
+
+
+class MakeInputTest(unittest.TestCase):
+    """Tests for the make_input() convenience helper."""
+
+    def test_make_input_name_only(self):
+        """make_input with just a name creates an untyped Value."""
+        v = builder.make_input("x")
+        self.assertEqual(v.name, "x")
+        self.assertIsNone(v.type)
+        self.assertIsNone(v.shape)
+
+    def test_make_input_with_type_spec(self):
+        """make_input with a TypeSpec sets type and shape."""
+        v = builder.make_input("x", FLOAT[3, 4])
+        self.assertEqual(v.name, "x")
+        self.assertIsNotNone(v.type)
+        self.assertIsNotNone(v.shape)
+
+    def test_make_input_with_dynamic_shape(self):
+        """make_input with symbolic dims works."""
+        v = builder.make_input("x", FLOAT["B", "T"])
+        self.assertEqual(v.name, "x")
+        self.assertIsNotNone(v.shape)
 
 
 if __name__ == "__main__":

--- a/onnxscript/_internal/builder_test.py
+++ b/onnxscript/_internal/builder_test.py
@@ -15,6 +15,7 @@ from onnxscript import script
 from onnxscript.onnx_types import DOUBLE, FLOAT, INT64
 
 _default_opset_version = 23
+_opset = {"": _default_opset_version}
 
 # Convenience alias for tests — creates an ir.Value from (name, TypeSpec).
 _input = builder.make_value
@@ -1238,6 +1239,7 @@ class BuildGraphFunctionTest(unittest.TestCase):
             inputs=[_input("x", FLOAT[...])],
             outputs=[_input("y", FLOAT[...])],
             name="loop_body",
+            opset_imports=_opset,
         )
         self.assertEqual(graph.name, "loop_body")
 
@@ -1262,6 +1264,7 @@ class BuildGraphFunctionTest(unittest.TestCase):
             inputs=[_input("x", FLOAT[3])],
             outputs=[_input("y", FLOAT[3])],
             parent=parent_builder,
+            opset_imports=_opset,
         )
 
     def test_subgraph_sets_parent_and_root(self):
@@ -1304,8 +1307,8 @@ class BuildGraphFunctionTest(unittest.TestCase):
             inputs=[_input("x", FLOAT[3, 4])],
             outputs=[_input("y", FLOAT[3, 4])],
             parent=parent_builder,
+            opset_imports=_opset,
         )
-
         # The single node created inside the subgraph should carry the
         # parent's scope prefix in its name and metadata.
         node = subgraph.node(0)
@@ -1685,6 +1688,7 @@ class BuildFunctionTest(unittest.TestCase):
             [_input("x", FLOAT[3, 4]), _input("y", FLOAT[3, 4])],
             domain="com.test",
             name="MyAdd",
+            opset_imports=_opset,
         )
         self.assertIsInstance(fn, ir.Function)
         self.assertEqual(fn.domain, "com.test")
@@ -1705,6 +1709,7 @@ class BuildFunctionTest(unittest.TestCase):
             [_input("x"), _input("y")],
             domain="com.test",
             name="AddAndMul",
+            opset_imports=_opset,
         )
         self.assertEqual(len(fn.graph.outputs), 2)
 
@@ -1719,6 +1724,7 @@ class BuildFunctionTest(unittest.TestCase):
                 ir.Attr("scale", ir.AttributeType.FLOAT, 0.5),
                 ir.Attr("mode", ir.AttributeType.STRING, "fast"),
             ],
+            opset_imports=_opset,
         )
         self.assertIn("scale", fn.attributes)
         self.assertIn("mode", fn.attributes)
@@ -1732,6 +1738,7 @@ class BuildFunctionTest(unittest.TestCase):
             domain="com.test",
             name="DictAttr",
             attributes={"scale": attr},
+            opset_imports=_opset,
         )
         self.assertIn("scale", fn.attributes)
 
@@ -1742,6 +1749,7 @@ class BuildFunctionTest(unittest.TestCase):
             [_input("x", FLOAT[3])],
             domain="com.test",
             name="WithLiteral",
+            opset_imports=_opset,
         )
         # No initializers in function body
         self.assertEqual(len(fn.graph.initializers), 0)
@@ -1763,6 +1771,7 @@ class BuildFunctionTest(unittest.TestCase):
             [_input("x", FLOAT[3]), None, _input("z", FLOAT[3])],
             domain="com.test",
             name="OptionalInputs",
+            opset_imports=_opset,
         )
         # Graph has 3 inputs: x, a placeholder for the absent y, and z
         self.assertEqual(len(fn.graph.inputs), 3)
@@ -1785,6 +1794,7 @@ class BuildFunctionTest(unittest.TestCase):
             [_input("x")],
             domain="com.test",
             name="AppendOutputs",
+            opset_imports=_opset,
         )
         self.assertEqual(len(fn.graph.outputs), 1)
         self.assertEqual(fn.graph.outputs[0].name, "result")
@@ -1803,6 +1813,7 @@ class BuildFunctionTest(unittest.TestCase):
                 [_input("x")],
                 domain="com.test",
                 name="MixedOutputs",
+            opset_imports=_opset,
             )
 
     def test_build_function_no_outputs_raises(self):
@@ -1818,6 +1829,7 @@ class BuildFunctionTest(unittest.TestCase):
                 [_input("x")],
                 domain="com.test",
                 name="NoOutputs",
+            opset_imports=_opset,
             )
 
     def test_build_function_input_with_producer_raises(self):
@@ -1832,6 +1844,7 @@ class BuildFunctionTest(unittest.TestCase):
                 [used_value],
                 domain="com.test",
                 name="BadInput",
+            opset_imports=_opset,
             )
 
     def test_build_function_custom_opset(self):
@@ -1852,6 +1865,7 @@ class BuildFunctionTest(unittest.TestCase):
             [_input("x", FLOAT[3])],
             domain="com.test",
             name="Isolated",
+            opset_imports=_opset,
         )
         # After lifting, there should be a Constant node and no initializers
         self.assertEqual(len(fn.graph.initializers), 0)

--- a/onnxscript/_internal/builder_test.py
+++ b/onnxscript/_internal/builder_test.py
@@ -1750,7 +1750,7 @@ class BuildFunctionTest(unittest.TestCase):
         self.assertGreater(len(const_nodes), 0)
 
     def test_build_function_optional_inputs_none(self):
-        """build_function passes None for absent optional inputs."""
+        """build_function passes None for absent optional inputs but declares them."""
 
         def body(op, x, y, z):
             self.assertIsNotNone(x)
@@ -1764,10 +1764,12 @@ class BuildFunctionTest(unittest.TestCase):
             domain="com.test",
             name="OptionalInputs",
         )
-        # Graph should have only 2 inputs (x and z), not 3
-        self.assertEqual(len(fn.graph.inputs), 2)
+        # Graph has 3 inputs: x, a placeholder for the absent y, and z
+        self.assertEqual(len(fn.graph.inputs), 3)
         self.assertEqual(fn.graph.inputs[0].name, "x")
-        self.assertEqual(fn.graph.inputs[1].name, "z")
+        self.assertEqual(fn.graph.inputs[1].name, "input_1")  # placeholder
+        self.assertIsNone(fn.graph.inputs[1].type)  # untyped
+        self.assertEqual(fn.graph.inputs[2].name, "z")
 
     def test_build_function_trace_appends_outputs(self):
         """build_function supports trace functions that append outputs directly."""

--- a/onnxscript/_internal/builder_test.py
+++ b/onnxscript/_internal/builder_test.py
@@ -1441,10 +1441,6 @@ class PartitionInputsAttributesTest(unittest.TestCase):
             )
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class RootInitializerTest(unittest.TestCase):
     """Tests for root-graph initializer storage and lift_initializers_to_constants."""
 
@@ -1485,17 +1481,11 @@ class RootInitializerTest(unittest.TestCase):
         )
         root_builder = builder.GraphBuilder(root_graph)
 
-        captured_values = []
-
         def body1(op, x):
-            result = op.Add(x, 2.0)
-            captured_values.append(result)
-            return result
+            return op.Add(x, 2.0)
 
         def body2(op, x):
-            result = op.Mul(x, 2.0)
-            captured_values.append(result)
-            return result
+            return op.Mul(x, 2.0)
 
         root_builder.subgraph(body1, inputs=[FLOAT[3]], outputs=[FLOAT[3]])
         root_builder.subgraph(body2, inputs=[FLOAT[3]], outputs=[FLOAT[3]])

--- a/onnxscript/_internal/builder_test.py
+++ b/onnxscript/_internal/builder_test.py
@@ -1443,3 +1443,180 @@ class PartitionInputsAttributesTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class RootInitializerTest(unittest.TestCase):
+    """Tests for root-graph initializer storage and lift_initializers_to_constants."""
+
+    def test_subgraph_literal_creates_initializer_in_root(self):
+        """A literal used inside a subgraph creates an initializer in the root graph."""
+        root_graph = ir.Graph(
+            name="main",
+            inputs=[],
+            outputs=[],
+            nodes=[],
+            opset_imports={"": _default_opset_version},
+        )
+        root_builder = builder.GraphBuilder(root_graph)
+
+        def body(op, x):
+            return op.Add(x, 1.0)
+
+        sub = root_builder.subgraph(body, inputs=[FLOAT[3]], outputs=[FLOAT[3]])
+        # Initializer should be in the root graph, not in the subgraph.
+        self.assertTrue(
+            any("const_1.0" in name for name in root_graph.initializers),
+            f"Expected const_1.0 in root initializers: {list(root_graph.initializers)}",
+        )
+        self.assertEqual(
+            len(sub.initializers),
+            0,
+            f"Subgraph should have no initializers: {list(sub.initializers)}",
+        )
+
+    def test_sibling_subgraphs_share_root_cache(self):
+        """Two subgraphs using the same literal share one root initializer."""
+        root_graph = ir.Graph(
+            name="main",
+            inputs=[],
+            outputs=[],
+            nodes=[],
+            opset_imports={"": _default_opset_version},
+        )
+        root_builder = builder.GraphBuilder(root_graph)
+
+        captured_values = []
+
+        def body1(op, x):
+            result = op.Add(x, 2.0)
+            captured_values.append(result)
+            return result
+
+        def body2(op, x):
+            result = op.Mul(x, 2.0)
+            captured_values.append(result)
+            return result
+
+        root_builder.subgraph(body1, inputs=[FLOAT[3]], outputs=[FLOAT[3]])
+        root_builder.subgraph(body2, inputs=[FLOAT[3]], outputs=[FLOAT[3]])
+
+        # Only one initializer should exist (shared via cache).
+        const_names = [n for n in root_graph.initializers if "const_2.0" in n]
+        self.assertEqual(len(const_names), 1, f"Expected 1 shared initializer: {const_names}")
+
+    def test_lift_initializers_to_constants_converts_all(self):
+        """lift_initializers_to_constants replaces initializers with Constant nodes."""
+        graph = ir.Graph(
+            name="func_body",
+            inputs=[],
+            outputs=[],
+            nodes=[],
+            opset_imports={"": _default_opset_version},
+        )
+        gb = builder.GraphBuilder(graph)
+        x = gb.input("x", ir.DataType.FLOAT, ir.Shape([3]))
+        result = gb.op.Add(x, 1.5)
+        gb.add_output(result, "y")
+
+        # Before lift: should have an initializer
+        self.assertTrue(len(graph.initializers) > 0)
+
+        builder.lift_initializers_to_constants(graph)
+
+        # After lift: no initializers, but a Constant node at the start
+        self.assertEqual(len(graph.initializers), 0)
+        first_node = graph.node(0)
+        self.assertEqual(first_node.op_type, "Constant")
+
+    def test_lift_preserves_value_identity(self):
+        """lift_initializers_to_constants reuses existing ir.Value objects."""
+        graph = ir.Graph(
+            name="func_body",
+            inputs=[],
+            outputs=[],
+            nodes=[],
+            opset_imports={"": _default_opset_version},
+        )
+        gb = builder.GraphBuilder(graph)
+        x = gb.input("x", ir.DataType.FLOAT, ir.Shape([3]))
+        # Use the literal 3.14 in two ops so the same ir.Value feeds both
+        const_val = gb.op.Add(x, 3.14)
+        result = gb.op.Mul(const_val, 3.14)
+        gb.add_output(result, "y")
+
+        # Grab the initializer value before lifting
+        init_values = list(graph.initializers.values())
+        self.assertEqual(len(init_values), 1)
+        original_value = init_values[0]
+
+        builder.lift_initializers_to_constants(graph)
+
+        # The Constant node's output should be the same ir.Value object
+        const_node = graph.node(0)
+        self.assertEqual(const_node.op_type, "Constant")
+        self.assertIs(const_node.outputs[0], original_value)
+
+    def test_lift_skips_graph_inputs_that_are_initializers(self):
+        """Graph inputs that are also initializers are NOT lifted."""
+        graph = ir.Graph(
+            name="func_body",
+            inputs=[],
+            outputs=[],
+            nodes=[],
+            opset_imports={"": _default_opset_version},
+        )
+        gb = builder.GraphBuilder(graph)
+        # Create an input that is also an initializer (default value pattern)
+        import numpy as np
+
+        default_tensor = ir.Tensor(np.array([1.0, 2.0, 3.0], dtype=np.float32))
+        input_with_default = gb.input(
+            "bias", ir.DataType.FLOAT, ir.Shape([3]), const_value=default_tensor
+        )
+        x = gb.input("x", ir.DataType.FLOAT, ir.Shape([3]))
+        result = gb.op.Add(x, input_with_default)
+        gb.add_output(result, "y")
+
+        self.assertEqual(len(graph.initializers), 1)
+
+        builder.lift_initializers_to_constants(graph)
+
+        # The input/initializer should NOT have been lifted
+        self.assertEqual(len(graph.initializers), 1)
+        # No Constant nodes should have been created
+        for node in graph:
+            self.assertNotEqual(node.op_type, "Constant")
+
+    def test_function_body_with_literal_after_lift(self):
+        """End-to-end: build a function body with a literal, lift, wrap in ir.Function."""
+        graph = ir.Graph(
+            name="MyFunc_body",
+            inputs=[],
+            outputs=[],
+            nodes=[],
+            opset_imports={"": _default_opset_version},
+        )
+        gb = builder.GraphBuilder(graph)
+        x = gb.input("x", ir.DataType.FLOAT, ir.Shape([3]))
+        # Use a float literal — this creates an initializer
+        scaled = gb.op.Mul(x, 0.5)
+        gb.add_output(scaled, "y")
+
+        # Lift before wrapping in ir.Function
+        builder.lift_initializers_to_constants(graph)
+
+        func = ir.Function(
+            domain="test.domain",
+            name="MyFunc",
+            graph=graph,
+            attributes={},
+        )
+        # Validate: function body should have no initializers
+        self.assertEqual(len(func.graph.initializers), 0)
+        # Should have a Constant node
+        const_nodes = [n for n in func.graph if n.op_type == "Constant"]
+        self.assertEqual(len(const_nodes), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnxscript/_internal/builder_test.py
+++ b/onnxscript/_internal/builder_test.py
@@ -17,7 +17,7 @@ from onnxscript.onnx_types import DOUBLE, FLOAT, INT64
 _default_opset_version = 23
 
 # Convenience alias for tests — creates an ir.Value from (name, TypeSpec).
-_input = builder.make_input
+_input = builder.make_value
 
 
 def _resolve_type_spec(spec: builder.TypeSpec) -> ir.TypeAndShape:
@@ -1857,26 +1857,26 @@ class BuildFunctionTest(unittest.TestCase):
         self.assertGreater(len(const_nodes), 0)
 
 
-class MakeInputTest(unittest.TestCase):
-    """Tests for the make_input() convenience helper."""
+class MakeValueTest(unittest.TestCase):
+    """Tests for the make_value() convenience helper."""
 
-    def test_make_input_name_only(self):
-        """make_input with just a name creates an untyped Value."""
-        v = builder.make_input("x")
+    def test_make_value_name_only(self):
+        """make_value with just a name creates an untyped Value."""
+        v = builder.make_value("x")
         self.assertEqual(v.name, "x")
         self.assertIsNone(v.type)
         self.assertIsNone(v.shape)
 
-    def test_make_input_with_type_spec(self):
-        """make_input with a TypeSpec sets type and shape."""
-        v = builder.make_input("x", FLOAT[3, 4])
+    def test_make_value_with_type_spec(self):
+        """make_value with a TypeSpec sets type and shape."""
+        v = builder.make_value("x", FLOAT[3, 4])
         self.assertEqual(v.name, "x")
         self.assertIsNotNone(v.type)
         self.assertIsNotNone(v.shape)
 
-    def test_make_input_with_dynamic_shape(self):
-        """make_input with symbolic dims works."""
-        v = builder.make_input("x", FLOAT["B", "T"])
+    def test_make_value_with_dynamic_shape(self):
+        """make_value with symbolic dims works."""
+        v = builder.make_value("x", FLOAT["B", "T"])
         self.assertEqual(v.name, "x")
         self.assertIsNotNone(v.shape)
 

--- a/onnxscript/_internal/builder_test.py
+++ b/onnxscript/_internal/builder_test.py
@@ -1813,7 +1813,7 @@ class BuildFunctionTest(unittest.TestCase):
                 [_input("x")],
                 domain="com.test",
                 name="MixedOutputs",
-            opset_imports=_opset,
+                opset_imports=_opset,
             )
 
     def test_build_function_no_outputs_raises(self):
@@ -1829,7 +1829,7 @@ class BuildFunctionTest(unittest.TestCase):
                 [_input("x")],
                 domain="com.test",
                 name="NoOutputs",
-            opset_imports=_opset,
+                opset_imports=_opset,
             )
 
     def test_build_function_input_with_producer_raises(self):
@@ -1844,7 +1844,7 @@ class BuildFunctionTest(unittest.TestCase):
                 [used_value],
                 domain="com.test",
                 name="BadInput",
-            opset_imports=_opset,
+                opset_imports=_opset,
             )
 
     def test_build_function_custom_opset(self):

--- a/onnxscript/_internal/builder_test.py
+++ b/onnxscript/_internal/builder_test.py
@@ -1504,6 +1504,29 @@ class RootInitializerTest(unittest.TestCase):
         const_names = [n for n in root_graph.initializers if "const_2.0" in n]
         self.assertEqual(len(const_names), 1, f"Expected 1 shared initializer: {const_names}")
 
+    def test_direct_initializer_in_subgraph_goes_to_root(self):
+        """builder.initializer() called on a sub-builder registers in root graph."""
+        import numpy as np
+
+        root_graph = ir.Graph(
+            name="main",
+            inputs=[],
+            outputs=[],
+            nodes=[],
+            opset_imports={"": _default_opset_version},
+        )
+        root_builder = builder.GraphBuilder(root_graph)
+
+        def body(op, x):
+            tensor = ir.Tensor(np.array([1.0, 2.0], dtype=np.float32))
+            bias = op.builder.initializer(tensor, name="my_bias")
+            return op.Add(x, bias)
+
+        sub = root_builder.subgraph(body, inputs=[FLOAT[3]], outputs=[FLOAT[3]])
+        # Initializer should be in root, not subgraph
+        self.assertIn("my_bias", root_graph.initializers)
+        self.assertEqual(len(sub.initializers), 0)
+
     def test_lift_initializers_to_constants_converts_all(self):
         """lift_initializers_to_constants replaces initializers with Constant nodes."""
         graph = ir.Graph(

--- a/onnxscript/_internal/builder_test.py
+++ b/onnxscript/_internal/builder_test.py
@@ -1532,7 +1532,7 @@ class RootInitializerTest(unittest.TestCase):
         gb.add_output(result, "y")
 
         # Before lift: should have an initializer
-        self.assertTrue(len(graph.initializers) > 0)
+        self.assertGreater(len(graph.initializers), 0)
 
         builder.lift_initializers_to_constants(graph)
 

--- a/onnxscript/_internal/builder_test.py
+++ b/onnxscript/_internal/builder_test.py
@@ -1847,6 +1847,27 @@ class BuildFunctionTest(unittest.TestCase):
                 opset_imports=_opset,
             )
 
+    def test_build_function_input_attached_to_graph_raises(self):
+        """build_function raises for inputs already attached to a graph."""
+        graph = ir.Graph(
+            name="other",
+            inputs=[],
+            outputs=[],
+            nodes=[],
+            opset_imports={"": 23},
+        )
+        attached = ir.Value(name="attached")
+        graph.inputs.append(attached)
+
+        with self.assertRaises(ValueError):
+            builder.build_function(
+                lambda op, x: op.Identity(x),
+                [attached],
+                domain="com.test",
+                name="AttachedInput",
+                opset_imports=_opset,
+            )
+
     def test_build_function_custom_opset(self):
         """build_function passes custom opset_imports to the graph."""
         fn = builder.build_function(

--- a/onnxscript/nn/_module_test.py
+++ b/onnxscript/nn/_module_test.py
@@ -74,7 +74,7 @@ class ParameterTest(unittest.TestCase):
 
     def test_realize_in_subgraph_registers_in_root(self):
         """Parameter realized inside a subgraph builder is stored in the root graph."""
-        from onnxscript._internal.builder import GraphBuilder, make_input
+        from onnxscript._internal.builder import GraphBuilder, make_value
         from onnxscript.onnx_types import FLOAT
 
         root_graph = ir.Graph(
@@ -95,8 +95,8 @@ class ParameterTest(unittest.TestCase):
 
         _sub_graph = root_builder.subgraph(
             body_fn,
-            inputs=[make_input("x", FLOAT[3, 4])],
-            outputs=[make_input("y", FLOAT[3, 4])],
+            inputs=[make_value("x", FLOAT[3, 4])],
+            outputs=[make_value("y", FLOAT[3, 4])],
         )
         # Parameter should be in the ROOT graph's initializers, not the subgraph's
         self.assertIn("weight", root_graph.initializers)
@@ -106,7 +106,7 @@ class ParameterTest(unittest.TestCase):
 
     def test_realize_in_nested_subgraph_registers_in_root(self):
         """Parameter realized in a doubly-nested subgraph goes to the root graph."""
-        from onnxscript._internal.builder import GraphBuilder, build_graph, make_input
+        from onnxscript._internal.builder import GraphBuilder, build_graph, make_value
         from onnxscript.onnx_types import FLOAT
 
         root_graph = ir.Graph(
@@ -128,16 +128,16 @@ class ParameterTest(unittest.TestCase):
             # Build a nested subgraph
             build_graph(
                 inner_fn,
-                inputs=[make_input("x", FLOAT[3])],
-                outputs=[make_input("y", FLOAT[3])],
+                inputs=[make_value("x", FLOAT[3])],
+                outputs=[make_value("y", FLOAT[3])],
                 parent=op.builder,
             )
             return op.Identity(x)
 
         root_builder.subgraph(
             outer_fn,
-            inputs=[make_input("x", FLOAT[3])],
-            outputs=[make_input("y", FLOAT[3])],
+            inputs=[make_value("x", FLOAT[3])],
+            outputs=[make_value("y", FLOAT[3])],
         )
         # Even through two levels of nesting, param ends up in root
         self.assertIn("bias", root_graph.initializers)

--- a/onnxscript/nn/_module_test.py
+++ b/onnxscript/nn/_module_test.py
@@ -131,6 +131,7 @@ class ParameterTest(unittest.TestCase):
                 inputs=[make_value("x", FLOAT[3])],
                 outputs=[make_value("y", FLOAT[3])],
                 parent=op.builder,
+                opset_imports={"": 23},
             )
             return op.Identity(x)
 

--- a/onnxscript/nn/_module_test.py
+++ b/onnxscript/nn/_module_test.py
@@ -74,7 +74,7 @@ class ParameterTest(unittest.TestCase):
 
     def test_realize_in_subgraph_registers_in_root(self):
         """Parameter realized inside a subgraph builder is stored in the root graph."""
-        from onnxscript._internal.builder import GraphBuilder
+        from onnxscript._internal.builder import GraphBuilder, make_input
         from onnxscript.onnx_types import FLOAT
 
         root_graph = ir.Graph(
@@ -95,8 +95,8 @@ class ParameterTest(unittest.TestCase):
 
         _sub_graph = root_builder.subgraph(
             body_fn,
-            inputs=[FLOAT[3, 4]],
-            outputs=[FLOAT[3, 4]],
+            inputs=[make_input("x", FLOAT[3, 4])],
+            outputs=[make_input("y", FLOAT[3, 4])],
         )
         # Parameter should be in the ROOT graph's initializers, not the subgraph's
         self.assertIn("weight", root_graph.initializers)
@@ -106,7 +106,7 @@ class ParameterTest(unittest.TestCase):
 
     def test_realize_in_nested_subgraph_registers_in_root(self):
         """Parameter realized in a doubly-nested subgraph goes to the root graph."""
-        from onnxscript._internal.builder import GraphBuilder, build_graph
+        from onnxscript._internal.builder import GraphBuilder, build_graph, make_input
         from onnxscript.onnx_types import FLOAT
 
         root_graph = ir.Graph(
@@ -128,16 +128,16 @@ class ParameterTest(unittest.TestCase):
             # Build a nested subgraph
             build_graph(
                 inner_fn,
-                inputs=[FLOAT[3]],
-                outputs=[FLOAT[3]],
+                inputs=[make_input("x", FLOAT[3])],
+                outputs=[make_input("y", FLOAT[3])],
                 parent=op.builder,
             )
             return op.Identity(x)
 
         root_builder.subgraph(
             outer_fn,
-            inputs=[FLOAT[3]],
-            outputs=[FLOAT[3]],
+            inputs=[make_input("x", FLOAT[3])],
+            outputs=[make_input("y", FLOAT[3])],
         )
         # Even through two levels of nesting, param ends up in root
         self.assertIn("bias", root_graph.initializers)


### PR DESCRIPTION
Motivation: Use of some standard graph-building techniques in Mobius fail when used to create ir.Function, because ONNX Functions do not allow initializers. This PR helps address this. It also reduces some of the boiler-plate code in creating functions via an utility function.

(a) Update the logic for creating initializers to ensure that they are always added to the root (main) Graph.
(b) Add a utility to convert initializers into Constant nodes (which is necessary for a Function in ONNX).
(c) Add a utility to build a function

Note: An alternative considered was adding an option to the GraphBuilder so that we automatically construct Constant nodes instead of initializers when the options says so. While that avoids the extra pass in the end, it has some minor implications to what the graph would look like (in terms of whether we want all Constant nodes upfront in one place, and what kind of node-names (based on node numbering) we generate etc. Hence, leaving it in the current form. But it can be changed as above if desirable. 

Usage: With the utility function, we should be able to create ir.Functions as below (example from Mobius).
```python
def causal_conv_nd_with_state(*, kernel_size, channels, ndim, activation):
    def body(op, input_val, weight_val, bias_val, conv_state_val):
        # ... body (unchanged) ...
        return output, present_state

    return builder.build_function(
        body,
        [
            ir.Value(name="input"),
            ir.Value(name="weight"),
            ir.Value(name="bias"),
            ir.Value(name="conv_state"),
        ],
        domain=DOMAIN,
        name="CausalConvWithState",
        attributes=[ir.Attr("activation", ir.AttributeType.STRING, activation)],
        opset_imports={"": OPSET_VERSION},
    )
```