### PR TITLE
Make GraphBuilder.__init__ use keyword-only args after graph

### DIFF
--- a/onnxscript/_internal/builder.py
+++ b/onnxscript/_internal/builder.py
@@ -421,7 +421,7 @@ def build_function(
 class GraphBuilder:
     """Imperative builder for constructing ONNX IR graphs with automatic constant promotion, type casting, and shape inference."""
 
-    def __init__(self, graph: ir.Graph, parent: GraphBuilder | None = None) -> None:
+    def __init__(self, graph: ir.Graph, *, parent: GraphBuilder | None = None) -> None:
         self._graph = graph
         self._parent = parent
         self._root: GraphBuilder = parent._root if parent is not None else self


### PR DESCRIPTION
Add '*' separator so that 'parent' (and future parameters like 'options') must be passed as keyword arguments, improving API stability and readability.