### PR TITLE
Honor the dtype argument of aten::mean when exporting without dim

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6350,21 +6350,33 @@ def aten_maximum(self: TTensor, other: TTensor) -> TTensor:
     return op.Max(self, other)
 
 
-@torch_op("aten::mean")
-def aten_mean(self: TReal) -> TReal:
+@torch_op("aten::mean", trace_only=True)
+def aten_mean(self: TReal, dtype: int = -1) -> TReal:
     """mean(Tensor self, *, ScalarType? dtype=None) -> Tensor"""
+
+    if dtype != -1 and dtype is not None:
+        # Cast before reducing so that the accumulation happens in the requested
+        # dtype, matching PyTorch. Casting the result afterwards would keep the
+        # precision loss of the input dtype.
+        self = op.Cast(self, to=dtype)
 
     result = op.ReduceMean(self)
     return op.Squeeze(result)
 
 
 @torch_op("aten::mean", complex=True, trace_only=True)
-def aten_mean_complex(self: TReal) -> TReal:
+def aten_mean_complex(self: TReal, dtype: int = -1) -> TReal:
     """mean(Tensor self, *, ScalarType? dtype=None) -> Tensor"""
 
     rank = len(self.shape) - 1
     dim = op.Constant(value_ints=list(range(rank)))
     result = op.ReduceMean(self, dim, keepdims=False)
+
+    if dtype != -1 and dtype is not None:
+        raise NotImplementedError(
+            "support for the dtype argument is not implemented for complex tensors"
+        )
+
     return result
 
 

