### PR TITLE
fix: prevent initializer name collision in rewrite rule registration

### DIFF
--- a/onnxscript/rewriter/_rewrite_rule.py
+++ b/onnxscript/rewriter/_rewrite_rule.py
@@ -712,10 +712,21 @@ class RewriteRuleSet:
                     initializers = graph_or_function.initializers
                     for initializer in delta.new_initializers:
                         if initializer.name in initializers:
+                            existing = initializers[initializer.name]
+                            if existing is initializer:
+                                # Same Value already registered, skip.
+                                continue
+                            # Name conflict with a different Value: generate a unique name.
+                            base_name = initializer.name
+                            counter = 1
+                            while f"{base_name}_{counter}" in initializers:
+                                counter += 1
                             if verbose:
-                                print(f"Initializer {initializer.name} already exists.")
-                            continue
-                    for initializer in delta.new_initializers:
+                                print(
+                                    f"Initializer '{initializer.name}' already exists. "
+                                    f"Renaming to '{base_name}_{counter}'."
+                                )
+                            initializer.name = f"{base_name}_{counter}"
                         initializers[initializer.name] = initializer  # type: ignore[index]
                 # TODO: This does not yet handle the problem of determining the correct insertion point
                 # for inserted nodes in the case of patterns with multiple output-nodes. The following

--- a/onnxscript/rewriter/rules/common/_basic_rules_test.py
+++ b/onnxscript/rewriter/rules/common/_basic_rules_test.py
@@ -554,6 +554,48 @@ class ReshapeReshapeTest(unittest.TestCase):
         self.assertEqual(tracer_match.status.value, orp.MatchStatus.CONDITION_FAILED)
         self.assertRegex(tracer_match.match_result.reason, error_msg)
 
+    def test_reshape_reshape_shared_shape_no_clobbering(self):
+        """Two Reshape->Reshape chains sharing the same shape with -1 should not clobber initializers."""
+        import onnx_ir
+
+        model = onnx_ir.from_onnx_text(
+            """\
+<ir_version: 9, opset_import: ["" : 21]>
+test (float[2, 3] input1, float[2, 6] input2) => (float[2, 3] out1, float[2, 6] out2) {
+    mid1 = Reshape (input1, shape_mid_a)
+    mid2 = Reshape (input2, shape_mid_b)
+    out1 = Reshape (mid1, shared_shape)
+    out2 = Reshape (mid2, shared_shape)
+}""",
+            initializers=[
+                ir.Tensor(np.array([6], dtype=np.int64), name="shape_mid_a"),
+                ir.Tensor(np.array([12], dtype=np.int64), name="shape_mid_b"),
+                ir.Tensor(np.array([2, -1], dtype=np.int64), name="shared_shape"),
+            ],
+        )
+
+        count = _basic_rules.reshape_reshape_rule.apply_to_model(model)
+        self.assertEqual(count, 2)
+
+        # All Reshape shape inputs must be registered initializers
+        for node in model.graph:
+            if node.op_type == "Reshape":
+                shape_val = node.inputs[1]
+                self.assertIn(
+                    shape_val.name,
+                    model.graph.initializers,
+                    f"Shape '{shape_val.name}' not registered as initializer",
+                )
+                self.assertIs(
+                    model.graph.initializers[shape_val.name],
+                    shape_val,
+                    f"Shape '{shape_val.name}' maps to a different Value object",
+                )
+
+        # Model must serialize and pass onnx checker
+        proto = onnx_ir.to_proto(model)
+        onnx.checker.check_model(proto, full_check=True)
+
 
 class Flatten2ReshapeTest(unittest.TestCase):
     @staticmethod


### PR DESCRIPTION
## Summary

> https://github.com/microsoft/onnxscript/issues/2945

Fix a bug where multiple rewrite rule matches producing initializers with the same name would silently clobber each other, resulting in a dangling `ir.Value` reference and a toposort validation failure on serialization.

## Problem

When two `Reshape→Reshape` chains share the same shape initializer (e.g. containing `-1`), the `ReshapeReshape` rule fires twice, each time calling `op.initializer(ir.Tensor(..., name=shape.name))`. Both produce an initializer with the same name but different resolved values.

The registration logic in `_rewrite_rule.py` had two independent for-loops:

```python
# Loop 1: check for duplicates (dead code — `continue` only skips this loop)
for initializer in delta.new_initializers:
    if initializer.name in initializers:
        continue

# Loop 2: unconditionally overwrite
for initializer in delta.new_initializers:
    initializers[initializer.name] = initializer
```

The second loop always overwrote the dict entry, so the first registered Value lost its dict reference. `NameFixPass` would then rename it to ensure uniqueness, but never re-registered it as an initializer — leaving it as a dangling reference that fails `onnx.checker`.

## Fix

Merge into a single loop. On name conflict with a different Value object, auto-generate a unique suffix (`_1`, `_2`, ...) and register under the new name. Since node inputs hold object references (not name strings), the rename propagates correctly on serialization.

## Test

Added `test_reshape_reshape_shared_shape_no_clobbering` covering the shared-shape scenario. Asserts that all shape Values are registered initializers and the serialized model passes `onnx.checker.check_model(full_check=True)`.

## Related

Also filed a separate issue/PR in [onnx-ir](https://github.com/onnx/ir-py/pull/449) for `NameFixPass` not registering renamed Values as initializers — that's an independent bug exposed by the same scenario.
