### PR TITLE
Fix upsample half pixel mode for size one

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -2320,7 +2320,7 @@ def aten_unflatten_dense_tensors(
 
 
 def _get_upsample_align_corners_mode(align_corners: bool) -> str:
-    return "align_corners" if align_corners else "pytorch_half_pixel"
+    return "align_corners" if align_corners else "half_pixel"
 
 
 def _aten_upsample_output_size(

--- a/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/tests/function_libs/torch_lib/extra_opinfo.py
@@ -1888,6 +1888,9 @@ def sample_inputs_upsample_2d(op_info, device, dtype, requires_grad, **kwargs):
 
     for align_corners in align_corners_options:
         yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)), shape(1, rank, False), align_corners
+        )
+        yield opinfo_core.SampleInput(
             make_arg(shape(D, rank)), shape(S, rank, False), align_corners
         )
         yield opinfo_core.SampleInput(
@@ -1934,6 +1937,9 @@ def sample_inputs_upsample_2d_vec(op_info, device, dtype, requires_grad, **kwarg
     yield opinfo_core.SampleInput(make_arg(shape(D, rank)), shape(SS, rank, False), True, None)
 
     for align_corners in align_corners_options:
+        yield opinfo_core.SampleInput(
+            make_arg(shape(D, rank)), shape(1, rank, False), align_corners, None
+        )
         yield opinfo_core.SampleInput(
             make_arg(shape(D, rank)), shape(S, rank, False), align_corners, None
         )


### PR DESCRIPTION
Fixes the ATen upsampling lowering for `align_corners=False` to use ONNX `half_pixel` mode instead of `pytorch_half_pixel`.

`pytorch_half_pixel` special-cases output size 1 differently from PyTorch eager behavior, causing mismatches for cases like `upsample_bilinear2d(..., output_size=(1, 1), align_corners=False)`. This change makes the exported `Resize` node match PyTorch results for that edge case.

Adds regression samples for 2D upsampling with output size 1, covering both `upsample_bilinear2d` and `upsample_bilinear2d.vec`.

Also reference: https://github.com/pytorch/pytorch/issues/79361