### PR TITLE
Disable Publish Docs workflow on forks

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -19,6 +19,8 @@ concurrency:
 
 jobs:
   deploy:
+    # Skip on forks so the workflow doesn't run on fork sync
+    if: ${{ !github.event.repository.fork }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Guard the deploy job with a condition that skips it when the repository is a fork, so it doesn't trigger on fork sync pushes to main.


Claude-Session: https://claude.ai/code/session_01AnvSvs4hLwKRpCTUQFVUsn