### PR TITLE
docs(_framework_apis): say check_model is a deliberate no-op

### DIFF
--- a/onnxscript/_framework_apis/torch_2_5.py
+++ b/onnxscript/_framework_apis/torch_2_5.py
@@ -121,7 +121,6 @@ def get_torchlib_ops() -> list[_OnnxFunctionMeta]:
     del ops  # Unused
 
     torchlib_registry = registration.default_registry
-
     function_metas = []
 
     for qualified_name, aten_overloads_func in torchlib_registry.items():

--- a/onnxscript/_framework_apis/torch_2_5.py
+++ b/onnxscript/_framework_apis/torch_2_5.py
@@ -59,9 +59,13 @@ def convert_version(model: ir.Model, target_version: int) -> ir.Model:
 
 
 def check_model(model: ir.Model) -> None:
-    """Check the model."""
+    """No-op retained for API compatibility.
 
-    del model  # Unused yet
+    This intentionally performs no validation. Running the ONNX checker here was
+    dropped because it can report false positives and adds overhead to export.
+    """
+
+    del model  # Intentionally unused: this function performs no validation.
 
 
 def save_model_with_external_data(
@@ -117,6 +121,7 @@ def get_torchlib_ops() -> list[_OnnxFunctionMeta]:
     del ops  # Unused
 
     torchlib_registry = registration.default_registry
+
     function_metas = []
 
     for qualified_name, aten_overloads_func in torchlib_registry.items():


### PR DESCRIPTION
`check_model` reads `"""Check the model."""` with a body of `del model  # Unused yet`. Together those say validation is pending implementation. Per #2981 it is not: the checker was removed deliberately because it can report false positives and adds overhead to export, and the function is kept for API compatibility.

This records that where someone reading the function will see it. No behaviour change; the body is still a no-op.

Wording is taken from @justinchuby's explanation in #2981 rather than invented:

> Initially it was intended that we ensure the model to be a "valid" model before returning. Later we realized (1) the checker may produce false positives and (2) it adds overhead for the export logic. So we decided to remove this step. But the api is maintained for compatibility.

Refs #2981.

## Checks

`ruff format --check` reports the file already formatted. `ruff check` under the repo's `pyproject.toml` reports the same single pre-existing finding before and after this change (`TID251` on `import pathlib`, line 18, untouched here), so it introduces nothing new. I diffed the two rule-code sets rather than eyeballing the counts.

I did not run the pytest suite: it needs a torch install this machine does not have. CI is the authority on that, and this change is a docstring and a comment.

Drafted with AI assistance. I read the function and its re-exports in `torch_2_6.py` through `torch_2_11.py` myself and confirmed `torch_2_5.py` holds the only definition, so this is the only site that needed changing.