### PR TITLE
Accept memory_format kwarg on rand/randn/randint _like ops

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -8164,7 +8164,12 @@ def aten_rand(
 
 @torch_op("aten::rand_like", trace_only=True)
 def aten_rand_like(
-    self: TFloat, dtype: int = -1, layout: str = "", device: str = "", pin_memory: bool = False
+    self: TFloat,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+    memory_format: str = "",
 ) -> TFloat:
     """rand_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor"""
 
@@ -8224,6 +8229,7 @@ def aten_randint_like(
     layout: str = "",
     device: str = "",
     pin_memory: bool = False,
+    memory_format: str = "",
 ) -> IntType:
     """randint_like(Tensor self, SymInt high, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor"""
 
@@ -8247,6 +8253,7 @@ def aten_randint_like_low_dtype(
     layout: str = "",
     device: str = "",
     pin_memory: bool = False,
+    memory_format: str = "",
 ) -> IntType:
     """randint_like.low_dtype(Tensor self, SymInt low, SymInt high, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
@@ -8282,7 +8289,12 @@ def aten_randn(
 
 @torch_op("aten::randn_like", trace_only=True)
 def aten_randn_like(
-    self: TFloat, dtype: int = -1, layout: str = "", device: str = "", pin_memory: bool = False
+    self: TFloat,
+    dtype: int = -1,
+    layout: str = "",
+    device: str = "",
+    pin_memory: bool = False,
+    memory_format: str = "",
 ) -> TFloat:
     """randn_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor"""
 

--- a/tests/function_libs/torch_lib/e2e_ops_tests.py
+++ b/tests/function_libs/torch_lib/e2e_ops_tests.py
@@ -97,6 +97,50 @@ class TorchLibe2eTest(unittest.TestCase):
         )
         _testing.assert_onnx_program(onnx_program)
 
+    def test_rand_like_memory_format(self):
+        # These random *_like ops are non-deterministic, so assert the export
+        # succeeds rather than comparing values (see issue #3002).
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.rand_like(x, memory_format=torch.preserve_format)
+
+        onnx_program = torch.onnx.export(
+            Model(), (torch.randn(10, 10),), dynamo=True, optimize=False
+        )
+        self.assertIsNotNone(onnx_program)
+
+    def test_randn_like_memory_format(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.randn_like(x, memory_format=torch.preserve_format)
+
+        onnx_program = torch.onnx.export(
+            Model(), (torch.randn(10, 10),), dynamo=True, optimize=False
+        )
+        self.assertIsNotNone(onnx_program)
+
+    def test_randint_like_memory_format(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.randint_like(x, 10, memory_format=torch.preserve_format)
+
+        onnx_program = torch.onnx.export(
+            Model(), (torch.randn(10, 10),), dynamo=True, optimize=False
+        )
+        self.assertIsNotNone(onnx_program)
+
+    def test_randint_like_low_dtype_memory_format(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.randint_like(
+                    x, 0, 10, memory_format=torch.preserve_format
+                )
+
+        onnx_program = torch.onnx.export(
+            Model(), (torch.randn(10, 10),), dynamo=True, optimize=False
+        )
+        self.assertIsNotNone(onnx_program)
+
     def test_bincount(self):
         class Model(torch.nn.Module):
             def forward(self, x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Exporting `rand_like`, `randn_like`, or `randint_like` with `memory_format=torch.preserve_format` raised a ConversionError: the torchlib signatures dropped the `memory_format` kwarg the aten schema declares. Adds it as a no-op trailing kwarg on the four `*_like` random ops, matching what #2994 did for `full_like`.

Fixes #3002.

Changes:
- `ops/core.py`: add `memory_format` to `aten_rand_like`, `aten_randn_like`, `aten_randint_like`, `aten_randint_like_low_dtype`
- e2e tests: export each op with `memory_format=torch.preserve_format`

Testing: the new tests assert export succeeds rather than value equality, since these ops are non-deterministic.
