### PR TITLE
Fix invalid ONNX graph from None start/end in aten_slice_scatter

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -9130,10 +9130,8 @@ def aten_slice_scatter(
 ) -> TTensor:
     """slice_scatter(Tensor self, Tensor src, int dim=0, SymInt? start=None, SymInt? end=None, SymInt step=1) -> Tensor"""
 
-    # Although 'start' and 'end' can be None in signature, but actually 'start' must be specified
-    # Assert(start is not None)
-    # And, 'end' also must be specified, and end-start must be equal to the size of 'src'
-    # Assert(end-start == shape(src) > 0)
+    # 'start' and 'end' are optional (aten schema: SymInt? start=None, SymInt? end=None).
+    # When absent, default start to 0 and end to _INT64_MAX (a full slice), mirroring aten_slice.
     # Try torch sample to get more information:
     # https://pytorch.org/docs/master/generated/torch.slice_scatter.html?highlight=slice_scatter#torch.slice_scatter
     # Take (torch.zeros(8, 8), torch.ones(2, 8), 0, 6, 64, 1) as example:
@@ -9146,10 +9144,14 @@ def aten_slice_scatter(
     self_shape = op.Shape(self)
     dim_shape = op.Gather(self_shape, dim, axis=0)
     index_base = op.Range(0, dim_shape, 1)
+    start_index = zero if start is None else op.Unsqueeze(start, zero)
+    end_index = (
+        op.Constant(value_ints=[_INT64_MAX]) if end is None else op.Unsqueeze(end, zero)
+    )
     index_base = op.Slice(
         index_base,
-        op.Unsqueeze(start, zero),
-        op.Unsqueeze(end, zero),
+        start_index,
+        end_index,
         zero,
         op.Unsqueeze(step, zero),
     )

--- a/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/tests/function_libs/torch_lib/extra_opinfo.py
@@ -1540,6 +1540,12 @@ def sample_inputs_slice_scatter(op_info, device, dtype, requires_grad, **kwargs)
         ((L, L, L), (L, L // 2, L), (1, L // 2, L * 2, 1)),  # end > L
         ((L, L, L), (L, L, L), (-2, 0, L, 1)),  # negative dim
         ((L, L, L), (L, L, L // 4), (-1, L // 2, L * 2, 2)),  # end > L and negative dim
+        # start/end = None (regression for #2372)
+        ((L, L, L), (L, L, L), (0, None, None, 1)),  # full replace, dim 0
+        ((L, L, L), (L // 2, L, L), (0, None, L // 2, 1)),  # None start
+        ((L, L, L), (L // 2, L, L), (0, L // 2, None, 1)),  # None end
+        ((L, L, L), (L, L, L), (1, None, None, 1)),  # None start & end, dim 1
+        ((L, L, L), (L // 2, L, L), (0, None, None, 2)),  # None start & end, step 2
     )
 
     for input_shape, src_shape, args in cases:

--- a/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/tests/function_libs/torch_lib/extra_opinfo.py
@@ -1546,6 +1546,7 @@ def sample_inputs_slice_scatter(op_info, device, dtype, requires_grad, **kwargs)
         ((L, L, L), (L // 2, L, L), (0, L // 2, None, 1)),  # None end
         ((L, L, L), (L, L, L), (1, None, None, 1)),  # None start & end, dim 1
         ((L, L, L), (L // 2, L, L), (0, None, None, 2)),  # None start & end, step 2
+        ((L, L, L), (L, L, L // 2), (-1, None, L // 2, 1)),  # None start, negative dim
     )
 
     for input_shape, src_shape, args in cases:


### PR DESCRIPTION
`aten::slice_scatter` produced an invalid ONNX graph whenever `start` or `end` came in as `None`. The lowering unsqueezed both bounds unconditionally, so a `None` turned into an empty-string input to `Unsqueeze`. A missing `start` now defaults to 0 and a missing `end` to `INT64_MAX`, a full slice, matching what `aten_slice` already does.

Changes:
- `torch_lib/ops/core.py`: build the `Slice` bounds conditionally, unsqueezing `start` or `end` only when they are provided.
- `tests/function_libs/torch_lib/extra_opinfo.py`: regression sample-input cases for `None` start, `None` end, both, and a step-2 variant.

Testing: the existing slice_scatter OpInfo suite now exercises the `None` bounds.

Fixes #2372
