### PR TITLE
Remove dead Opset function_defs registration

### DIFF
--- a/onnxscript/_internal/converter.py
+++ b/onnxscript/_internal/converter.py
@@ -1478,7 +1478,6 @@ class Converter:
             self._current_fn = irbuilder.IRFunction(stmt.name, domain)
             self._analyzer = analysis.AstAnalyzer(stmt, self._message, self.globals)
             fn_ir = self._translate_function_def_common(stmt)
-            self.this_module.add_function_def(fn_ir)
             self._analyzer = None
             return fn_ir
         raise ValueError(f"Unsupported top-level statement type {type(stmt)!r}.")

--- a/onnxscript/_internal/values.py
+++ b/onnxscript/_internal/values.py
@@ -94,7 +94,6 @@ class Opset:
         instance = super().__new__(cls)
         instance.domain = domain  # type: ignore[attr-defined]
         instance.version = version  # type: ignore[attr-defined]
-        instance.function_defs = {}  # type: ignore[attr-defined]
         cls.cache[key] = instance
         return instance
 
@@ -129,9 +128,6 @@ class Opset:
             return Op(self, attr, schema)
         except Exception as exc:  # pylint: disable=broad-exception-caught
             raise AttributeError(f"Attribute {attr} not found.") from exc
-
-    def add_function_def(self, fun):
-        self.function_defs[fun.name] = fun
 
     def _prepare_inputs(self, _: onnx.defs.OpSchema, *inputs):
         """Trims 'None' values from the end of the inputs list. This is used to support


### PR DESCRIPTION
The function_defs dict on Opset and add_function_def() method are written to but never read from anywhere in the codebase. Removing this dead code eliminates a memory leak where the singleton Opset holds references to all compiled functions forever.

This will also help simplify further cleanups (relating to better handling of conversion of script functions to IR ... which currently goes from IR to proto to IR unnecessarily).