### PR TITLE
Add more fusion test-cases (part 1)

### DIFF
--- a/onnxscript/rewriter/ort_fusions/erfgelu_test.py
+++ b/onnxscript/rewriter/ort_fusions/erfgelu_test.py
@@ -1,0 +1,143 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import math
+import unittest
+
+import numpy as np
+import onnx_ir as ir
+
+import onnxscript.rewriter.ort_fusions._test_utils as test_utils
+from onnxscript import FLOAT, script
+from onnxscript import opset18 as op
+from onnxscript.optimizer import optimize, remove_unused_nodes
+from onnxscript.rewriter.ort_fusions.erfgelu import fuse_erfgelu
+
+_SQRT_TWO = math.sqrt(2.0)
+
+
+class ErfGeluFusionTest(unittest.TestCase):
+    """Tests for erf-based GELU fusion patterns in erfgelu.py.
+
+    Pattern 1: 0.5 * (x * (erf(x / sqrt(2)) + 1))
+    Pattern 2: x * (0.5 * (erf(x / sqrt(2)) + 1))
+    """
+
+    def _check_fusion(self, model, input):
+        original_output = test_utils.ort_run("Original", model, input)
+        fuse_erfgelu(model)
+        remove_unused_nodes(model)
+        self.assertEqual(len(model.graph), 1)
+        self.assertEqual(model.graph.node(0).op_type, "Gelu")
+        self.assertEqual(model.graph.node(0).domain, "com.microsoft")
+        optimized_output = test_utils.ort_run("Optimized", model, input)
+        test_utils.assert_allclose(original_output, optimized_output)
+
+    def _check_no_fusion(self, model):
+        node_count_before = len(model.graph)
+        fuse_erfgelu(model)
+        remove_unused_nodes(model)
+        self.assertEqual(len(model.graph), node_count_before)
+        self.assertTrue(
+            all(node.op_type != "Gelu" for node in model.graph),
+            "Gelu node should not be present after failed fusion",
+        )
+
+    def _build_model(self, script_fn, shape):
+        model_proto = script_fn.to_model_proto(
+            input_types=[FLOAT[shape]], output_types=[FLOAT[shape]]
+        )
+        model = ir.serde.deserialize_model(model_proto)
+        optimize(model)
+        return model
+
+    def test_pattern1_half_times_x_times_erf_plus_one(self):
+        """Pattern 1: 0.5 * (x * (erf(x / sqrt(2)) + 1))"""
+
+        @script()
+        def erf_gelu_p1(x):
+            t1 = op.Div(x, _SQRT_TWO)
+            t2 = op.Erf(t1)
+            t3 = op.Add(t2, 1.0)
+            t4 = op.Mul(x, t3)
+            return op.Mul(0.5, t4)
+
+        model = self._build_model(erf_gelu_p1, 10)
+        input = {"x": np.random.randn(10).astype(np.float32)}
+        self._check_fusion(model, input)
+
+    def test_pattern2_x_times_half_times_erf_plus_one(self):
+        """Pattern 2: x * (0.5 * (erf(x / sqrt(2)) + 1))"""
+
+        @script()
+        def erf_gelu_p2(x):
+            t1 = op.Div(x, _SQRT_TWO)
+            t2 = op.Erf(t1)
+            t3 = op.Add(t2, 1.0)
+            t4 = op.Mul(0.5, t3)
+            return op.Mul(x, t4)
+
+        model = self._build_model(erf_gelu_p2, 10)
+        input = {"x": np.random.randn(10).astype(np.float32)}
+        self._check_fusion(model, input)
+
+    def test_multidimensional_input(self):
+        """Verify fusion works with 3D inputs (batch, seq, hidden)."""
+
+        @script()
+        def erf_gelu_3d(x):
+            t1 = op.Div(x, _SQRT_TWO)
+            t2 = op.Erf(t1)
+            t3 = op.Add(t2, 1.0)
+            t4 = op.Mul(x, t3)
+            return op.Mul(0.5, t4)
+
+        model = self._build_model(erf_gelu_3d, (2, 4, 8))
+        input = {"x": np.random.randn(2, 4, 8).astype(np.float32)}
+        self._check_fusion(model, input)
+
+    def test_no_fusion_without_erf(self):
+        """Replacing Erf with Tanh should not match the erf-gelu pattern."""
+
+        @script()
+        def not_erf_gelu(x):
+            t1 = op.Div(x, _SQRT_TWO)
+            t2 = op.Tanh(t1)
+            t3 = op.Add(t2, 1.0)
+            t4 = op.Mul(x, t3)
+            return op.Mul(0.5, t4)
+
+        model = self._build_model(not_erf_gelu, 10)
+        self._check_no_fusion(model)
+
+    def test_no_fusion_wrong_divisor(self):
+        """Using a divisor other than sqrt(2) should not match."""
+
+        @script()
+        def wrong_divisor(x):
+            t1 = op.Div(x, 2.0)
+            t2 = op.Erf(t1)
+            t3 = op.Add(t2, 1.0)
+            t4 = op.Mul(x, t3)
+            return op.Mul(0.5, t4)
+
+        model = self._build_model(wrong_divisor, 10)
+        self._check_no_fusion(model)
+
+    def test_no_fusion_wrong_scale(self):
+        """Using 0.3 instead of 0.5 should not match."""
+
+        @script()
+        def wrong_scale(x):
+            t1 = op.Div(x, _SQRT_TWO)
+            t2 = op.Erf(t1)
+            t3 = op.Add(t2, 1.0)
+            t4 = op.Mul(x, t3)
+            return op.Mul(0.3, t4)
+
+        model = self._build_model(wrong_scale, 10)
+        self._check_no_fusion(model)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnxscript/rewriter/ort_fusions/mha_bias_test.py
+++ b/onnxscript/rewriter/ort_fusions/mha_bias_test.py
@@ -118,14 +118,14 @@ class FuseBiasMHATest(unittest.TestCase):
         model = self._build(
             _mha_all_biases,
             input_types=[
-                FLOAT[_B, _S, _D],
-                FLOAT[_B, _S, _Dk],
-                FLOAT[_B, _S, _Dv],
+                FLOAT["B", "S", _D],
+                FLOAT["B", "S", _Dk],
+                FLOAT["B", "S", _Dv],
                 FLOAT[_D],
                 FLOAT[_Dk],
                 FLOAT[_Dv],
             ],
-            output_types=[FLOAT[_B, _S, _D]],
+            output_types=[FLOAT["B", "S", _D]],
         )
         inputs = {
             "query_matmul": np.random.randn(_B, _S, _D).astype(np.float32),
@@ -145,12 +145,12 @@ class FuseBiasMHATest(unittest.TestCase):
         model = self._build(
             _mha_q_bias_only,
             input_types=[
-                FLOAT[_B, _S, _D],
-                FLOAT[_B, _S, _Dk],
-                FLOAT[_B, _S, _Dv],
+                FLOAT["B", "S", _D],
+                FLOAT["B", "S", _Dk],
+                FLOAT["B", "S", _Dv],
                 FLOAT[_D],
             ],
-            output_types=[FLOAT[_B, _S, _D]],
+            output_types=[FLOAT["B", "S", _D]],
         )
         inputs = {
             "query_matmul": np.random.randn(_B, _S, _D).astype(np.float32),
@@ -167,12 +167,12 @@ class FuseBiasMHATest(unittest.TestCase):
         model = self._build(
             _mha_k_bias_only,
             input_types=[
-                FLOAT[_B, _S, _D],
-                FLOAT[_B, _S, _Dk],
-                FLOAT[_B, _S, _Dv],
+                FLOAT["B", "S", _D],
+                FLOAT["B", "S", _Dk],
+                FLOAT["B", "S", _Dv],
                 FLOAT[_Dk],
             ],
-            output_types=[FLOAT[_B, _S, _D]],
+            output_types=[FLOAT["B", "S", _D]],
         )
         inputs = {
             "query_matmul": np.random.randn(_B, _S, _D).astype(np.float32),
@@ -188,12 +188,12 @@ class FuseBiasMHATest(unittest.TestCase):
         model = self._build(
             _mha_v_bias_only,
             input_types=[
-                FLOAT[_B, _S, _D],
-                FLOAT[_B, _S, _Dk],
-                FLOAT[_B, _S, _Dv],
+                FLOAT["B", "S", _D],
+                FLOAT["B", "S", _Dk],
+                FLOAT["B", "S", _Dv],
                 FLOAT[_Dv],
             ],
-            output_types=[FLOAT[_B, _S, _D]],
+            output_types=[FLOAT["B", "S", _D]],
         )
         inputs = {
             "query_matmul": np.random.randn(_B, _S, _D).astype(np.float32),
@@ -209,13 +209,13 @@ class FuseBiasMHATest(unittest.TestCase):
         model = self._build(
             _mha_qk_biases,
             input_types=[
-                FLOAT[_B, _S, _D],
-                FLOAT[_B, _S, _Dk],
-                FLOAT[_B, _S, _Dv],
+                FLOAT["B", "S", _D],
+                FLOAT["B", "S", _Dk],
+                FLOAT["B", "S", _Dv],
                 FLOAT[_D],
                 FLOAT[_Dk],
             ],
-            output_types=[FLOAT[_B, _S, _D]],
+            output_types=[FLOAT["B", "S", _D]],
         )
         inputs = {
             "query_matmul": np.random.randn(_B, _S, _D).astype(np.float32),
@@ -232,8 +232,8 @@ class FuseBiasMHATest(unittest.TestCase):
         """No bias Adds at all → rule should not apply."""
         model = self._build(
             _mha_no_biases,
-            input_types=[FLOAT[_B, _S, _D], FLOAT[_B, _S, _Dk], FLOAT[_B, _S, _Dv]],
-            output_types=[FLOAT[_B, _S, _D]],
+            input_types=[FLOAT["B", "S", _D], FLOAT["B", "S", _Dk], FLOAT["B", "S", _Dv]],
+            output_types=[FLOAT["B", "S", _D]],
         )
         count = self._apply(model)
         self.assertEqual(count, 0)
@@ -244,12 +244,12 @@ class FuseBiasMHATest(unittest.TestCase):
         model = self._build(
             _mha_int32_with_bias,
             input_types=[
-                INT32[_B, _S, _D],
-                INT32[_B, _S, _Dk],
-                INT32[_B, _S, _Dv],
+                INT32["B", "S", _D],
+                INT32["B", "S", _Dk],
+                INT32["B", "S", _Dv],
                 INT32[_D],
             ],
-            output_types=[INT32[_B, _S, _D]],
+            output_types=[INT32["B", "S", _D]],
         )
         count = self._apply(model)
         self.assertEqual(count, 0)
@@ -259,12 +259,12 @@ class FuseBiasMHATest(unittest.TestCase):
         model = self._build(
             _mha_rank2_query_with_bias,
             input_types=[
-                FLOAT[_S, _D],
-                FLOAT[_B, _S, _Dk],
-                FLOAT[_B, _S, _Dv],
+                FLOAT["S", _D],
+                FLOAT["B", "S", _Dk],
+                FLOAT["B", "S", _Dv],
                 FLOAT[_D],
             ],
-            output_types=[FLOAT[_B, _S, _D]],
+            output_types=[FLOAT["B", "S", _D]],
         )
         count = self._apply(model)
         self.assertEqual(count, 0)

--- a/onnxscript/rewriter/ort_fusions/mha_bias_test.py
+++ b/onnxscript/rewriter/ort_fusions/mha_bias_test.py
@@ -14,14 +14,13 @@ import unittest
 import numpy as np
 import onnx_ir as ir
 
-import onnxscript
-import onnxscript.rewriter.ort_fusions._test_utils as test_utils
-from onnxscript import FLOAT, INT32, script
+from onnxscript import FLOAT, INT32, script, values
 from onnxscript import opset18 as op
 from onnxscript.optimizer import optimize
+from onnxscript.rewriter.ort_fusions import _test_utils as test_utils
 from onnxscript.rewriter.ort_fusions.mha_bias import fuse_mha_bias
 
-msft_op = onnxscript.values.Opset("com.microsoft", 1)
+msft_op = values.Opset("com.microsoft", 1)
 
 _B, _S, _D, _Dk, _Dv = 2, 8, 16, 16, 16
 _NUM_HEADS = 4

--- a/onnxscript/rewriter/ort_fusions/mha_bias_test.py
+++ b/onnxscript/rewriter/ort_fusions/mha_bias_test.py
@@ -1,0 +1,274 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Unit tests for FuseBiasMHA rule (mha_bias.py).
+
+The rule detects Add(matmul, bias) before MultiHeadAttention inputs and
+fuses the biases into the MHA's consolidated bias input (Concat of q/k/v biases).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import onnx_ir as ir
+
+import onnxscript
+import onnxscript.rewriter.ort_fusions._test_utils as test_utils
+from onnxscript import FLOAT, INT32, script
+from onnxscript import opset18 as op
+from onnxscript.optimizer import optimize
+from onnxscript.rewriter.ort_fusions.mha_bias import fuse_mha_bias
+
+msft_op = onnxscript.values.Opset("com.microsoft", 1)
+
+_B, _S, _D, _Dk, _Dv = 2, 8, 16, 16, 16
+_NUM_HEADS = 4
+
+
+def _count_op(model: ir.Model, op_type: str, domain: str = "") -> int:
+    return sum(1 for node in model.graph if node.op_type == op_type and node.domain == domain)
+
+
+# --- Script models for positive tests ---
+
+
+@script()
+def _mha_all_biases(query_matmul, key_matmul, value_matmul, q_bias, k_bias, v_bias):
+    query = op.Add(query_matmul, q_bias)
+    key = op.Add(key_matmul, k_bias)
+    value = op.Add(value_matmul, v_bias)
+    return msft_op.MultiHeadAttention(query, key, value, num_heads=_NUM_HEADS)
+
+
+@script()
+def _mha_q_bias_only(query_matmul, key_matmul, value_matmul, q_bias):
+    query = op.Add(query_matmul, q_bias)
+    return msft_op.MultiHeadAttention(query, key_matmul, value_matmul, num_heads=_NUM_HEADS)
+
+
+@script()
+def _mha_k_bias_only(query_matmul, key_matmul, value_matmul, k_bias):
+    key = op.Add(key_matmul, k_bias)
+    return msft_op.MultiHeadAttention(query_matmul, key, value_matmul, num_heads=_NUM_HEADS)
+
+
+@script()
+def _mha_v_bias_only(query_matmul, key_matmul, value_matmul, v_bias):
+    value = op.Add(value_matmul, v_bias)
+    return msft_op.MultiHeadAttention(query_matmul, key_matmul, value, num_heads=_NUM_HEADS)
+
+
+@script()
+def _mha_qk_biases(query_matmul, key_matmul, value_matmul, q_bias, k_bias):
+    query = op.Add(query_matmul, q_bias)
+    key = op.Add(key_matmul, k_bias)
+    return msft_op.MultiHeadAttention(query, key, value_matmul, num_heads=_NUM_HEADS)
+
+
+# --- Script models for negative tests ---
+
+
+@script()
+def _mha_no_biases(query_matmul, key_matmul, value_matmul):
+    return msft_op.MultiHeadAttention(
+        query_matmul, key_matmul, value_matmul, num_heads=_NUM_HEADS
+    )
+
+
+@script()
+def _mha_int32_with_bias(query_matmul, key_matmul, value_matmul, q_bias):
+    query = op.Add(query_matmul, q_bias)
+    return msft_op.MultiHeadAttention(query, key_matmul, value_matmul, num_heads=_NUM_HEADS)
+
+
+@script()
+def _mha_rank2_query_with_bias(query_matmul, key_matmul, value_matmul, q_bias):
+    query = op.Add(query_matmul, q_bias)
+    return msft_op.MultiHeadAttention(query, key_matmul, value_matmul, num_heads=_NUM_HEADS)
+
+
+class FuseBiasMHATest(unittest.TestCase):
+    """Unit tests for the FuseBiasMHA rewrite rule."""
+
+    def _build(self, script_fn, input_types, output_types) -> ir.Model:
+        model_proto = script_fn.to_model_proto(
+            input_types=input_types, output_types=output_types
+        )
+        model = ir.serde.deserialize_model(model_proto)
+        optimize(model)
+        return model
+
+    def _apply(self, model: ir.Model) -> int:
+        return fuse_mha_bias(model)
+
+    def _check_numerical_equivalence(self, model: ir.Model, inputs: dict, expected_count: int):
+        """Apply fusion and verify the result is numerically equivalent."""
+        original_output = test_utils.ort_run("Original", model, inputs)
+        count = self._apply(model)
+        self.assertEqual(count, expected_count)
+        fused_output = test_utils.ort_run("Fused", model, inputs)
+        test_utils.assert_allclose(original_output, fused_output)
+
+    # --- Positive tests: fusion should apply with numerical validation ---
+
+    def test_all_three_biases_fused(self):
+        """Q, K, V all have bias Adds → fused into MHA bias input."""
+        model = self._build(
+            _mha_all_biases,
+            input_types=[
+                FLOAT[_B, _S, _D],
+                FLOAT[_B, _S, _Dk],
+                FLOAT[_B, _S, _Dv],
+                FLOAT[_D],
+                FLOAT[_Dk],
+                FLOAT[_Dv],
+            ],
+            output_types=[FLOAT[_B, _S, _D]],
+        )
+        inputs = {
+            "query_matmul": np.random.randn(_B, _S, _D).astype(np.float32),
+            "key_matmul": np.random.randn(_B, _S, _Dk).astype(np.float32),
+            "value_matmul": np.random.randn(_B, _S, _Dv).astype(np.float32),
+            "q_bias": np.random.randn(_D).astype(np.float32),
+            "k_bias": np.random.randn(_Dk).astype(np.float32),
+            "v_bias": np.random.randn(_Dv).astype(np.float32),
+        }
+        self._check_numerical_equivalence(model, inputs, expected_count=1)
+        self.assertEqual(_count_op(model, "Add"), 0)
+        self.assertEqual(_count_op(model, "Concat"), 1)
+        self.assertEqual(_count_op(model, "MultiHeadAttention", "com.microsoft"), 1)
+
+    def test_only_q_bias(self):
+        """Only query has a bias Add → still fuses (k/v get zero biases)."""
+        model = self._build(
+            _mha_q_bias_only,
+            input_types=[
+                FLOAT[_B, _S, _D],
+                FLOAT[_B, _S, _Dk],
+                FLOAT[_B, _S, _Dv],
+                FLOAT[_D],
+            ],
+            output_types=[FLOAT[_B, _S, _D]],
+        )
+        inputs = {
+            "query_matmul": np.random.randn(_B, _S, _D).astype(np.float32),
+            "key_matmul": np.random.randn(_B, _S, _Dk).astype(np.float32),
+            "value_matmul": np.random.randn(_B, _S, _Dv).astype(np.float32),
+            "q_bias": np.random.randn(_D).astype(np.float32),
+        }
+        self._check_numerical_equivalence(model, inputs, expected_count=1)
+        self.assertEqual(_count_op(model, "Add"), 0)
+        self.assertEqual(_count_op(model, "Concat"), 1)
+
+    def test_only_k_bias(self):
+        """Only key has a bias Add → still fuses."""
+        model = self._build(
+            _mha_k_bias_only,
+            input_types=[
+                FLOAT[_B, _S, _D],
+                FLOAT[_B, _S, _Dk],
+                FLOAT[_B, _S, _Dv],
+                FLOAT[_Dk],
+            ],
+            output_types=[FLOAT[_B, _S, _D]],
+        )
+        inputs = {
+            "query_matmul": np.random.randn(_B, _S, _D).astype(np.float32),
+            "key_matmul": np.random.randn(_B, _S, _Dk).astype(np.float32),
+            "value_matmul": np.random.randn(_B, _S, _Dv).astype(np.float32),
+            "k_bias": np.random.randn(_Dk).astype(np.float32),
+        }
+        self._check_numerical_equivalence(model, inputs, expected_count=1)
+        self.assertEqual(_count_op(model, "Add"), 0)
+
+    def test_only_v_bias(self):
+        """Only value has a bias Add → still fuses."""
+        model = self._build(
+            _mha_v_bias_only,
+            input_types=[
+                FLOAT[_B, _S, _D],
+                FLOAT[_B, _S, _Dk],
+                FLOAT[_B, _S, _Dv],
+                FLOAT[_Dv],
+            ],
+            output_types=[FLOAT[_B, _S, _D]],
+        )
+        inputs = {
+            "query_matmul": np.random.randn(_B, _S, _D).astype(np.float32),
+            "key_matmul": np.random.randn(_B, _S, _Dk).astype(np.float32),
+            "value_matmul": np.random.randn(_B, _S, _Dv).astype(np.float32),
+            "v_bias": np.random.randn(_Dv).astype(np.float32),
+        }
+        self._check_numerical_equivalence(model, inputs, expected_count=1)
+        self.assertEqual(_count_op(model, "Add"), 0)
+
+    def test_q_and_k_bias_only(self):
+        """Q and K have biases, V does not → still fuses."""
+        model = self._build(
+            _mha_qk_biases,
+            input_types=[
+                FLOAT[_B, _S, _D],
+                FLOAT[_B, _S, _Dk],
+                FLOAT[_B, _S, _Dv],
+                FLOAT[_D],
+                FLOAT[_Dk],
+            ],
+            output_types=[FLOAT[_B, _S, _D]],
+        )
+        inputs = {
+            "query_matmul": np.random.randn(_B, _S, _D).astype(np.float32),
+            "key_matmul": np.random.randn(_B, _S, _Dk).astype(np.float32),
+            "value_matmul": np.random.randn(_B, _S, _Dv).astype(np.float32),
+            "q_bias": np.random.randn(_D).astype(np.float32),
+            "k_bias": np.random.randn(_Dk).astype(np.float32),
+        }
+        self._check_numerical_equivalence(model, inputs, expected_count=1)
+
+    # --- Negative tests: fusion should NOT apply ---
+
+    def test_no_biases_no_fusion(self):
+        """No bias Adds at all → rule should not apply."""
+        model = self._build(
+            _mha_no_biases,
+            input_types=[FLOAT[_B, _S, _D], FLOAT[_B, _S, _Dk], FLOAT[_B, _S, _Dv]],
+            output_types=[FLOAT[_B, _S, _D]],
+        )
+        count = self._apply(model)
+        self.assertEqual(count, 0)
+        self.assertEqual(_count_op(model, "Concat"), 0)
+
+    def test_int32_dtype_no_fusion(self):
+        """Integer query dtype → check rejects non-float types."""
+        model = self._build(
+            _mha_int32_with_bias,
+            input_types=[
+                INT32[_B, _S, _D],
+                INT32[_B, _S, _Dk],
+                INT32[_B, _S, _Dv],
+                INT32[_D],
+            ],
+            output_types=[INT32[_B, _S, _D]],
+        )
+        count = self._apply(model)
+        self.assertEqual(count, 0)
+
+    def test_shape_mismatch_no_fusion(self):
+        """Query with rank-2 shape [S, D] instead of [B, S, D] → check rejects."""
+        model = self._build(
+            _mha_rank2_query_with_bias,
+            input_types=[
+                FLOAT[_S, _D],
+                FLOAT[_B, _S, _Dk],
+                FLOAT[_B, _S, _Dv],
+                FLOAT[_D],
+            ],
+            output_types=[FLOAT[_B, _S, _D]],
+        )
+        count = self._apply(model)
+        self.assertEqual(count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnxscript/rewriter/ort_fusions/mha_scale_test.py
+++ b/onnxscript/rewriter/ort_fusions/mha_scale_test.py
@@ -1,0 +1,198 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Unit tests for FuseMHAScale rule (mha_scale.py).
+
+The rule detects Mul(query, constant_scale) before MultiHeadAttention and
+fuses the scaling into the MHA's ``scale`` attribute.
+"""
+
+from __future__ import annotations
+
+import math
+import unittest
+
+import numpy as np
+import onnx_ir as ir
+
+import onnxscript
+import onnxscript.rewriter.ort_fusions._test_utils as test_utils
+from onnxscript import FLOAT, script
+from onnxscript import opset18 as op
+from onnxscript.optimizer import optimize
+from onnxscript.rewriter.ort_fusions.mha_scale import fuse_mha_scale
+
+msft_op = onnxscript.values.Opset("com.microsoft", 1)
+
+_B, _S, _D = 2, 8, 16
+_NUM_HEADS = 4
+_HEAD_SIZE = _D // _NUM_HEADS
+_DEFAULT_SCALE = 1.0 / math.sqrt(_HEAD_SIZE)
+
+# Pre-computed constant for use inside @script functions
+_SCALE_VALUE = 0.25
+
+
+# --- Script models ---
+
+
+@script()
+def _mha_with_scalar_scale(query, key, value, scale):
+    scaled_q = op.Mul(query, scale)
+    return msft_op.MultiHeadAttention(scaled_q, key, value, num_heads=_NUM_HEADS)
+
+
+@script()
+def _mha_no_scale(query, key, value):
+    return msft_op.MultiHeadAttention(query, key, value, num_heads=_NUM_HEADS)
+
+
+@script()
+def _mha_with_dynamic_scale(query, key, value, scale):
+    """Scale is a graph input (not constant) → fusion should not apply."""
+    scaled_q = op.Mul(query, scale)
+    return msft_op.MultiHeadAttention(scaled_q, key, value, num_heads=_NUM_HEADS)
+
+
+class FuseMHAScaleTest(unittest.TestCase):
+    """Unit tests for the FuseMHAScale rewrite rule."""
+
+    def _build(self, script_fn, input_types, output_types) -> ir.Model:
+        model_proto = script_fn.to_model_proto(
+            input_types=input_types, output_types=output_types
+        )
+        model = ir.serde.deserialize_model(model_proto)
+        optimize(model)
+        return model
+
+    def _apply(self, model: ir.Model) -> int:
+        return fuse_mha_scale(model)
+
+    def _get_mha_node(self, model: ir.Model) -> ir.Node | None:
+        for node in model.graph:
+            if node.op_type == "MultiHeadAttention" and node.domain == "com.microsoft":
+                return node
+        return None
+
+    def _make_scale_constant(self, model: ir.Model, scale_value: float):
+        """Convert the ``scale`` graph input into a constant initializer."""
+        for node in model.graph:
+            if node.op_type == "Mul":
+                scale_input = node.inputs[1]
+                assert scale_input is not None
+                scale_input.const_value = ir.tensor(np.array([scale_value], dtype=np.float32))
+                model.graph.inputs.pop()
+                return
+        raise RuntimeError("Mul node not found")
+
+    def _check_numerical_equivalence(
+        self, model: ir.Model, inputs: dict, scale_value: float, expected_count: int
+    ):
+        # Run original model *before* making scale constant (scale is a graph input)
+        inputs_with_scale = {
+            **inputs,
+            "scale": np.array([scale_value], dtype=np.float32),
+        }
+        original_output = test_utils.ort_run("Original", model, inputs_with_scale)
+        # Now convert scale to constant and apply fusion
+        self._make_scale_constant(model, scale_value)
+        count = self._apply(model)
+        self.assertEqual(count, expected_count)
+        fused_output = test_utils.ort_run("Fused", model, inputs)
+        test_utils.assert_allclose(original_output, fused_output)
+
+    # --- Positive tests ---
+
+    def _build_scale_model(self):
+        return self._build(
+            _mha_with_scalar_scale,
+            input_types=[
+                FLOAT["B", "S", _D],
+                FLOAT["B", "S", _D],
+                FLOAT["B", "S", _D],
+                FLOAT[1],
+            ],
+            output_types=[FLOAT["B", "S", _D]],
+        )
+
+    def _make_inputs(self):
+        return {
+            "query": np.random.randn(_B, _S, _D).astype(np.float32),
+            "key": np.random.randn(_B, _S, _D).astype(np.float32),
+            "value": np.random.randn(_B, _S, _D).astype(np.float32),
+        }
+
+    def test_scalar_scale_fused(self):
+        """Mul(query, scalar_constant) before MHA → scale absorbed into attribute."""
+        model = self._build_scale_model()
+        inputs = self._make_inputs()
+        self._check_numerical_equivalence(model, inputs, _SCALE_VALUE, expected_count=1)
+        # Verify Mul is gone and MHA has scale attribute
+        self.assertFalse(any(n.op_type == "Mul" for n in model.graph), "Mul should be removed")
+        mha_node = self._get_mha_node(model)
+        self.assertIsNotNone(mha_node)
+        scale_attr = mha_node.attributes.get_float("scale", None)
+        self.assertIsNotNone(scale_attr)
+        expected = _SCALE_VALUE * _DEFAULT_SCALE
+        self.assertAlmostEqual(scale_attr, expected, places=5)
+
+    def test_integer_scale_fused(self):
+        """Integer scale constant (e.g. 2) → still fused."""
+        model = self._build_scale_model()
+        inputs = self._make_inputs()
+        self._check_numerical_equivalence(model, inputs, 2.0, expected_count=1)
+        mha_node = self._get_mha_node(model)
+        self.assertIsNotNone(mha_node)
+        scale_attr = mha_node.attributes.get_float("scale", None)
+        self.assertIsNotNone(scale_attr)
+        expected = 2.0 * _DEFAULT_SCALE
+        self.assertAlmostEqual(scale_attr, expected, places=5)
+
+    def test_scale_combined_with_existing_scale_attr(self):
+        """MHA already has a scale attribute → external scale is multiplied with it."""
+        model = self._build_scale_model()
+        # Set existing MHA scale attribute before any ORT run
+        existing_scale = 0.1
+        for node in model.graph:
+            if node.op_type == "MultiHeadAttention" and node.domain == "com.microsoft":
+                node.attributes["scale"] = ir.AttrFloat32("scale", existing_scale)
+
+        inputs = self._make_inputs()
+        self._check_numerical_equivalence(model, inputs, _SCALE_VALUE, expected_count=1)
+        mha_node = self._get_mha_node(model)
+        self.assertIsNotNone(mha_node)
+        scale_attr = mha_node.attributes.get_float("scale", None)
+        self.assertIsNotNone(scale_attr)
+        expected = _SCALE_VALUE * existing_scale
+        self.assertAlmostEqual(scale_attr, expected, places=5)
+
+    # --- Negative tests ---
+
+    def test_no_mul_no_fusion(self):
+        """No Mul before MHA → rule does not match."""
+        model = self._build(
+            _mha_no_scale,
+            input_types=[FLOAT["B", "S", _D], FLOAT["B", "S", _D], FLOAT["B", "S", _D]],
+            output_types=[FLOAT["B", "S", _D]],
+        )
+        count = self._apply(model)
+        self.assertEqual(count, 0)
+
+    def test_dynamic_scale_no_fusion(self):
+        """Scale is a non-constant graph input → check rejects."""
+        model = self._build(
+            _mha_with_dynamic_scale,
+            input_types=[
+                FLOAT["B", "S", _D],
+                FLOAT["B", "S", _D],
+                FLOAT["B", "S", _D],
+                FLOAT[1],
+            ],
+            output_types=[FLOAT["B", "S", _D]],
+        )
+        count = self._apply(model)
+        self.assertEqual(count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnxscript/rewriter/ort_fusions/mha_scale_test.py
+++ b/onnxscript/rewriter/ort_fusions/mha_scale_test.py
@@ -15,14 +15,13 @@ import unittest
 import numpy as np
 import onnx_ir as ir
 
-import onnxscript
-import onnxscript.rewriter.ort_fusions._test_utils as test_utils
-from onnxscript import FLOAT, script
+from onnxscript import FLOAT, script, values
 from onnxscript import opset18 as op
 from onnxscript.optimizer import optimize
+from onnxscript.rewriter.ort_fusions import _test_utils as test_utils
 from onnxscript.rewriter.ort_fusions.mha_scale import fuse_mha_scale
 
-msft_op = onnxscript.values.Opset("com.microsoft", 1)
+msft_op = values.Opset("com.microsoft", 1)
 
 _B, _S, _D = 2, 8, 16
 _NUM_HEADS = 4

--- a/onnxscript/rewriter/ort_fusions/mha_scale_test.py
+++ b/onnxscript/rewriter/ort_fusions/mha_scale_test.py
@@ -83,8 +83,8 @@ class FuseMHAScaleTest(unittest.TestCase):
                 return node
         return None
 
-    _3D = [FLOAT["B", "S", _D]] * 3
-    _OUT = [FLOAT["B", "S", _D]]
+    _3D = (FLOAT["B", "S", _D],) * 3
+    _OUT = (FLOAT["B", "S", _D],)
 
     def _check_numerical_equivalence(self, model: ir.Model, inputs: dict, expected_count: int):
         original_output = test_utils.ort_run("Original", model, inputs)

--- a/onnxscript/rewriter/ort_fusions/mha_scale_test.py
+++ b/onnxscript/rewriter/ort_fusions/mha_scale_test.py
@@ -29,15 +29,24 @@ _NUM_HEADS = 4
 _HEAD_SIZE = _D // _NUM_HEADS
 _DEFAULT_SCALE = 1.0 / math.sqrt(_HEAD_SIZE)
 
-# Pre-computed constant for use inside @script functions
-_SCALE_VALUE = 0.25
+# Constants for use inside @script functions
+_SCALE_TENSOR_025 = ir.tensor(np.array([0.25], dtype=np.float32))
+_SCALE_TENSOR_2 = ir.tensor(np.array([2.0], dtype=np.float32))
 
 
 # --- Script models ---
 
 
 @script()
-def _mha_with_scalar_scale(query, key, value, scale):
+def _mha_with_scale_025(query, key, value):
+    scale = op.Constant(value=_SCALE_TENSOR_025)
+    scaled_q = op.Mul(query, scale)
+    return msft_op.MultiHeadAttention(scaled_q, key, value, num_heads=_NUM_HEADS)
+
+
+@script()
+def _mha_with_scale_2(query, key, value):
+    scale = op.Constant(value=_SCALE_TENSOR_2)
     scaled_q = op.Mul(query, scale)
     return msft_op.MultiHeadAttention(scaled_q, key, value, num_heads=_NUM_HEADS)
 
@@ -74,46 +83,15 @@ class FuseMHAScaleTest(unittest.TestCase):
                 return node
         return None
 
-    def _make_scale_constant(self, model: ir.Model, scale_value: float):
-        """Convert the ``scale`` graph input into a constant initializer."""
-        for node in model.graph:
-            if node.op_type == "Mul":
-                scale_input = node.inputs[1]
-                assert scale_input is not None
-                scale_input.const_value = ir.tensor(np.array([scale_value], dtype=np.float32))
-                model.graph.inputs.pop()
-                return
-        raise RuntimeError("Mul node not found")
+    _3D = [FLOAT["B", "S", _D]] * 3
+    _OUT = [FLOAT["B", "S", _D]]
 
-    def _check_numerical_equivalence(
-        self, model: ir.Model, inputs: dict, scale_value: float, expected_count: int
-    ):
-        # Run original model *before* making scale constant (scale is a graph input)
-        inputs_with_scale = {
-            **inputs,
-            "scale": np.array([scale_value], dtype=np.float32),
-        }
-        original_output = test_utils.ort_run("Original", model, inputs_with_scale)
-        # Now convert scale to constant and apply fusion
-        self._make_scale_constant(model, scale_value)
+    def _check_numerical_equivalence(self, model: ir.Model, inputs: dict, expected_count: int):
+        original_output = test_utils.ort_run("Original", model, inputs)
         count = self._apply(model)
         self.assertEqual(count, expected_count)
         fused_output = test_utils.ort_run("Fused", model, inputs)
         test_utils.assert_allclose(original_output, fused_output)
-
-    # --- Positive tests ---
-
-    def _build_scale_model(self):
-        return self._build(
-            _mha_with_scalar_scale,
-            input_types=[
-                FLOAT["B", "S", _D],
-                FLOAT["B", "S", _D],
-                FLOAT["B", "S", _D],
-                FLOAT[1],
-            ],
-            output_types=[FLOAT["B", "S", _D]],
-        )
 
     def _make_inputs(self):
         return {
@@ -122,25 +100,26 @@ class FuseMHAScaleTest(unittest.TestCase):
             "value": np.random.randn(_B, _S, _D).astype(np.float32),
         }
 
+    # --- Positive tests ---
+
     def test_scalar_scale_fused(self):
         """Mul(query, scalar_constant) before MHA → scale absorbed into attribute."""
-        model = self._build_scale_model()
+        model = self._build(_mha_with_scale_025, self._3D, self._OUT)
         inputs = self._make_inputs()
-        self._check_numerical_equivalence(model, inputs, _SCALE_VALUE, expected_count=1)
-        # Verify Mul is gone and MHA has scale attribute
+        self._check_numerical_equivalence(model, inputs, expected_count=1)
         self.assertFalse(any(n.op_type == "Mul" for n in model.graph), "Mul should be removed")
         mha_node = self._get_mha_node(model)
         self.assertIsNotNone(mha_node)
         scale_attr = mha_node.attributes.get_float("scale", None)
         self.assertIsNotNone(scale_attr)
-        expected = _SCALE_VALUE * _DEFAULT_SCALE
+        expected = 0.25 * _DEFAULT_SCALE
         self.assertAlmostEqual(scale_attr, expected, places=5)
 
     def test_integer_scale_fused(self):
-        """Integer scale constant (e.g. 2) → still fused."""
-        model = self._build_scale_model()
+        """Scale constant of 2.0 → still fused."""
+        model = self._build(_mha_with_scale_2, self._3D, self._OUT)
         inputs = self._make_inputs()
-        self._check_numerical_equivalence(model, inputs, 2.0, expected_count=1)
+        self._check_numerical_equivalence(model, inputs, expected_count=1)
         mha_node = self._get_mha_node(model)
         self.assertIsNotNone(mha_node)
         scale_attr = mha_node.attributes.get_float("scale", None)
@@ -150,31 +129,26 @@ class FuseMHAScaleTest(unittest.TestCase):
 
     def test_scale_combined_with_existing_scale_attr(self):
         """MHA already has a scale attribute → external scale is multiplied with it."""
-        model = self._build_scale_model()
-        # Set existing MHA scale attribute before any ORT run
+        model = self._build(_mha_with_scale_025, self._3D, self._OUT)
         existing_scale = 0.1
         for node in model.graph:
             if node.op_type == "MultiHeadAttention" and node.domain == "com.microsoft":
                 node.attributes["scale"] = ir.AttrFloat32("scale", existing_scale)
 
         inputs = self._make_inputs()
-        self._check_numerical_equivalence(model, inputs, _SCALE_VALUE, expected_count=1)
+        self._check_numerical_equivalence(model, inputs, expected_count=1)
         mha_node = self._get_mha_node(model)
         self.assertIsNotNone(mha_node)
         scale_attr = mha_node.attributes.get_float("scale", None)
         self.assertIsNotNone(scale_attr)
-        expected = _SCALE_VALUE * existing_scale
+        expected = 0.25 * existing_scale
         self.assertAlmostEqual(scale_attr, expected, places=5)
 
     # --- Negative tests ---
 
     def test_no_mul_no_fusion(self):
         """No Mul before MHA → rule does not match."""
-        model = self._build(
-            _mha_no_scale,
-            input_types=[FLOAT["B", "S", _D], FLOAT["B", "S", _D], FLOAT["B", "S", _D]],
-            output_types=[FLOAT["B", "S", _D]],
-        )
+        model = self._build(_mha_no_scale, self._3D, self._OUT)
         count = self._apply(model)
         self.assertEqual(count, 0)
 
@@ -182,13 +156,8 @@ class FuseMHAScaleTest(unittest.TestCase):
         """Scale is a non-constant graph input → check rejects."""
         model = self._build(
             _mha_with_dynamic_scale,
-            input_types=[
-                FLOAT["B", "S", _D],
-                FLOAT["B", "S", _D],
-                FLOAT["B", "S", _D],
-                FLOAT[1],
-            ],
-            output_types=[FLOAT["B", "S", _D]],
+            input_types=[*self._3D, FLOAT[1]],
+            output_types=self._OUT,
         )
         count = self._apply(model)
         self.assertEqual(count, 0)

--- a/onnxscript/rewriter/ort_fusions/mha_unit_test.py
+++ b/onnxscript/rewriter/ort_fusions/mha_unit_test.py
@@ -1,0 +1,259 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Unit tests for MultiHeadAttention fusion rules (mha.py).
+
+The MHA rule matches the pattern:
+    Q/K/V → Reshape → Transpose → [RotaryEmbedding] → [Concat past] → SDPA → Transpose → Reshape
+and fuses it into a single MultiHeadAttention contrib op.
+
+These are structural tests (no ORT run) because the pattern requires internal
+SDPA nodes (ai.onnxruntime._fusion domain) which ORT cannot execute directly.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import onnx_ir as ir
+
+from onnxscript import FLOAT, script, values
+from onnxscript import opset18 as op
+from onnxscript.optimizer import optimize
+from onnxscript.rewriter.ort_fusions.mha import fuse_mha1, fuse_mha2
+
+# Custom opsets
+msft_op = values.Opset("com.microsoft", 1)
+fusion_op = values.Opset("ai.onnxruntime._fusion", 1)
+
+_B, _S, _H, _Dh = 2, 8, 4, 4
+_D = _H * _Dh  # 16
+_Skv = 8
+_Spast = 4
+
+_RESHAPE_Q = ir.tensor(np.array([0, 0, _H, _Dh], dtype=np.int64))
+_RESHAPE_K = ir.tensor(np.array([0, 0, _H, _Dh], dtype=np.int64))
+_RESHAPE_V = ir.tensor(np.array([0, 0, _H, _Dh], dtype=np.int64))
+_RESHAPE_OUT = ir.tensor(np.array([0, 0, _D], dtype=np.int64))
+
+
+# --- Simplest: no rotary, no past, key transposed ---
+
+
+@script()
+def _mha_basic_key_transposed(query_BSD, key_BSD, value_BSD):
+    q_shape = op.Constant(value=_RESHAPE_Q)
+    q_4d = op.Reshape(query_BSD, q_shape)
+    q_BHSDh = op.Transpose(q_4d, perm=[0, 2, 1, 3])
+
+    k_shape = op.Constant(value=_RESHAPE_K)
+    k_4d = op.Reshape(key_BSD, k_shape)
+    k_BHSDh = op.Transpose(k_4d, perm=[0, 2, 1, 3])
+
+    v_shape = op.Constant(value=_RESHAPE_V)
+    v_4d = op.Reshape(value_BSD, v_shape)
+    v_BHSDh = op.Transpose(v_4d, perm=[0, 2, 1, 3])
+
+    sdpa_out = fusion_op.SDPA(q_BHSDh, k_BHSDh, v_BHSDh, key_format="BHSd")
+
+    att_transposed = op.Transpose(sdpa_out, perm=[0, 2, 1, 3])
+    out_shape = op.Constant(value=_RESHAPE_OUT)
+    return op.Reshape(att_transposed, out_shape)
+
+
+# --- No rotary, no past, key NOT transposed ---
+
+
+@script()
+def _mha_basic_key_not_transposed(query_BSD, key_BSD, value_BSD):
+    q_shape = op.Constant(value=_RESHAPE_Q)
+    q_4d = op.Reshape(query_BSD, q_shape)
+    q_BHSDh = op.Transpose(q_4d, perm=[0, 2, 1, 3])
+
+    k_shape = op.Constant(value=_RESHAPE_K)
+    k_4d = op.Reshape(key_BSD, k_shape)
+    # Key is NOT transposed — stays in BSHd format
+
+    v_shape = op.Constant(value=_RESHAPE_V)
+    v_4d = op.Reshape(value_BSD, v_shape)
+    v_BHSDh = op.Transpose(v_4d, perm=[0, 2, 1, 3])
+
+    sdpa_out = fusion_op.SDPA(q_BHSDh, k_4d, v_BHSDh, key_format="BSHd")
+
+    att_transposed = op.Transpose(sdpa_out, perm=[0, 2, 1, 3])
+    out_shape = op.Constant(value=_RESHAPE_OUT)
+    return op.Reshape(att_transposed, out_shape)
+
+
+# --- With past key/value (has_past_present=True) ---
+
+
+@script()
+def _mha_with_past(query_BSD, key_BSD, value_BSD, past_key, past_value):
+    q_shape = op.Constant(value=_RESHAPE_Q)
+    q_4d = op.Reshape(query_BSD, q_shape)
+    q_BHSDh = op.Transpose(q_4d, perm=[0, 2, 1, 3])
+
+    k_shape = op.Constant(value=_RESHAPE_K)
+    k_4d = op.Reshape(key_BSD, k_shape)
+    k_BHSDh = op.Transpose(k_4d, perm=[0, 2, 1, 3])
+
+    v_shape = op.Constant(value=_RESHAPE_V)
+    v_4d = op.Reshape(value_BSD, v_shape)
+    v_BHSDh = op.Transpose(v_4d, perm=[0, 2, 1, 3])
+
+    # Concat with past
+    key_seq = op.Concat(past_key, k_BHSDh, axis=-2)
+    value_seq = op.Concat(past_value, v_BHSDh, axis=-2)
+
+    sdpa_out = fusion_op.SDPA(q_BHSDh, key_seq, value_seq, key_format="BHSd")
+
+    att_transposed = op.Transpose(sdpa_out, perm=[0, 2, 1, 3])
+    out_shape = op.Constant(value=_RESHAPE_OUT)
+    attention = op.Reshape(att_transposed, out_shape)
+    return attention, key_seq, value_seq
+
+
+# --- With rotary embedding (no past) ---
+
+
+@script()
+def _mha_with_rotary(query_BSD, key_BSD, value_BSD, position_ids, cos, sin):
+    q_shape = op.Constant(value=_RESHAPE_Q)
+    q_4d = op.Reshape(query_BSD, q_shape)
+    q_BHSDh = op.Transpose(q_4d, perm=[0, 2, 1, 3])
+
+    k_shape = op.Constant(value=_RESHAPE_K)
+    k_4d = op.Reshape(key_BSD, k_shape)
+    k_BHSDh = op.Transpose(k_4d, perm=[0, 2, 1, 3])
+
+    v_shape = op.Constant(value=_RESHAPE_V)
+    v_4d = op.Reshape(value_BSD, v_shape)
+    v_BHSDh = op.Transpose(v_4d, perm=[0, 2, 1, 3])
+
+    q_emb = msft_op.RotaryEmbedding(q_BHSDh, position_ids, cos, sin)
+    k_emb = msft_op.RotaryEmbedding(k_BHSDh, position_ids, cos, sin)
+
+    sdpa_out = fusion_op.SDPA(q_emb, k_emb, v_BHSDh, key_format="BHSd")
+
+    att_transposed = op.Transpose(sdpa_out, perm=[0, 2, 1, 3])
+    out_shape = op.Constant(value=_RESHAPE_OUT)
+    return op.Reshape(att_transposed, out_shape)
+
+
+class MultiHeadAttentionFusionTest(unittest.TestCase):
+    """Structural unit tests for MultiHeadAttention fusion rules."""
+
+    def _build(self, script_fn, input_types, output_types) -> ir.Model:
+        model_proto = script_fn.to_model_proto(
+            input_types=input_types, output_types=output_types
+        )
+        model = ir.serde.deserialize_model(model_proto)
+        optimize(model)
+        return model
+
+    def _apply(self, model: ir.Model) -> int:
+        count = fuse_mha1(model)
+        count += fuse_mha2(model)
+        return count
+
+    def _count_op(self, model: ir.Model, op_type: str, domain: str = "") -> int:
+        return sum(1 for n in model.graph if n.op_type == op_type and n.domain == domain)
+
+    def _get_mha_node(self, model: ir.Model) -> ir.Node | None:
+        for node in model.graph:
+            if node.op_type == "MultiHeadAttention" and node.domain == "com.microsoft":
+                return node
+        return None
+
+    _3D = (FLOAT["B", "S", _D],) * 3
+    _OUT_1 = (FLOAT["B", "S", _D],)
+
+    # --- Positive tests ---
+
+    def test_basic_key_transposed(self):
+        """Simplest MHA: no rotary, no past, key transposed → fuses."""
+        model = self._build(_mha_basic_key_transposed, self._3D, self._OUT_1)
+        count = self._apply(model)
+        self.assertEqual(count, 1)
+        self.assertEqual(self._count_op(model, "MultiHeadAttention", "com.microsoft"), 1)
+        self.assertEqual(self._count_op(model, "SDPA", "ai.onnxruntime._fusion"), 0)
+        mha = self._get_mha_node(model)
+        self.assertIsNotNone(mha)
+        self.assertEqual(mha.attributes.get_int("num_heads", 0), _H)
+
+    def test_basic_key_not_transposed(self):
+        """Key not transposed (BSHd format) → still fuses."""
+        model = self._build(_mha_basic_key_not_transposed, self._3D, self._OUT_1)
+        count = self._apply(model)
+        self.assertEqual(count, 1)
+        self.assertEqual(self._count_op(model, "MultiHeadAttention", "com.microsoft"), 1)
+
+    def test_with_past_key_value(self):
+        """Past key/value Concats → fuses with 3 outputs (attention, present_k, present_v)."""
+        model = self._build(
+            _mha_with_past,
+            input_types=[
+                FLOAT["B", "S", _D],
+                FLOAT["B", "S", _D],
+                FLOAT["B", "S", _D],
+                FLOAT["B", _H, "Spast", _Dh],
+                FLOAT["B", _H, "Spast", _Dh],
+            ],
+            output_types=[
+                FLOAT["B", "S", _D],
+                FLOAT["B", _H, "St", _Dh],
+                FLOAT["B", _H, "St", _Dh],
+            ],
+        )
+        count = self._apply(model)
+        self.assertEqual(count, 1)
+        mha = self._get_mha_node(model)
+        self.assertIsNotNone(mha)
+        self.assertEqual(len(mha.outputs), 3)
+        # past_key and past_value should be connected (inputs 6, 7)
+        self.assertIsNotNone(mha.inputs[6])
+        self.assertIsNotNone(mha.inputs[7])
+
+    def test_with_rotary_embedding(self):
+        """RotaryEmbedding on Q and K before SDPA → fuses."""
+        model = self._build(
+            _mha_with_rotary,
+            input_types=[
+                FLOAT["B", "S", _D],
+                FLOAT["B", "S", _D],
+                FLOAT["B", "S", _D],
+                FLOAT["B", "S"],  # position_ids
+                FLOAT["S", _Dh],  # cos
+                FLOAT["S", _Dh],  # sin
+            ],
+            output_types=[FLOAT["B", "S", _D]],
+        )
+        count = self._apply(model)
+        self.assertEqual(count, 1)
+        mha = self._get_mha_node(model)
+        self.assertIsNotNone(mha)
+        # Rotary should be moved to operate on BSD-format inputs in the rewrite
+        rotary_count = self._count_op(model, "RotaryEmbedding", "com.microsoft")
+        self.assertGreater(rotary_count, 0)
+
+    # --- Negative test ---
+
+    def test_rank2_query_no_fusion(self):
+        """Query with rank 2 [S, D] instead of [B, S, D] → shape check rejects."""
+        model = self._build(
+            _mha_basic_key_transposed,
+            input_types=[
+                FLOAT["S", _D],
+                FLOAT["B", "S", _D],
+                FLOAT["B", "S", _D],
+            ],
+            output_types=[FLOAT["B", "S", _D]],
+        )
+        count = self._apply(model)
+        self.assertEqual(count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnxscript/rewriter/ort_fusions/mha_unit_test.py
+++ b/onnxscript/rewriter/ort_fusions/mha_unit_test.py
@@ -29,8 +29,6 @@ fusion_op = values.Opset("ai.onnxruntime._fusion", 1)
 
 _B, _S, _H, _Dh = 2, 8, 4, 4
 _D = _H * _Dh  # 16
-_Skv = 8
-_Spast = 4
 
 _RESHAPE_Q = ir.tensor(np.array([0, 0, _H, _Dh], dtype=np.int64))
 _RESHAPE_K = ir.tensor(np.array([0, 0, _H, _Dh], dtype=np.int64))

--- a/onnxscript/rewriter/ort_fusions/mha_unit_test.py
+++ b/onnxscript/rewriter/ort_fusions/mha_unit_test.py
@@ -254,6 +254,18 @@ class MultiHeadAttentionFusionTest(unittest.TestCase):
         count = self._apply(model)
         self.assertEqual(count, 0)
 
+    def test_wrong_query_transpose_perm_no_fusion(self):
+        """Corrupted query Transpose perm → pattern should not match."""
+        model = self._build(_mha_basic_key_transposed, self._3D, self._OUT_1)
+        for node in model.graph:
+            if node.op_type == "Transpose":
+                perm = node.attributes.get_ints("perm")
+                if perm == (0, 2, 1, 3):
+                    node.attributes["perm"] = ir.AttrInt64s("perm", [0, 1, 2, 3])
+                    break
+        count = self._apply(model)
+        self.assertEqual(count, 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/onnxscript/rewriter/ort_fusions/rms_normalization_unit_test.py
+++ b/onnxscript/rewriter/ort_fusions/rms_normalization_unit_test.py
@@ -1,0 +1,171 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Unit tests for RmsNormFusion rules (rms_normalization.py).
+
+The rule detects the RMS-normalization pattern:
+    x_norm = x / sqrt(mean(x^2) + eps)
+    output = x_norm * scale
+and fuses it into SimplifiedLayerNormalization.
+
+Covers both mul-orderings, optional Casts (mixed-precision),
+and negative cases (bad dtype, non-scalar epsilon).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import onnx_ir as ir
+from parameterized import parameterized
+
+from onnxscript import FLOAT, FLOAT16, script
+from onnxscript import opset18 as op
+from onnxscript.optimizer import optimize
+from onnxscript.rewriter.ort_fusions import _test_utils as test_utils
+from onnxscript.rewriter.ort_fusions.rms_normalization import fuse_rms_normalization
+
+_B, _S, _D = 2, 8, 16
+_EPS = ir.tensor(np.array([1e-6], dtype=np.float32))
+
+
+# --- Pattern: Mul(scale, normalized) — mul_order=False ---
+
+
+@script()
+def _rms_norm_scale_first(x, scale):
+    x_sq = op.Pow(x, 2.0)
+    mean_sq = op.ReduceMean(x_sq, [-1], keepdims=1, noop_with_empty_axes=0)
+    eps = op.Constant(value=_EPS)
+    rms = op.Sqrt(op.Add(mean_sq, eps))
+    inv_rms = op.Reciprocal(rms)
+    normalized = op.Mul(x, inv_rms)
+    return op.Mul(scale, normalized)
+
+
+# --- Pattern: Mul(normalized, scale) — mul_order=True ---
+
+
+@script()
+def _rms_norm_norm_first(x, scale):
+    x_sq = op.Pow(x, 2.0)
+    mean_sq = op.ReduceMean(x_sq, [-1], keepdims=1, noop_with_empty_axes=0)
+    eps = op.Constant(value=_EPS)
+    rms = op.Sqrt(op.Add(mean_sq, eps))
+    inv_rms = op.Reciprocal(rms)
+    normalized = op.Mul(x, inv_rms)
+    return op.Mul(normalized, scale)
+
+
+# --- Pattern with Cast on input (mixed-precision: fp16 input, fp32 compute) ---
+
+
+@script()
+def _rms_norm_with_cast_input(x, scale):
+    x_f32 = op.Cast(x, to=ir.DataType.FLOAT)
+    x_sq = op.Pow(x_f32, 2.0)
+    mean_sq = op.ReduceMean(x_sq, [-1], keepdims=1, noop_with_empty_axes=0)
+    eps = op.Constant(value=_EPS)
+    rms = op.Sqrt(op.Add(mean_sq, eps))
+    inv_rms = op.Reciprocal(rms)
+    normalized = op.Mul(x_f32, inv_rms)
+    result = op.Cast(normalized, to=ir.DataType.FLOAT16)
+    return op.Mul(result, scale)
+
+
+# --- Negative: integer input ---
+
+
+@script()
+def _rms_norm_int_input(x, scale):
+    x_f = op.Cast(x, to=ir.DataType.FLOAT)
+    x_sq = op.Pow(x_f, 2.0)
+    mean_sq = op.ReduceMean(x_sq, [-1], keepdims=1, noop_with_empty_axes=0)
+    eps = op.Constant(value=_EPS)
+    rms = op.Sqrt(op.Add(mean_sq, eps))
+    inv_rms = op.Reciprocal(rms)
+    normalized = op.Mul(x_f, inv_rms)
+    return op.Mul(normalized, scale)
+
+
+class RmsNormFusionTest(unittest.TestCase):
+    """Unit tests for RmsNormFusion rewrite rules."""
+
+    def _build(self, script_fn, input_types, output_types) -> ir.Model:
+        model_proto = script_fn.to_model_proto(
+            input_types=input_types, output_types=output_types
+        )
+        model = ir.serde.deserialize_model(model_proto)
+        optimize(model)
+        return model
+
+    def _apply(self, model: ir.Model) -> int:
+        return fuse_rms_normalization(model)
+
+    def _count_op(self, model: ir.Model, op_type: str) -> int:
+        return sum(1 for n in model.graph if n.op_type == op_type)
+
+    def _check_numerical_equivalence(self, model: ir.Model, inputs: dict, expected_count: int):
+        original_output = test_utils.ort_run("Original", model, inputs)
+        count = self._apply(model)
+        self.assertEqual(count, expected_count)
+        fused_output = test_utils.ort_run("Fused", model, inputs)
+        test_utils.assert_allclose(original_output, fused_output)
+
+    # --- Positive tests ---
+
+    @parameterized.expand(
+        [
+            ("scale_times_normalized", _rms_norm_scale_first),
+            ("normalized_times_scale", _rms_norm_norm_first),
+        ]
+    )
+    def test_mul_order_variants(self, _name, script_fn):
+        """Both Mul orderings (scale*norm and norm*scale) should fuse."""
+        model = self._build(
+            script_fn,
+            input_types=[FLOAT["B", "S", _D], FLOAT[_D]],
+            output_types=[FLOAT["B", "S", _D]],
+        )
+        inputs = {
+            "x": np.random.randn(_B, _S, _D).astype(np.float32),
+            "scale": np.random.randn(_D).astype(np.float32),
+        }
+        self._check_numerical_equivalence(model, inputs, expected_count=1)
+        self.assertEqual(self._count_op(model, "SimplifiedLayerNormalization"), 1)
+        self.assertEqual(self._count_op(model, "Pow"), 0)
+        self.assertEqual(self._count_op(model, "ReduceMean"), 0)
+
+    def test_cast_input_mixed_precision(self):
+        """fp16 input Cast to fp32 for compute, Cast back → still fuses."""
+        model = self._build(
+            _rms_norm_with_cast_input,
+            input_types=[FLOAT16["B", "S", _D], FLOAT16[_D]],
+            output_types=[FLOAT16["B", "S", _D]],
+        )
+        inputs = {
+            "x": np.random.randn(_B, _S, _D).astype(np.float16),
+            "scale": np.random.randn(_D).astype(np.float16),
+        }
+        self._check_numerical_equivalence(model, inputs, expected_count=1)
+        self.assertEqual(self._count_op(model, "SimplifiedLayerNormalization"), 1)
+
+    # --- Negative tests ---
+
+    def test_int_input_no_fusion(self):
+        """Integer input dtype → check rejects (x.dtype not in float_types)."""
+        from onnxscript import INT32
+
+        model = self._build(
+            _rms_norm_int_input,
+            input_types=[INT32["B", "S", _D], FLOAT[_D]],
+            output_types=[FLOAT["B", "S", _D]],
+        )
+        count = self._apply(model)
+        self.assertEqual(count, 0)
+        self.assertEqual(self._count_op(model, "SimplifiedLayerNormalization"), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnxscript/rewriter/ort_fusions/rotary_embedding_unit_test.py
+++ b/onnxscript/rewriter/ort_fusions/rotary_embedding_unit_test.py
@@ -1,0 +1,167 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Unit tests for RotaryEmbeddingFusion and PartialRotaryEmbeddingFusion rules.
+
+RotaryEmbeddingFusion matches: x * cos + rotate_half(x) * sin
+and rewrites to RotaryEmbedding(x, cos, sin, ...).
+
+PartialRotaryEmbeddingFusion matches: Concat(RotaryEmbedding(Slice(x)), Slice(x))
+and adds rotary_embedding_dim attribute to the RotaryEmbedding op.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import onnx_ir as ir
+
+from onnxscript import FLOAT, script, values
+from onnxscript import opset18 as op
+from onnxscript.optimizer import optimize
+from onnxscript.rewriter.ort_fusions.rotary_embedding import (
+    fuse_partial_rotary_embedding,
+    fuse_rotary_embedding,
+)
+
+fusion_op = values.Opset("ai.onnxruntime._fusion", 1)
+msft_op = values.Opset("com.microsoft", 1)
+
+_B, _H, _S, _Dh = 2, 4, 8, 8
+_HALF = _Dh // 2
+
+# Constants for slice boundaries
+_ZERO = ir.tensor(np.array([0], dtype=np.int64))
+_HALF_TENSOR = ir.tensor(np.array([_HALF], dtype=np.int64))
+_HEAD_SIZE_TENSOR = ir.tensor(np.array([_Dh], dtype=np.int64))
+_MAX_INT = ir.tensor(np.array([9223372036854775807], dtype=np.int64))
+
+
+# --- Full rotary embedding pattern ---
+
+
+@script()
+def _rotary_full(x, cos, sin):
+    """X * cos + rotate_half(x) * sin — standard non-interleaved pattern."""
+    start_0 = op.Constant(value=_ZERO)
+    end_half = op.Constant(value=_HALF_TENSOR)
+    start_half = op.Constant(value=_HALF_TENSOR)
+    end_full = op.Constant(value=_HEAD_SIZE_TENSOR)
+    # rotate_half: concat(-x2, x1)
+    x1 = op.Slice(x, start_0, end_half, [3], [1])
+    x2 = op.Slice(x, start_half, end_full, [3], [1])
+    neg_x2 = op.Neg(x2)
+    rotated = op.Concat(neg_x2, x1, axis=-1)
+    return op.Add(op.Mul(x, cos), op.Mul(rotated, sin))
+
+
+# --- Partial rotary embedding pattern ---
+
+
+@script()
+def _partial_rotary(x, cos, sin, position_ids):
+    """Slice → RotaryEmbedding on first half, concat with second half."""
+    end1 = op.Constant(value=_HALF_TENSOR)
+    start2 = op.Constant(value=_HALF_TENSOR)
+    max_end = op.Constant(value=_MAX_INT)
+    x_part1 = op.Slice(x, [0], end1, [3], [1])
+    x_part2 = op.Slice(x, start2, max_end, [3], [1])
+    x_part1_rope = msft_op.RotaryEmbedding(x_part1, position_ids, cos, sin, interleaved=0)
+    return op.Concat(x_part1_rope, x_part2, axis=-1)
+
+
+# --- Negative: 3D input instead of 4D ---
+
+
+@script()
+def _rotary_3d_input(x, cos, sin):
+    """3D input — should fail the 4D check."""
+    start_0 = op.Constant(value=_ZERO)
+    end_half = op.Constant(value=_HALF_TENSOR)
+    start_half = op.Constant(value=_HALF_TENSOR)
+    end_full = op.Constant(value=_HEAD_SIZE_TENSOR)
+    x1 = op.Slice(x, start_0, end_half, [3], [1])
+    x2 = op.Slice(x, start_half, end_full, [3], [1])
+    neg_x2 = op.Neg(x2)
+    rotated = op.Concat(neg_x2, x1, axis=-1)
+    return op.Add(op.Mul(x, cos), op.Mul(rotated, sin))
+
+
+class RotaryEmbeddingFusionTest(unittest.TestCase):
+    """Unit tests for RotaryEmbeddingFusion rule."""
+
+    def _build(self, script_fn, input_types, output_types) -> ir.Model:
+        model_proto = script_fn.to_model_proto(
+            input_types=input_types, output_types=output_types
+        )
+        model = ir.serde.deserialize_model(model_proto)
+        optimize(model)
+        return model
+
+    def _count_op(self, model: ir.Model, op_type: str, domain: str = "") -> int:
+        return sum(1 for n in model.graph if n.op_type == op_type and n.domain == domain)
+
+    # --- Positive tests ---
+
+    def test_full_rotary_fuses(self):
+        """Standard full rotary embedding pattern → fuses to RotaryEmbedding op."""
+        model = self._build(
+            _rotary_full,
+            input_types=[
+                FLOAT[_B, _H, "S", _Dh],
+                FLOAT[_B, _H, "S", _Dh],
+                FLOAT[_B, _H, "S", _Dh],
+            ],
+            output_types=[FLOAT[_B, _H, "S", _Dh]],
+        )
+        count = fuse_rotary_embedding(model)
+        self.assertEqual(count, 1)
+        self.assertEqual(self._count_op(model, "RotaryEmbedding", "ai.onnxruntime._fusion"), 1)
+        # Pattern ops should be consumed
+        self.assertEqual(self._count_op(model, "Neg"), 0)
+
+    def test_partial_rotary_fuses(self):
+        """Partial rotary: Slice → RotaryEmbedding on first part, concat with rest."""
+        model = self._build(
+            _partial_rotary,
+            input_types=[
+                FLOAT[_B, _H, "S", _Dh],
+                FLOAT["S", _HALF],
+                FLOAT["S", _HALF],
+                FLOAT[_B, "S"],
+            ],
+            output_types=[FLOAT[_B, _H, "S", _Dh]],
+        )
+        count = fuse_partial_rotary_embedding(model)
+        self.assertEqual(count, 1)
+        # RotaryEmbedding should still exist but now with rotary_embedding_dim
+        rope_nodes = [
+            n
+            for n in model.graph
+            if n.op_type == "RotaryEmbedding" and n.domain == "com.microsoft"
+        ]
+        self.assertEqual(len(rope_nodes), 1)
+        self.assertIn("rotary_embedding_dim", rope_nodes[0].attributes)
+        self.assertEqual(rope_nodes[0].attributes["rotary_embedding_dim"].value, _HALF)
+
+    # --- Negative tests ---
+
+    def test_3d_input_no_fusion(self):
+        """3D input (missing batch or head dim) → check rejects."""
+        model_proto = _rotary_3d_input.to_model_proto(
+            input_types=[
+                FLOAT[_H, "S", _Dh],
+                FLOAT[_H, "S", _Dh],
+                FLOAT[_H, "S", _Dh],
+            ],
+            output_types=[FLOAT[_H, "S", _Dh]],
+        )
+        model = ir.serde.deserialize_model(model_proto)
+        # Skip optimize — 3D shapes cause shape inference errors which is expected
+        count = fuse_rotary_embedding(model)
+        self.assertEqual(count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnxscript/rewriter/ort_fusions/skip_normalization_unit_test.py
+++ b/onnxscript/rewriter/ort_fusions/skip_normalization_unit_test.py
@@ -30,7 +30,6 @@ from onnxscript.rewriter.ort_fusions.skip_normalization import (
 )
 
 _B, _S, _D = 2, 8, 16
-_EPS_F = ir.tensor(np.array([1e-6], dtype=np.float32))
 
 
 # ========== Skip RMS Norm patterns ==========

--- a/onnxscript/rewriter/ort_fusions/skip_normalization_unit_test.py
+++ b/onnxscript/rewriter/ort_fusions/skip_normalization_unit_test.py
@@ -1,0 +1,217 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Unit tests for SkipRmsNormFusion and SkipLayerNormFusion rules.
+
+SkipRmsNormFusion: Add(input, skip) → SimplifiedLayerNormalization →
+    SkipSimplifiedLayerNormalization (com.microsoft).
+
+SkipLayerNormFusion: Add(input, skip) → LayerNormalization →
+    SkipLayerNormalization (com.microsoft).
+
+Covers: no bias, post-add bias, pre-add bias variants; negative tests.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import onnx_ir as ir
+from parameterized import parameterized
+
+from onnxscript import FLOAT, script
+from onnxscript import opset18 as op
+from onnxscript.optimizer import optimize
+from onnxscript.rewriter.ort_fusions.skip_normalization import (
+    fuse_skip_layer_normalization,
+    fuse_skip_rms_normalization,
+)
+
+_B, _S, _D = 2, 8, 16
+_EPS_F = ir.tensor(np.array([1e-6], dtype=np.float32))
+
+
+# ========== Skip RMS Norm patterns ==========
+
+
+@script()
+def _skip_rms_no_bias(input, skip, gamma):
+    skip_sum = op.Add(input, skip)
+    return op.SimplifiedLayerNormalization(
+        skip_sum, gamma, axis=-1, epsilon=1e-6, stash_type=1
+    )
+
+
+@script()
+def _skip_rms_no_bias_reversed(input, skip, gamma):
+    """Skip + input order reversed (OrValue alternative)."""
+    skip_sum = op.Add(skip, input)
+    return op.SimplifiedLayerNormalization(
+        skip_sum, gamma, axis=-1, epsilon=1e-6, stash_type=1
+    )
+
+
+@script()
+def _skip_rms_post_bias(input, skip, gamma, bias):
+    skip_sum = op.Add(input, skip)
+    skip_sum_biased = op.Add(skip_sum, bias)
+    return op.SimplifiedLayerNormalization(
+        skip_sum_biased, gamma, axis=-1, epsilon=1e-6, stash_type=1
+    )
+
+
+@script()
+def _skip_rms_pre_bias(input, skip, gamma, bias):
+    input_biased = op.Add(input, bias)
+    skip_sum = op.Add(input_biased, skip)
+    return op.SimplifiedLayerNormalization(
+        skip_sum, gamma, axis=-1, epsilon=1e-6, stash_type=1
+    )
+
+
+# ========== Skip Layer Norm patterns ==========
+
+
+@script()
+def _skip_ln_no_bias(input, skip, gamma, beta):
+    skip_sum = op.Add(input, skip)
+    return op.LayerNormalization(skip_sum, gamma, beta, axis=-1, epsilon=1e-6, stash_type=1)
+
+
+@script()
+def _skip_ln_post_bias(input, skip, gamma, beta, bias):
+    skip_sum = op.Add(input, skip)
+    skip_sum_biased = op.Add(skip_sum, bias)
+    return op.LayerNormalization(
+        skip_sum_biased, gamma, beta, axis=-1, epsilon=1e-6, stash_type=1
+    )
+
+
+# ========== Negative patterns ==========
+
+
+@script()
+def _skip_rms_no_add(input, gamma):
+    """No skip addition at all — just SimplifiedLayerNormalization."""
+    return op.SimplifiedLayerNormalization(input, gamma, axis=-1, epsilon=1e-6, stash_type=1)
+
+
+class SkipNormalizationTest(unittest.TestCase):
+    """Unit tests for SkipRmsNormFusion and SkipLayerNormFusion."""
+
+    def _build(self, script_fn, input_types, output_types) -> ir.Model:
+        model_proto = script_fn.to_model_proto(
+            input_types=input_types, output_types=output_types
+        )
+        model = ir.serde.deserialize_model(model_proto)
+        optimize(model)
+        return model
+
+    def _count_op(self, model: ir.Model, op_type: str, domain: str = "") -> int:
+        return sum(1 for n in model.graph if n.op_type == op_type and n.domain == domain)
+
+    _3D = FLOAT["B", "S", _D]
+    _1D = FLOAT[_D]
+
+    # ---- Skip RMS Norm positive tests ----
+
+    @parameterized.expand(
+        [
+            ("input_plus_skip", _skip_rms_no_bias),
+            ("skip_plus_input", _skip_rms_no_bias_reversed),
+        ]
+    )
+    def test_skip_rms_no_bias(self, _name, script_fn):
+        """Skip + Input (both orderings) → SkipSimplifiedLayerNormalization."""
+        model = self._build(
+            script_fn,
+            input_types=[self._3D, self._3D, self._1D],
+            output_types=[self._3D],
+        )
+        count = fuse_skip_rms_normalization(model)
+        self.assertGreater(count, 0)
+        self.assertEqual(
+            self._count_op(model, "SkipSimplifiedLayerNormalization", "com.microsoft"), 1
+        )
+        self.assertEqual(self._count_op(model, "SimplifiedLayerNormalization"), 0)
+
+    def test_skip_rms_post_bias(self):
+        """(Input + Skip) + Bias → fuses with bias."""
+        model = self._build(
+            _skip_rms_post_bias,
+            input_types=[self._3D, self._3D, self._1D, self._1D],
+            output_types=[self._3D],
+        )
+        count = fuse_skip_rms_normalization(model)
+        self.assertGreater(count, 0)
+        self.assertEqual(
+            self._count_op(model, "SkipSimplifiedLayerNormalization", "com.microsoft"), 1
+        )
+
+    def test_skip_rms_pre_bias(self):
+        """(Input + Bias) + Skip → fuses with pre-add bias."""
+        model = self._build(
+            _skip_rms_pre_bias,
+            input_types=[self._3D, self._3D, self._1D, self._1D],
+            output_types=[self._3D],
+        )
+        count = fuse_skip_rms_normalization(model)
+        self.assertGreater(count, 0)
+        self.assertEqual(
+            self._count_op(model, "SkipSimplifiedLayerNormalization", "com.microsoft"), 1
+        )
+
+    # ---- Skip Layer Norm positive tests ----
+
+    def test_skip_ln_no_bias(self):
+        """Skip + Input → SkipLayerNormalization."""
+        model = self._build(
+            _skip_ln_no_bias,
+            input_types=[self._3D, self._3D, self._1D, self._1D],
+            output_types=[self._3D],
+        )
+        count = fuse_skip_layer_normalization(model)
+        self.assertGreater(count, 0)
+        self.assertEqual(self._count_op(model, "SkipLayerNormalization", "com.microsoft"), 1)
+        self.assertEqual(self._count_op(model, "LayerNormalization"), 0)
+
+    def test_skip_ln_post_bias(self):
+        """(Input + Skip) + Bias → fuses with bias."""
+        model = self._build(
+            _skip_ln_post_bias,
+            input_types=[self._3D, self._3D, self._1D, self._1D, self._1D],
+            output_types=[self._3D],
+        )
+        count = fuse_skip_layer_normalization(model)
+        self.assertGreater(count, 0)
+        self.assertEqual(self._count_op(model, "SkipLayerNormalization", "com.microsoft"), 1)
+
+    # ---- Negative tests ----
+
+    def test_no_skip_add_no_fusion(self):
+        """No Add before norm → rule should not match."""
+        model = self._build(
+            _skip_rms_no_add,
+            input_types=[self._3D, self._1D],
+            output_types=[self._3D],
+        )
+        count = fuse_skip_rms_normalization(model)
+        self.assertEqual(count, 0)
+        self.assertEqual(
+            self._count_op(model, "SkipSimplifiedLayerNormalization", "com.microsoft"), 0
+        )
+
+    def test_rank2_input_no_fusion(self):
+        """Rank-2 input [S, D] → shape check rejects (expects 3D)."""
+        model = self._build(
+            _skip_rms_no_bias,
+            input_types=[FLOAT["S", _D], FLOAT["S", _D], self._1D],
+            output_types=[FLOAT["S", _D]],
+        )
+        count = fuse_skip_rms_normalization(model)
+        self.assertEqual(count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnxscript/rewriter/ort_fusions/skip_normalization_unit_test.py
+++ b/onnxscript/rewriter/ort_fusions/skip_normalization_unit_test.py
@@ -23,6 +23,7 @@ from parameterized import parameterized
 from onnxscript import FLOAT, script
 from onnxscript import opset18 as op
 from onnxscript.optimizer import optimize
+from onnxscript.rewriter.ort_fusions import _test_utils as test_utils
 from onnxscript.rewriter.ort_fusions.skip_normalization import (
     fuse_skip_layer_normalization,
     fuse_skip_rms_normalization,
@@ -111,8 +112,27 @@ class SkipNormalizationTest(unittest.TestCase):
     def _count_op(self, model: ir.Model, op_type: str, domain: str = "") -> int:
         return sum(1 for n in model.graph if n.op_type == op_type and n.domain == domain)
 
-    _3D = FLOAT["B", "S", _D]
+    def _check_numerical_equivalence(
+        self, model: ir.Model, inputs: dict, fuse_fn, expected_count: int
+    ):
+        original_output = test_utils.ort_run("Original", model, inputs)
+        count = fuse_fn(model)
+        self.assertGreaterEqual(count, expected_count)
+        fused_output = test_utils.ort_run("Fused", model, inputs)
+        test_utils.assert_allclose(original_output, fused_output)
+
+    _3D = FLOAT[_B, _S, _D]
     _1D = FLOAT[_D]
+
+    def _make_inputs(self, *names):
+        shapes = {
+            "input": (_B, _S, _D),
+            "skip": (_B, _S, _D),
+            "gamma": (_D,),
+            "beta": (_D,),
+            "bias": (_D,),
+        }
+        return {n: np.random.randn(*shapes[n]).astype(np.float32) for n in names}
 
     # ---- Skip RMS Norm positive tests ----
 
@@ -129,8 +149,10 @@ class SkipNormalizationTest(unittest.TestCase):
             input_types=[self._3D, self._3D, self._1D],
             output_types=[self._3D],
         )
-        count = fuse_skip_rms_normalization(model)
-        self.assertGreater(count, 0)
+        inputs = self._make_inputs("input", "skip", "gamma")
+        self._check_numerical_equivalence(
+            model, inputs, fuse_skip_rms_normalization, expected_count=1
+        )
         self.assertEqual(
             self._count_op(model, "SkipSimplifiedLayerNormalization", "com.microsoft"), 1
         )
@@ -143,8 +165,10 @@ class SkipNormalizationTest(unittest.TestCase):
             input_types=[self._3D, self._3D, self._1D, self._1D],
             output_types=[self._3D],
         )
-        count = fuse_skip_rms_normalization(model)
-        self.assertGreater(count, 0)
+        inputs = self._make_inputs("input", "skip", "gamma", "bias")
+        self._check_numerical_equivalence(
+            model, inputs, fuse_skip_rms_normalization, expected_count=1
+        )
         self.assertEqual(
             self._count_op(model, "SkipSimplifiedLayerNormalization", "com.microsoft"), 1
         )
@@ -156,8 +180,10 @@ class SkipNormalizationTest(unittest.TestCase):
             input_types=[self._3D, self._3D, self._1D, self._1D],
             output_types=[self._3D],
         )
-        count = fuse_skip_rms_normalization(model)
-        self.assertGreater(count, 0)
+        inputs = self._make_inputs("input", "skip", "gamma", "bias")
+        self._check_numerical_equivalence(
+            model, inputs, fuse_skip_rms_normalization, expected_count=1
+        )
         self.assertEqual(
             self._count_op(model, "SkipSimplifiedLayerNormalization", "com.microsoft"), 1
         )
@@ -171,8 +197,10 @@ class SkipNormalizationTest(unittest.TestCase):
             input_types=[self._3D, self._3D, self._1D, self._1D],
             output_types=[self._3D],
         )
-        count = fuse_skip_layer_normalization(model)
-        self.assertGreater(count, 0)
+        inputs = self._make_inputs("input", "skip", "gamma", "beta")
+        self._check_numerical_equivalence(
+            model, inputs, fuse_skip_layer_normalization, expected_count=1
+        )
         self.assertEqual(self._count_op(model, "SkipLayerNormalization", "com.microsoft"), 1)
         self.assertEqual(self._count_op(model, "LayerNormalization"), 0)
 
@@ -183,8 +211,10 @@ class SkipNormalizationTest(unittest.TestCase):
             input_types=[self._3D, self._3D, self._1D, self._1D, self._1D],
             output_types=[self._3D],
         )
-        count = fuse_skip_layer_normalization(model)
-        self.assertGreater(count, 0)
+        inputs = self._make_inputs("input", "skip", "gamma", "beta", "bias")
+        self._check_numerical_equivalence(
+            model, inputs, fuse_skip_layer_normalization, expected_count=1
+        )
         self.assertEqual(self._count_op(model, "SkipLayerNormalization", "com.microsoft"), 1)
 
     # ---- Negative tests ----

--- a/onnxscript/rewriter/rules/fusion/_layer_norm_extended_test.py
+++ b/onnxscript/rewriter/rules/fusion/_layer_norm_extended_test.py
@@ -1,0 +1,189 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Extended unit tests for LayerNormFusion and LayerNormBiasFusion rules.
+
+Adds coverage for: OrValue alternatives (Pow vs Mul for deviation²,
+Div vs Mul+Reciprocal for normalization), double precision, and negative cases.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import onnx_ir as ir
+
+import onnxscript.optimizer
+import onnxscript.rewriter.testing
+from onnxscript import DOUBLE, FLOAT, script
+from onnxscript import opset18 as op
+from onnxscript.rewriter.rules.fusion._layer_norm import fuse_layer_normalization
+
+# --- Pow variant for deviation_squared ---
+
+
+@script()
+def _ln_pow_variant(x: FLOAT[2, 4, 8], scale: FLOAT[8]) -> FLOAT[2, 4, 8]:
+    """Uses Pow(deviation, 2) instead of Mul(deviation, deviation)."""
+    mean = op.ReduceMean(x, [-1], keepdims=1)
+    deviation = op.Sub(x, mean)
+    deviation_squared = op.Pow(deviation, 2)
+    variance = op.ReduceMean(deviation_squared, [-1], keepdims=1)
+    epsilon = op.Constant(value_float=1e-5)
+    std_dev = op.Sqrt(op.Add(variance, epsilon))
+    inv_std_dev = op.Reciprocal(std_dev)
+    normalized = op.Mul(deviation, inv_std_dev)
+    return op.Mul(normalized, scale)
+
+
+# --- Div variant for normalization ---
+
+
+@script()
+def _ln_div_variant(x: FLOAT[2, 4, 8], scale: FLOAT[8]) -> FLOAT[2, 4, 8]:
+    """Uses Div(deviation, std_dev) instead of Mul(deviation, Reciprocal(std_dev))."""
+    mean = op.ReduceMean(x, [-1], keepdims=1)
+    deviation = op.Sub(x, mean)
+    deviation_squared = op.Mul(deviation, deviation)
+    variance = op.ReduceMean(deviation_squared, [-1], keepdims=1)
+    epsilon = op.Constant(value_float=1e-5)
+    std_dev = op.Sqrt(op.Add(variance, epsilon))
+    normalized = op.Div(deviation, std_dev)
+    return op.Mul(normalized, scale)
+
+
+# --- Pow + Div combined (both OrValue alternatives) ---
+
+
+@script()
+def _ln_pow_div(x: FLOAT[2, 4, 8], scale: FLOAT[8]) -> FLOAT[2, 4, 8]:
+    """Both alternative branches: Pow for deviation², Div for normalization."""
+    mean = op.ReduceMean(x, [-1], keepdims=1)
+    deviation = op.Sub(x, mean)
+    deviation_squared = op.Pow(deviation, 2)
+    variance = op.ReduceMean(deviation_squared, [-1], keepdims=1)
+    epsilon = op.Constant(value_float=1e-5)
+    std_dev = op.Sqrt(op.Add(variance, epsilon))
+    normalized = op.Div(deviation, std_dev)
+    return op.Mul(normalized, scale)
+
+
+# --- Div variant with bias ---
+
+
+@script()
+def _ln_div_with_bias(x: FLOAT[2, 4, 8], scale: FLOAT[8], bias: FLOAT[8]) -> FLOAT[2, 4, 8]:
+    """Div normalization path + bias addition."""
+    mean = op.ReduceMean(x, [-1], keepdims=1)
+    deviation = op.Sub(x, mean)
+    deviation_squared = op.Mul(deviation, deviation)
+    variance = op.ReduceMean(deviation_squared, [-1], keepdims=1)
+    epsilon = op.Constant(value_float=1e-5)
+    std_dev = op.Sqrt(op.Add(variance, epsilon))
+    normalized = op.Div(deviation, std_dev)
+    scaled = op.Mul(normalized, scale)
+    return op.Add(scaled, bias)
+
+
+# --- Double precision ---
+
+
+@script()
+def _ln_double(x: DOUBLE[2, 4, 8], scale: DOUBLE[8]) -> DOUBLE[2, 4, 8]:
+    """Double-precision inputs."""
+    mean = op.ReduceMean(x, [-1], keepdims=1)
+    deviation = op.Sub(x, mean)
+    deviation_squared = op.Mul(deviation, deviation)
+    variance = op.ReduceMean(deviation_squared, [-1], keepdims=1)
+    epsilon = op.Constant(value_float=1e-5)
+    std_dev = op.Sqrt(op.Add(variance, epsilon))
+    inv_std_dev = op.Reciprocal(std_dev)
+    normalized = op.Mul(deviation, inv_std_dev)
+    return op.Mul(normalized, scale)
+
+
+# --- Negative: float16 input (not in LAYER_NORM_COMPUTE_TYPES) ---
+
+
+@script()
+def _ln_fp16(x: FLOAT[2, 4, 8], scale: FLOAT[8]) -> FLOAT[2, 4, 8]:
+    """Pattern is structurally correct but input dtype will be fp16."""
+    mean = op.ReduceMean(x, [-1], keepdims=1)
+    deviation = op.Sub(x, mean)
+    deviation_squared = op.Mul(deviation, deviation)
+    variance = op.ReduceMean(deviation_squared, [-1], keepdims=1)
+    epsilon = op.Constant(value_float=1e-5)
+    std_dev = op.Sqrt(op.Add(variance, epsilon))
+    inv_std_dev = op.Reciprocal(std_dev)
+    normalized = op.Mul(deviation, inv_std_dev)
+    return op.Mul(normalized, scale)
+
+
+class LayerNormFusionExtendedTest(unittest.TestCase):
+    """Extended tests for LayerNormFusion (OrValue alternatives, dtypes, negatives)."""
+
+    def _check(self, test_script, expected_op="LayerNormalization"):
+        """Build, fuse, verify single fused node, numerical equivalence."""
+        model_proto = test_script.to_model_proto()
+        input_data = onnxscript.rewriter.testing.generate_random_inputs(model_proto)
+        model = ir.serde.deserialize_model(model_proto)
+        count = fuse_layer_normalization(model)
+        self.assertGreater(count, 0)
+        onnxscript.optimizer.remove_unused_nodes(model)
+        op_types = [n.op_type for n in model.graph]
+        self.assertIn(expected_op, op_types)
+        fused_proto = ir.serde.serialize_model(model)
+        onnxscript.rewriter.testing.assert_numerically_equal(
+            model_proto, fused_proto, input_data
+        )
+
+    # --- Positive tests: OrValue alternatives ---
+
+    def test_pow_for_deviation_squared(self):
+        """Pow(deviation, 2) instead of Mul(deviation, deviation) → fuses."""
+        self._check(_ln_pow_variant)
+
+    def test_div_for_normalization(self):
+        """Div(deviation, std_dev) instead of Mul(deviation, Reciprocal(std_dev)) → fuses."""
+        self._check(_ln_div_variant)
+
+    def test_pow_and_div_combined(self):
+        """Both OrValue alternative branches active → fuses."""
+        self._check(_ln_pow_div)
+
+    def test_div_with_bias(self):
+        """Div normalization + bias → fuses into LayerNormalization with bias."""
+        self._check(_ln_div_with_bias)
+
+    def test_double_precision(self):
+        """Double-precision inputs → fuses (double is a valid compute type)."""
+        model_proto = _ln_double.to_model_proto()
+        input_data = {
+            "x": np.random.randn(2, 4, 8).astype(np.float64),
+            "scale": np.random.randn(8).astype(np.float64),
+        }
+        model = ir.serde.deserialize_model(model_proto)
+        count = fuse_layer_normalization(model)
+        self.assertGreater(count, 0)
+        onnxscript.optimizer.remove_unused_nodes(model)
+        op_types = [n.op_type for n in model.graph]
+        self.assertIn("LayerNormalization", op_types)
+
+    # --- Negative test ---
+
+    def test_fp16_input_no_fusion(self):
+        """float16 input dtype → check rejects (not in LAYER_NORM_COMPUTE_TYPES)."""
+        from onnxscript import FLOAT16
+
+        model_proto = _ln_fp16.to_model_proto(
+            input_types=[FLOAT16[2, 4, 8], FLOAT16[8]],
+            output_types=[FLOAT16[2, 4, 8]],
+        )
+        model = ir.serde.deserialize_model(model_proto)
+        count = fuse_layer_normalization(model)
+        self.assertEqual(count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnxscript/rewriter/rules/fusion/_layer_norm_extended_test.py
+++ b/onnxscript/rewriter/rules/fusion/_layer_norm_extended_test.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import unittest
 
-import numpy as np
 import onnx_ir as ir
 
 import onnxscript.optimizer
@@ -159,10 +158,6 @@ class LayerNormFusionExtendedTest(unittest.TestCase):
     def test_double_precision(self):
         """Double-precision inputs → fuses (double is a valid compute type)."""
         model_proto = _ln_double.to_model_proto()
-        input_data = {
-            "x": np.random.randn(2, 4, 8).astype(np.float64),
-            "scale": np.random.randn(8).astype(np.float64),
-        }
         model = ir.serde.deserialize_model(model_proto)
         count = fuse_layer_normalization(model)
         self.assertGreater(count, 0)

--- a/onnxscript/rewriter/rules/fusion/_rms_normalization_extended_test.py
+++ b/onnxscript/rewriter/rules/fusion/_rms_normalization_extended_test.py
@@ -1,0 +1,173 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Extended unit tests for RmsNormFusion rules (rules/fusion/_rms_normalization.py).
+
+Adds coverage for: mul_order variants, mixed-precision Cast paths,
+double dtype, and negative cases (int input, non-float compute dtype).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import onnx_ir as ir
+from parameterized import parameterized
+
+from onnxscript import DOUBLE, FLOAT, FLOAT16, script
+from onnxscript import opset18 as op
+from onnxscript.optimizer import optimize
+from onnxscript.rewriter.rules.fusion._rms_normalization import fuse_rms_normalization
+
+_EPS = ir.tensor(np.array([1e-6], dtype=np.float32))
+_EPS_D = ir.tensor(np.array([1e-6], dtype=np.float64))
+
+
+# --- mul_order=False: Mul(scale, normalized) ---
+
+
+@script()
+def _rms_scale_first(x, scale):
+    x_sq = op.Pow(x, 2.0)
+    mean_sq = op.ReduceMean(x_sq, [-1], keepdims=1, noop_with_empty_axes=0)
+    eps = op.Constant(value=_EPS)
+    rms = op.Sqrt(op.Add(mean_sq, eps))
+    inv_rms = op.Reciprocal(rms)
+    normalized = op.Mul(x, inv_rms)
+    return op.Mul(scale, normalized)
+
+
+# --- mul_order=True: Mul(normalized, scale) ---
+
+
+@script()
+def _rms_norm_first(x, scale):
+    x_sq = op.Pow(x, 2.0)
+    mean_sq = op.ReduceMean(x_sq, [-1], keepdims=1, noop_with_empty_axes=0)
+    eps = op.Constant(value=_EPS)
+    rms = op.Sqrt(op.Add(mean_sq, eps))
+    inv_rms = op.Reciprocal(rms)
+    normalized = op.Mul(x, inv_rms)
+    return op.Mul(normalized, scale)
+
+
+# --- Mixed-precision: fp16 input, fp32 compute, fp16 output ---
+
+
+@script()
+def _rms_mixed_precision(x, scale):
+    x_f32 = op.Cast(x, to=ir.DataType.FLOAT)
+    x_sq = op.Pow(x_f32, 2.0)
+    mean_sq = op.ReduceMean(x_sq, [-1], keepdims=1, noop_with_empty_axes=0)
+    eps = op.Constant(value=_EPS)
+    rms = op.Sqrt(op.Add(mean_sq, eps))
+    inv_rms = op.Reciprocal(rms)
+    normalized = op.Mul(x_f32, inv_rms)
+    result = op.Cast(normalized, to=ir.DataType.FLOAT16)
+    return op.Mul(result, scale)
+
+
+# --- Double precision ---
+
+
+@script()
+def _rms_double(x, scale):
+    x_sq = op.Pow(x, 2.0)
+    mean_sq = op.ReduceMean(x_sq, [-1], keepdims=1, noop_with_empty_axes=0)
+    eps = op.Constant(value=_EPS_D)
+    rms = op.Sqrt(op.Add(mean_sq, eps))
+    inv_rms = op.Reciprocal(rms)
+    normalized = op.Mul(x, inv_rms)
+    return op.Mul(normalized, scale)
+
+
+# --- Negative: int32 input ---
+
+
+@script()
+def _rms_int_input(x, scale):
+    x_f = op.Cast(x, to=ir.DataType.FLOAT)
+    x_sq = op.Pow(x_f, 2.0)
+    mean_sq = op.ReduceMean(x_sq, [-1], keepdims=1, noop_with_empty_axes=0)
+    eps = op.Constant(value=_EPS)
+    rms = op.Sqrt(op.Add(mean_sq, eps))
+    inv_rms = op.Reciprocal(rms)
+    normalized = op.Mul(x_f, inv_rms)
+    return op.Mul(normalized, scale)
+
+
+class RmsNormOnnxFusionExtendedTest(unittest.TestCase):
+    """Extended tests for RmsNormFusion (rules/fusion variant producing RMSNormalization)."""
+
+    def _build(self, script_fn, input_types, output_types) -> ir.Model:
+        model_proto = script_fn.to_model_proto(
+            input_types=input_types, output_types=output_types
+        )
+        model = ir.serde.deserialize_model(model_proto)
+        optimize(model)
+        return model
+
+    def _count_op(self, model: ir.Model, op_type: str) -> int:
+        return sum(1 for n in model.graph if n.op_type == op_type)
+
+    # --- Positive tests ---
+
+    @parameterized.expand(
+        [
+            ("scale_times_normalized", _rms_scale_first),
+            ("normalized_times_scale", _rms_norm_first),
+        ]
+    )
+    def test_mul_order_variants(self, _name, script_fn):
+        """Both Mul orderings should fuse to RMSNormalization."""
+        model = self._build(
+            script_fn,
+            input_types=[FLOAT["B", "S", 16], FLOAT[16]],
+            output_types=[FLOAT["B", "S", 16]],
+        )
+        count = fuse_rms_normalization(model)
+        self.assertEqual(count, 1)
+        self.assertEqual(self._count_op(model, "RMSNormalization"), 1)
+        self.assertEqual(self._count_op(model, "Pow"), 0)
+
+    def test_mixed_precision_cast(self):
+        """fp16 input Cast to fp32 for compute, Cast back → fuses."""
+        model = self._build(
+            _rms_mixed_precision,
+            input_types=[FLOAT16["B", "S", 16], FLOAT16[16]],
+            output_types=[FLOAT16["B", "S", 16]],
+        )
+        count = fuse_rms_normalization(model)
+        self.assertEqual(count, 1)
+        self.assertEqual(self._count_op(model, "RMSNormalization"), 1)
+
+    def test_double_precision(self):
+        """Double-precision inputs → fuses (double is a valid compute type)."""
+        model = self._build(
+            _rms_double,
+            input_types=[DOUBLE["B", "S", 16], DOUBLE[16]],
+            output_types=[DOUBLE["B", "S", 16]],
+        )
+        count = fuse_rms_normalization(model)
+        self.assertEqual(count, 1)
+        self.assertEqual(self._count_op(model, "RMSNormalization"), 1)
+
+    # --- Negative tests ---
+
+    def test_int_input_no_fusion(self):
+        """Integer input dtype → check rejects (x.dtype not in float_types)."""
+        from onnxscript import INT32
+
+        model = self._build(
+            _rms_int_input,
+            input_types=[INT32["B", "S", 16], FLOAT[16]],
+            output_types=[FLOAT["B", "S", 16]],
+        )
+        count = fuse_rms_normalization(model)
+        self.assertEqual(count, 0)
+        self.assertEqual(self._count_op(model, "RMSNormalization"), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnxscript/rewriter/rules/fusion/_rms_normalization_extended_test.py
+++ b/onnxscript/rewriter/rules/fusion/_rms_normalization_extended_test.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import unittest
 
 import numpy as np
+import onnx
 import onnx_ir as ir
 from parameterized import parameterized
 
@@ -23,6 +24,10 @@ from onnxscript.rewriter.rules.fusion._rms_normalization import fuse_rms_normali
 
 _EPS = ir.tensor(np.array([1e-6], dtype=np.float32))
 _EPS_D = ir.tensor(np.array([1e-6], dtype=np.float64))
+
+_has_rms_normalization_schema = hasattr(onnx.defs, "get_schema") and (
+    onnx.defs.onnx_opset_version() >= 23
+)
 
 
 # --- mul_order=False: Mul(scale, normalized) ---
@@ -118,15 +123,19 @@ class RmsNormOnnxFusionExtendedTest(unittest.TestCase):
         """Apply fusion and verify numerical equivalence using ONNX reference impl.
 
         ORT does not yet have a kernel for RMSNormalization, so we use
-        the ONNX reference implementation for validation.
+        the ONNX reference implementation for validation. Serialization of
+        the fused model requires the RMSNormalization schema (onnx opset >= 23),
+        so numerical validation is skipped on older onnx versions.
         """
-        original_proto = ir.serde.serialize_model(model)
+        if _has_rms_normalization_schema:
+            original_proto = ir.serde.serialize_model(model)
         count = fuse_rms_normalization(model)
         self.assertEqual(count, expected_count)
-        fused_proto = ir.serde.serialize_model(model)
-        rewriter_testing.assert_numerically_equal(
-            original_proto, fused_proto, args=inputs, use_reference=True
-        )
+        if _has_rms_normalization_schema:
+            fused_proto = ir.serde.serialize_model(model)
+            rewriter_testing.assert_numerically_equal(
+                original_proto, fused_proto, args=inputs, use_reference=True
+            )
 
     # --- Positive tests ---
 

--- a/onnxscript/rewriter/rules/fusion/_rms_normalization_extended_test.py
+++ b/onnxscript/rewriter/rules/fusion/_rms_normalization_extended_test.py
@@ -18,6 +18,7 @@ from parameterized import parameterized
 from onnxscript import DOUBLE, FLOAT, FLOAT16, script
 from onnxscript import opset18 as op
 from onnxscript.optimizer import optimize
+from onnxscript.rewriter import testing as rewriter_testing
 from onnxscript.rewriter.rules.fusion._rms_normalization import fuse_rms_normalization
 
 _EPS = ir.tensor(np.array([1e-6], dtype=np.float32))
@@ -100,6 +101,8 @@ def _rms_int_input(x, scale):
 class RmsNormOnnxFusionExtendedTest(unittest.TestCase):
     """Extended tests for RmsNormFusion (rules/fusion variant producing RMSNormalization)."""
 
+    _B, _S, _D = 2, 4, 16
+
     def _build(self, script_fn, input_types, output_types) -> ir.Model:
         model_proto = script_fn.to_model_proto(
             input_types=input_types, output_types=output_types
@@ -110,6 +113,20 @@ class RmsNormOnnxFusionExtendedTest(unittest.TestCase):
 
     def _count_op(self, model: ir.Model, op_type: str) -> int:
         return sum(1 for n in model.graph if n.op_type == op_type)
+
+    def _check_numerical_equivalence(self, model: ir.Model, inputs: dict, expected_count: int):
+        """Apply fusion and verify numerical equivalence using ONNX reference impl.
+
+        ORT does not yet have a kernel for RMSNormalization, so we use
+        the ONNX reference implementation for validation.
+        """
+        original_proto = ir.serde.serialize_model(model)
+        count = fuse_rms_normalization(model)
+        self.assertEqual(count, expected_count)
+        fused_proto = ir.serde.serialize_model(model)
+        rewriter_testing.assert_numerically_equal(
+            original_proto, fused_proto, args=inputs, use_reference=True
+        )
 
     # --- Positive tests ---
 
@@ -123,11 +140,14 @@ class RmsNormOnnxFusionExtendedTest(unittest.TestCase):
         """Both Mul orderings should fuse to RMSNormalization."""
         model = self._build(
             script_fn,
-            input_types=[FLOAT["B", "S", 16], FLOAT[16]],
-            output_types=[FLOAT["B", "S", 16]],
+            input_types=[FLOAT[self._B, self._S, self._D], FLOAT[self._D]],
+            output_types=[FLOAT[self._B, self._S, self._D]],
         )
-        count = fuse_rms_normalization(model)
-        self.assertEqual(count, 1)
+        inputs = {
+            "x": np.random.randn(self._B, self._S, self._D).astype(np.float32),
+            "scale": np.random.randn(self._D).astype(np.float32),
+        }
+        self._check_numerical_equivalence(model, inputs, expected_count=1)
         self.assertEqual(self._count_op(model, "RMSNormalization"), 1)
         self.assertEqual(self._count_op(model, "Pow"), 0)
 
@@ -135,19 +155,26 @@ class RmsNormOnnxFusionExtendedTest(unittest.TestCase):
         """fp16 input Cast to fp32 for compute, Cast back → fuses."""
         model = self._build(
             _rms_mixed_precision,
-            input_types=[FLOAT16["B", "S", 16], FLOAT16[16]],
-            output_types=[FLOAT16["B", "S", 16]],
+            input_types=[FLOAT16[self._B, self._S, self._D], FLOAT16[self._D]],
+            output_types=[FLOAT16[self._B, self._S, self._D]],
         )
-        count = fuse_rms_normalization(model)
-        self.assertEqual(count, 1)
+        inputs = {
+            "x": np.random.randn(self._B, self._S, self._D).astype(np.float16),
+            "scale": np.random.randn(self._D).astype(np.float16),
+        }
+        self._check_numerical_equivalence(model, inputs, expected_count=1)
         self.assertEqual(self._count_op(model, "RMSNormalization"), 1)
 
     def test_double_precision(self):
-        """Double-precision inputs → fuses (double is a valid compute type)."""
+        """Double-precision inputs → fuses (double is a valid compute type).
+
+        Structural check only: ONNX reference impl does not support
+        RMSNormalization with stash_type=DOUBLE.
+        """
         model = self._build(
             _rms_double,
-            input_types=[DOUBLE["B", "S", 16], DOUBLE[16]],
-            output_types=[DOUBLE["B", "S", 16]],
+            input_types=[DOUBLE[self._B, self._S, self._D], DOUBLE[self._D]],
+            output_types=[DOUBLE[self._B, self._S, self._D]],
         )
         count = fuse_rms_normalization(model)
         self.assertEqual(count, 1)


### PR DESCRIPTION
Add more unit test cases for fusion rules. (Currently, these are tested via real-world models in the benchmark-suite elsewhere, but unit tests are missing for various fusions.) 

* Erfgelu fusion
* MHA-Bias fusion
* MHA-Scale fusion
* RmsNormalization fusion
* MHA fusion
* Rotary Embedding
* Skip Norm
* Layer Norm