### PR TITLE
Fix aten::mean dtype handling

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -6350,9 +6350,12 @@ def aten_maximum(self: TTensor, other: TTensor) -> TTensor:
     return op.Max(self, other)
 
 
-@torch_op("aten::mean")
-def aten_mean(self: TReal) -> TReal:
+@torch_op("aten::mean", trace_only=True)
+def aten_mean(self: TReal, dtype: int = -1) -> TReal:
     """mean(Tensor self, *, ScalarType? dtype=None) -> Tensor"""
+
+    if dtype != -1:
+        self = op.Cast(self, to=dtype)
 
     result = op.ReduceMean(self)
     return op.Squeeze(result)

--- a/tests/function_libs/torch_lib/e2e_ops_tests.py
+++ b/tests/function_libs/torch_lib/e2e_ops_tests.py
@@ -1281,6 +1281,19 @@ class TorchLibe2eTest(unittest.TestCase):
         )
         _testing.assert_onnx_program(onnx_program)
 
+    def test_mean_dtype_casts_before_reduction(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return torch.mean(x, dtype=torch.float64)
+
+        model = Model()
+        x = torch.tensor([1e8, 1.0, -1e8], dtype=torch.float32)
+        onnx_program = torch.onnx.export(model, (x,), dynamo=True, optimize=False)
+
+        _testing.assert_onnx_program(onnx_program)
+        actual = onnx_program.call_reference({onnx_program.model.graph.inputs[0].name: x})[0]
+        torch.testing.assert_close(actual, model(x))
+
     def test_aten_histc_float(self):
         class Model(torch.nn.Module):
             def forward(self, x):


### PR DESCRIPTION
## Summary

While testing ONNXScript's TorchLib lowering for `torch.mean(..., dtype=...)`, I found that the `aten::mean` overload ignored its schema's `dtype` argument and silently exported the wrong output type.

This change:
- accepts the optional `dtype` argument
- casts the input before `ReduceMean`, preserving the requested accumulation precision
- adds a precision-sensitive end-to-end regression

Fixes #3008.

## Validation

- Exported `torch.mean([1e8, 1, -1e8], dtype=torch.float64)`
- Verified graph order: `Cast -> ReduceMean -> Squeeze`
- Verified ONNX reference output matches PyTorch in value and float64 dtype
- `ruff check` passed
- `ruff format --check` passed

The focused e2e test file cannot collect on this local Python 3.14 build because `torchvision` imports the unavailable stdlib `_lzma` extension; the same test logic was executed directly and passed.