### PR TITLE
Emit scalar Range bounds in aten_unfold

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -10104,7 +10104,12 @@ def aten_unfold(self: TTensor, dimension: int, size: int, step: int) -> TTensor:
             dimension = dimension + self_rank
 
         input_shape = op.Shape(self)
-        dim_size = op.Gather(input_shape, op.Constant(value_ints=[dimension]))
+        # Range requires rank 0 (scalar) inputs, so squeeze the [1] shaped
+        # Gather result down to a scalar.
+        dim_size = op.Squeeze(
+            op.Gather(input_shape, op.Constant(value_ints=[dimension])),
+            op.Constant(value_ints=[0]),
+        )
 
         # Create indices for each window
         window_starts = op.Range(0, op.Sub(dim_size, size - 1), step)

--- a/tests/function_libs/torch_lib/e2e_ops_tests.py
+++ b/tests/function_libs/torch_lib/e2e_ops_tests.py
@@ -858,6 +858,16 @@ class TorchLibe2eTest(unittest.TestCase):
         )
         _testing.assert_onnx_program(onnx_program)
 
+    def test_unfold_emits_scalar_range_bounds(self):
+        class UnfoldModel(torch.nn.Module):
+            def forward(self, x):
+                return x.unfold(1, 2, 1)
+
+        onnx_program = torch.onnx.export(
+            UnfoldModel(), (torch.randn(3, 4),), dynamo=True, optimize=False
+        )
+        _testing.assert_onnx_program(onnx_program)
+
     def test_quantize_per_channel_int8(self):
         class Model(torch.nn.Module):
             def forward(self, x):


### PR DESCRIPTION

`aten_unfold` reads the size of the unfolded dimension like this:

```python
dim_size = op.Gather(input_shape, op.Constant(value_ints=[dimension]))
window_starts = op.Range(0, op.Sub(dim_size, size - 1), step)
```

A rank 1 index makes `Gather` return `int64[1]`, not a scalar. `Sub` preserves that rank, so a rank 1 value reaches the `limit` input of `Range`. The ONNX spec requires all three `Range` inputs to be rank 0, and onnxruntime rejects the model at session creation:

```
Node (node_Range_6) Op (Range) [ShapeInferenceError] Input to 'Range' op should be scalars (Tensor with only one element and shape empty)
```

### Scope

This is narrower than it first looks. With `x.unfold(1, 2, 1)` on a `(3, 4)` input:

| export | ops in graph | onnxruntime |
| --- | --- | --- |
| static dim, `optimize=True` (default) | `['Gather']` | runs, correct |
| static dim, `optimize=False` | full chain, `Range` survives | rejected at session creation |
| dynamic unfold dim | full chain, `Range` survives | runs |

On the default path the constant folder collapses `Shape`/`Gather`/`Sub`/`Range` into a single index constant, so no `Range` node survives and those exports are fine and numerically correct. The bad node is reachable with `optimize=False`, and on a dynamic unfold dimension `Range` survives with a rank 1 `limit` but onnxruntime cannot fold its inputs, so the scalar check never runs and the spec violation is silently tolerated.

So: a spec compliance fix on an unoptimized path, not a broken operator.

### The fix

```python
# Range requires rank 0 (scalar) inputs, so squeeze the [1] shaped
# Gather result down to a scalar.
dim_size = op.Squeeze(
    op.Gather(input_shape, op.Constant(value_ints=[dimension])),
    op.Constant(value_ints=[0]),
)
```

### Why not just `value_int=dimension`

That one token change also gives `Range` a scalar and it does fix onnxruntime, but it quietly defeats the `Shape`/`Gather` constant folding. The rule in `onnxscript/optimizer/_constant_folding.py` bails out on any index whose `ndim` is not 1:

```python
if indices_numpy_value.ndim != 1:
    return None
```

Measured on a dynamic batch dimension with a static unfold dimension, default `optimize=True`:

```
main                    ops: ['Gather']
value_int variant       ops: ['Shape', 'Gather', 'Sub', 'Range', 'Unsqueeze', 'Add', 'Gather']
Squeeze variant         ops: ['Gather']
```

`Squeeze` is registered as a shape value propagator in that same file, so the symbolic shape value survives the squeeze and the folded path keeps working. The seven node chain would otherwise be left in the graph at runtime.

### Testing

Added `test_unfold_emits_scalar_range_bounds` to `tests/function_libs/torch_lib/e2e_ops_tests.py`, following the `optimize=False` pattern already used by the tests around it.

With only the `core.py` change reverted, the new test fails with the error quoted above. With the fix it passes. Rest of `e2e_ops_tests.py` and the `unfold` cases in `ops_test.py` are unchanged.

Same class of fix as #2943 (rank 1 where a scalar was required, same file) and #3006 (invalid ONNX graph out of a torchlib lowering).
