### PR TITLE
Fix aten_stft ONNX spec violations

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -9331,13 +9331,17 @@ def aten_stft(
         # core dump
         # hop_length = op.Div(op.Constant(value_ints=n_fft), op.Constant(value_ints=[4]))
         hop_length = n_fft // 4
-    frame_step_const = op.Reshape(hop_length, op.Constant(value_ints=[1]))
 
     # Pre-process input if needed
     is_signal_rank1 = len(self.shape) == 1
     if is_signal_rank1:
         # Add a batch dimension
         self = op.Identity(op.Unsqueeze(self, op.Constant(value_ints=[0])))
+
+    # ONNX's STFT requires a rank-3 signal of shape [batch_size, signal_length, 1]
+    # (the trailing dimension is the real component). torch.stft accepts rank-1 or
+    # rank-2 signals, so add the trailing dimension here for both cases.
+    self = op.Unsqueeze(self, op.Constant(value_ints=[-1]))
 
     # Get window and make sure it's the same size as `win_length` or `n_fft`
     if window is not None and window.shape[0] is not None:
@@ -9367,7 +9371,7 @@ def aten_stft(
     else:
         onesided = 0
     window = op.CastLike(window, self)
-    result = op.STFT(self, frame_step_const, window, n_fft, onesided=onesided)
+    result = op.STFT(self, hop_length, window, n_fft, onesided=onesided)
     result = op.Transpose(result, perm=[0, 2, 1, 3])
     # Remove batch dimension, if needed
     if is_signal_rank1:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -9332,16 +9332,16 @@ def aten_stft(
         # hop_length = op.Div(op.Constant(value_ints=n_fft), op.Constant(value_ints=[4]))
         hop_length = n_fft // 4
 
-    # Pre-process input if needed
-    is_signal_rank1 = len(self.shape) == 1
-    if is_signal_rank1:
-        # Add a batch dimension
-        self = op.Identity(op.Unsqueeze(self, op.Constant(value_ints=[0])))
-
     # ONNX's STFT requires a rank-3 signal of shape [batch_size, signal_length, 1]
     # (the trailing dimension is the real component). torch.stft accepts rank-1 or
-    # rank-2 signals, so add the trailing dimension here for both cases.
-    self = op.Unsqueeze(self, op.Constant(value_ints=[-1]))
+    # rank-2 signals.
+    is_signal_rank1 = len(self.shape) == 1
+    if is_signal_rank1:
+        # [signal_length] -> [1, signal_length, 1]: add batch dim and trailing real-component dim
+        self = op.Unsqueeze(self, op.Constant(value_ints=[0, -1]))
+    else:
+        # [batch_size, signal_length] -> [batch_size, signal_length, 1]
+        self = op.Unsqueeze(self, op.Constant(value_ints=[-1]))
 
     # Get window and make sure it's the same size as `win_length` or `n_fft`
     if window is not None and window.shape[0] is not None:

--- a/tests/function_libs/torch_lib/e2e_ops_tests.py
+++ b/tests/function_libs/torch_lib/e2e_ops_tests.py
@@ -554,6 +554,53 @@ class TorchLibe2eTest(unittest.TestCase):
         )
         _testing.assert_onnx_program(onnx_program)
 
+    @parameterized.parameterized.expand(
+        [
+            ("rank1", (100,)),
+            ("rank2", (4, 100)),
+        ]
+    )
+    def test_aten_stft_emits_spec_compliant_node(self, _: str, shape: tuple[int, ...]):
+        # Regression test for https://github.com/microsoft/onnxscript/issues/2942
+        # The ONNX STFT op requires a rank-3 signal ([batch, signal_length, 1]) and
+        # `frame_step`/`frame_length` to share the same (scalar) type. torch.stft
+        # accepts rank-1 or rank-2 signals, so aten_stft must reshape accordingly.
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.stft(x, n_fft=16, return_complex=False)
+
+        x = torch.randn(*shape, dtype=torch.float32)
+        onnx_program = torch.onnx.export(
+            Model(),
+            (x,),
+            dynamo=True,
+            verbose=False,
+        )
+        _testing.assert_onnx_program(onnx_program)
+
+        model = onnx_program.model_proto
+
+        def _rank(name: str) -> int:
+            for vi in (
+                list(model.graph.value_info)
+                + list(model.graph.input)
+                + list(model.graph.output)
+            ):
+                if vi.name == name:
+                    return len(vi.type.tensor_type.shape.dim)
+            raise AssertionError(f"value_info for {name} not found")
+
+        stft_nodes = [n for n in model.graph.node if n.op_type == "STFT"]
+        self.assertEqual(len(stft_nodes), 1)
+        node = stft_nodes[0]
+        signal, frame_step = node.input[0], node.input[1]
+        frame_length = node.input[3]
+        # signal must be rank 3: [batch, signal_length, 1]
+        self.assertEqual(_rank(signal), 3)
+        # frame_step and frame_length must share the same (scalar) rank
+        self.assertEqual(_rank(frame_step), 0)
+        self.assertEqual(_rank(frame_length), 0)
+
     def test_unbind_dim0(self):
         """Test unbind along dimension 0"""
 


### PR DESCRIPTION
## Summary

`aten_stft` emitted an ONNX `STFT` node that violated the operator spec in two ways (reported in #2942 by @bas-aarts):

1. **`frame_step` / `frame_length` type mismatch.** `frame_step` was built via `op.Reshape(hop_length, [1])`, producing a rank-1 tensor, while `frame_length` (`n_fft`) is a rank-0 scalar. The spec (`T2` for both) requires them to share the same type/rank.
2. **Signal rank.** The ONNX `STFT` signal must be rank 3 (`[batch, signal_length, 1]` for real input). `torch.stft` accepts rank-1 or rank-2 signals, and the code only unsqueezed a rank-1 signal up to rank 2, leaving the signal one dimension short of the spec.

## Fix

- Pass `hop_length` directly as `frame_step` (a rank-0 scalar, matching `n_fft`) and remove the `frame_step_const = op.Reshape(...)` line. `hop_length` is always a Python int in this trace-only function (input arg or `n_fft // 4`), so it is emitted as a rank-0 scalar exactly like `n_fft`.
- Add `self = op.Unsqueeze(self, [-1])` after the existing batch-dim handling so the signal becomes rank 3 for **both** rank-1 and rank-2 inputs.

## Rank trace (verified by inspecting the emitted STFT node)

Before → after, STFT inputs `[signal, frame_step, window, frame_length]`:

| input | buggy rank | fixed rank | spec |
|-------|-----------|-----------|------|
| signal | 2 | **3** | 3 |
| frame_step | 1 | **0** | scalar |
| window | 1 | 1 | 1 |
| frame_length | 0 | 0 | scalar |

End-to-end shapes (fixed): rank-1 input `[L]` → batch unsqueeze `[1, L]` → trailing unsqueeze `[1, L, 1]` → STFT `[1, frames, bins, 2]` → Transpose `[1, bins, frames, 2]` → squeeze batch `[bins, frames, 2]`. Rank-2 input `[B, L]` → `[B, L, 1]` → `[B, frames, bins, 2]` → `[B, bins, frames, 2]`. Both match `torch.stft`'s real output. The `normalized` and `onesided` paths are unaffected (only dtype/scaling, not rank).

## Tests

- The existing OpInfo (`ops.aten.stft`) and `_testing.assert_onnx_program` value-comparison harnesses pass both before and after — they don't strictly enforce the STFT rank, which is why this spec bug went unnoticed.
- Added `test_aten_stft_emits_spec_compliant_node` (parameterized for rank-1 and rank-2 inputs) in `tests/function_libs/torch_lib/e2e_ops_tests.py`, which asserts the emitted STFT node's `signal` is rank 3 and `frame_step`/`frame_length` are both scalar. This test **fails on the old code** (`2 != 3`) and passes with the fix.

Ran:
- `pytest tests/function_libs/torch_lib/ops_test.py -k stft` → 2 passed, 1 skipped, 2 xfailed
- `pytest tests/function_libs/torch_lib/e2e_ops_tests.py -k stft` → 6 passed
- `lintrunner -a` → no lint issues

Fixes #2942