### PR TITLE
Expose build_function and build_graph in public API

### DIFF
--- a/onnxscript/__init__.py
+++ b/onnxscript/__init__.py
@@ -16,6 +16,8 @@ __all__ = [
     "OpBuilder",
     "OpBuilderBase",
     "TapeBuilder",
+    "build_function",
+    "build_graph",
     "proto2python",
     "external_tensor",
     "BFLOAT16",
@@ -132,7 +134,7 @@ from .onnx_types import (
 # isort: on
 
 from . import ir, nn, optimizer, rewriter, version_converter
-from ._internal.builder import GraphBuilder, OpBuilder
+from ._internal.builder import GraphBuilder, OpBuilder, build_function, build_graph
 from ._internal.tape_builder import OpBuilderBase, TapeBuilder
 from ._internal.utils import external_tensor
 from ._internal.values import OnnxFunction, TracedOnnxFunction


### PR DESCRIPTION
Add build_function and build_graph to onnxscript's top-level exports, allowing downstream packages (e.g. mobius) to import them directly as onnxscript.build_function / onnxscript.build_graph instead of reaching into onnxscript._internal.builder.