--- a/tests/function_libs/torch_lib/extra_opinfo.py
+++ b/tests/function_libs/torch_lib/extra_opinfo.py
@@ -1206,6 +1206,27 @@ def sample_inputs_max_pool3d_with_indices(op_info, device, dtype, requires_grad,
         yield opinfo_core.SampleInput(arg, kwargs=kwargs)
 
 
+def sample_inputs_mean_dtype(op_info, device, dtype, requires_grad, **kwargs):
+    del op_info  # Unused
+    del kwargs  # Unused
+
+    make_arg = functools.partial(
+        torch_testing.make_tensor, device=device, dtype=dtype, requires_grad=requires_grad
+    )
+    for shape in ((S, S), (S,), ()):
+        yield opinfo_core.SampleInput(make_arg(shape), kwargs={"dtype": torch.float64})
+
+    # Precision sensitive values: accumulating in float32 gives 0.0 while accumulating
+    # in float64 gives 1/3, so an implementation that casts only the reduced result
+    # cannot pass this sample.
+    yield opinfo_core.SampleInput(
+        torch.tensor(
+            [[1e8, 1.0, -1e8]], dtype=dtype, device=device, requires_grad=requires_grad
+        ),
+        kwargs={"dtype": torch.float64},
+    )
+
+
 def sample_inputs_native_group_norm(op_info, device, dtype, requires_grad, **kwargs):
     del op_info
     make_arg = functools.partial(
@@ -2744,6 +2765,14 @@ OP_DB: List[opinfo_core.OpInfo] = [
         aten_name="max_pool3d",
         dtypes=common_dtype.floating_types_and(torch.bfloat16),
         sample_inputs_func=sample_inputs_max_pool_empty_strides,
+        supports_out=False,
+    ),
+    opinfo_core.OpInfo(
+        "ops.aten.mean.dtype",
+        op=torch.ops.aten.mean,
+        aten_name="mean",
+        dtypes=common_dtype.floating_types(),
+        sample_inputs_func=sample_inputs_mean_dtype,
         supports_out=False,
     ),
     opinfo_core.OpInfo(

--- a/tests/function_libs/torch_lib/ops_test_data.py
+++ b/tests/function_libs/torch_lib/ops_test_data.py
@@ -872,6 +872,7 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
         matcher=lambda sample: sample.kwargs.get("dim") is not None,
         reason="this Aten overload only accept 1 inputs: self",
     ),
+    TorchLibOpInfo("ops.aten.mean.dtype", core_ops.aten_mean),
     TorchLibOpInfo(
         "mean_dim", core_ops.aten_mean_dim, input_wrangler=_mean_input_wrangler
     ).skip(


### PR DESCRIPTION
# Honor the dtype argument of aten::mean when exporting without dim

Fixes #3008

## Summary

The no dim overload of `aten::mean` declares `dtype` in its schema (`mean(Tensor self, *, ScalarType? dtype=None)`), but `aten_mean` in `onnxscript/function_libs/torch_lib/ops/core.py` did not accept the argument. Exporting `torch.mean(x, dtype=torch.float64)` for a float32 input succeeded silently, emitted only `ReduceMean -> Squeeze`, declared a FLOAT output, and accumulated in float32. For the input `[[1e8, 1.0, -1e8]]` PyTorch returns `0.3333333333333333` as float64 while the exported model returned `0.0` as float32.

## Changes

- `aten_mean` is now `trace_only=True`, takes `dtype: int = -1`, and when a dtype is given casts `self` before `ReduceMean`. The no dtype path is unchanged (`ReduceMean -> Squeeze`).
- `aten_mean_complex` takes the same argument and raises `NotImplementedError` when it is supplied, matching `aten_mean_dim_complex` and `aten_sum_complex`.
- New `ops.aten.mean.dtype` OpInfo in `tests/function_libs/torch_lib/extra_opinfo.py` (`sample_inputs_mean_dtype`) registered against `core_ops.aten_mean` in `ops_test_data.py`. It yields `make_tensor` samples of shapes `(5, 5)`, `(5,)` and `()` plus the precision sensitive tensor `[[1e8, 1.0, -1e8]]`, all with `dtype=torch.float64`.

## Why the cast happens before the reduction

`aten_mean_dim` (#2885) and `aten_sum` cast the reduced result after the reduction. That is not sufficient here: PyTorch accumulates in the requested dtype, so for `[1e8, 1.0, -1e8]` the float32 mean is `0.0` (the `1.0` is lost when added to `1e8`) while the float64 mean is `1/3`. Casting after `ReduceMean` would produce a DOUBLE tensor holding `0.0`, which still mismatches PyTorch. Casting the input first reproduces PyTorch semantics. The new test includes this sample specifically so that a cast after reduction implementation cannot pass by accident.

## Verification

Reporter's script (`torch.onnx.export(..., dynamo=True)` of `torch.mean(x, dtype=torch.float64)` with float32 input) on pristine main at a39c0a5:

```
torch eager result: 0.3333333333333333 dtype: torch.float64
ONNX output elem_type: 1 (FLOAT), expected 11 (DOUBLE)
ORT result: 0.0 dtype: float32
```

With this change:

```
torch eager result: 0.3333333333333333 dtype: torch.float64
ONNX output elem_type: 11 (DOUBLE)
ORT result: 0.3333333333333333 dtype: float64
```

`pytest tests/function_libs/torch_lib/ops_test.py -k mean`:

| State | Result |
| --- | --- |
| Pristine main, without the new test | 8 passed, 48 skipped, 8 xfailed, 60 subtests passed |
| New test with the source change stashed | 4 failed, 10 passed, 48 skipped, 8 xfailed, 60 subtests passed. All four `ops_aten_mean_dtype` samples fail with `TypeInferenceError: Inferred elem type differs from existing elem type: (1) vs (11)` |
| New test with a cast placed after the reduction | 1 failed, 8 passed, 50 skipped, 8 xfailed, 63 subtests passed. Only the `[[1e8, 1.0, -1e8]]` sample fails: `Expected 0.3333333333333333 but got 0.0` |
| New test with this change | 8 passed, 50 skipped, 8 xfailed, 64 subtests passed |

The two additional skips in the fixed state are the function proto validity checks, which skip for traced functions.

`ruff check` and `ruff format --check` (ruff 0.15.1, the lintrunner pinned version) pass on the three changed files.

Environment: Python 3.10, torch 2.13.0 (CPU), onnx 1.22.0, onnxruntime 1.23.2, macOS arm64.
