### PR TITLE
Use the query dtype's lowest finite value for the causal attention mask

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/nn.py
+++ b/onnxscript/function_libs/torch_lib/ops/nn.py
@@ -1713,13 +1713,17 @@ def _causal_attention_mask(query: TFloat, key: TFloat) -> TFloat:
     attn_mask = op.Expand(op.Constant(value_float=1.0), size)
     # }
     attn_mask = op.Trilu(attn_mask, upper=0)
-    # The causal mask has 0s in the lower triangle and -inf in the upper triangle.
+    # The causal mask has 0s in the lower triangle and the lowest representable value
+    # of the query dtype in the upper triangle. The lowest finite value is used instead
+    # of -inf to stay consistent with the boolean mask path and to avoid producing NaN
+    # in the subsequent Softmax when a row is fully masked.
+    # The constants are built in the query dtype directly rather than in float32 and
+    # cast down, because casting float32's lowest value to float16 overflows to -inf.
     attn_mask = op.Where(
         op.Equal(attn_mask, op.Constant(value_float=0.0)),
-        op.Constant(value_float=-float("inf")),
-        op.Constant(value_float=0.0),
+        op.Constant(value=ir.tensor(query.dtype.min, dtype=query.dtype)),
+        op.Constant(value=ir.tensor(0.0, dtype=query.dtype)),
     )
-    attn_mask = op.CastLike(attn_mask, query)
     return attn_mask
 
 

--- a/tests/function_libs/torch_lib/e2e_ops_tests.py
+++ b/tests/function_libs/torch_lib/e2e_ops_tests.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import unittest
 
+import numpy as np
 import parameterized
 
 # TODO(pytorch/pytorch#129279): Migrate these tests to the PyTorch repo
@@ -1391,6 +1392,53 @@ class TorchLibe2eTest(unittest.TestCase):
                 expected = model(*inputs)
                 got = onnx_program.call_reference({"x": inputs[0]})
                 torch.testing.assert_close(expected, got[0])
+
+    @parameterized.parameterized.expand(
+        [
+            ("float32", torch.float32),
+            ("float16", torch.float16),
+        ]
+    )
+    def test_scaled_dot_product_attention_causal_mask_uses_dtype_min(
+        self, _: str, dtype: torch.dtype
+    ):
+        # The causal mask must fill masked positions with the lowest finite value of
+        # the query dtype rather than -inf, matching the boolean mask path.
+        # The constant has to be built in the query dtype directly: creating it in
+        # float32 and casting down overflows back to -inf for float16.
+        target_length = source_length = 4
+
+        class Model(torch.nn.Module):
+            def forward(self, query, key, value):
+                return torch.nn.functional.scaled_dot_product_attention(
+                    query, key, value, is_causal=True
+                )
+
+        inputs = tuple(torch.randn(1, 2, target_length, 8, dtype=dtype) for _ in range(3))
+        onnx_program = torch.onnx.export(Model().eval(), inputs, dynamo=True, verbose=False)
+        if dtype is torch.float32:
+            # float16 attention accumulates enough rounding error to exceed the
+            # default tolerances, independently of the mask value asserted below.
+            _testing.assert_onnx_program(onnx_program)
+
+        masks = [
+            initializer.const_value.numpy()
+            for initializer in onnx_program.model.graph.initializers.values()
+            if initializer.const_value.shape == (target_length, source_length)
+        ]
+        self.assertEqual(len(masks), 1)
+        mask = masks[0]
+        self.assertFalse(np.isinf(mask).any())
+
+        expected = (
+            torch.zeros(target_length, source_length, dtype=dtype)
+            .masked_fill(
+                ~torch.ones(target_length, source_length, dtype=torch.bool).tril(),
+                torch.finfo(dtype).min,
+            )
+            .numpy()
+        )
+        np.testing.assert_array_equal(mask, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`_causal_attention_mask` fills masked positions with `-inf`. The boolean mask path was already moved to the dtype's lowest finite value in #2654 (issue #2561), following the ONNX Runtime recommendation, but the causal path — which `is_causal=True` routes through — still emits infinities.

Note that `is_causal=True` produces a **float** mask, so it is dispatched to `_aten_scaled_dot_product_attention_float_mask_onnx`, which has no `IsNaN` guard (unlike the boolean path). That makes the `-inf` here more exposed than in the masked path.

### Change

```python
attn_mask = op.Where(
    op.Equal(attn_mask, op.Constant(value_float=0.0)),
    op.Constant(value=ir.tensor(query.dtype.min, dtype=query.dtype)),
    op.Constant(value=ir.tensor(0.0, dtype=query.dtype)),
)
```

The constants are built in the query dtype directly rather than created in float32 and cast down. This matters: casting float32's lowest value to float16 overflows back to `-inf`, which would defeat the purpose. Building them in the query dtype also makes the trailing `op.CastLike(attn_mask, query)` redundant, so it is removed.

### Before / after

Exported constant for the causal mask, `torch.nn.functional.scaled_dot_product_attention(..., is_causal=True)`:

| dtype | before | after |
| --- | --- | --- |
| float32 | `-inf` | `-3.4028235e+38` |
| float16 | `-inf` | `-65504.0` |

### Testing

Adds a parameterized regression test over float32 and float16 asserting the exported causal mask contains no infinities and equals the expected mask. It fails on `main` and passes with this change.

Numerics are unchanged: the existing `ops_test.py -k scaled_dot_product` suite passes. The float16 case skips `assert_onnx_program` because float16 attention exceeds its default tolerances on `main` too (3/64 elements, identical with and without this change), which is unrelated to the mask value under test.

---

Disclosure: this patch was written with the help of an AI coding assistant. I have reviewed and tested the change myself and will respond to review feedback here directly.
