### PR TITLE
Emit empty-input placeholders for skipped interior optional inputs

### DIFF
--- a/onnxscript/_internal/converter.py
+++ b/onnxscript/_internal/converter.py
@@ -619,10 +619,14 @@ class Converter:
         result = self._generate_unique_name(target)
         return self._emit1([result], callee, args, attrs)
 
-    def _translate_opt_expr(self, node: ast.expr) -> ir.Value | None:
+    def _translate_opt_expr(self, node: ast.expr | None) -> ir.Value | None:
         """Translation of an expression where "None" is permitted (eg., for an optional argument).
         None is represented as a Constant in Python 3.9+.
         """
+        # A bare None marks a skipped optional input injected by
+        # separate_input_attributes_from_arguments; keep it as an empty input.
+        if node is None:
+            return None
         if isinstance(node, ast.Constant) and (node.value is None):
             return None
         return self._translate_expr(node)

--- a/onnxscript/_internal/converter_test.py
+++ b/onnxscript/_internal/converter_test.py
@@ -586,6 +586,28 @@ class TestConverter(testutils.TestBase):
         node = none_as_input.to_function_proto().node[0]
         self.assertEqual(node.input[1], "")
 
+    def test_skipped_optional_input_becomes_empty_placeholder(self):
+        """Interior optional inputs skipped via keyword become "" placeholders (issue #2007)."""
+        from onnxscript import opset19
+
+        @script()
+        def resize_sizes(X):
+            return opset19.Resize(X, sizes=[512, 512])
+
+        node = next(n for n in resize_sizes.to_function_proto().node if n.op_type == "Resize")
+        # roi and scales are skipped; sizes must stay in the 4th slot.
+        self.assertEqual(len(node.input), 4)
+        self.assertEqual(node.input[1], "")  # roi
+        self.assertEqual(node.input[2], "")  # scales
+
+        @script()
+        def clip_max(X):
+            return opset19.Clip(X, max=1.0)
+
+        node = next(n for n in clip_max.to_function_proto().node if n.op_type == "Clip")
+        # min stays empty so the max value keeps its own slot.
+        self.assertEqual(node.input[1], "")
+
     def test_unique_names_in_subscript_expr(self):
         @script()
         def nested_index_expr(X):

--- a/onnxscript/_internal/param_manipulation.py
+++ b/onnxscript/_internal/param_manipulation.py
@@ -80,12 +80,24 @@ def separate_input_attributes_from_arguments(
                 onnx_attributes[param.name] = param.default.value
         elif param.required:
             raise TypeError(f"Required input '{param}' was not provided")
+        elif is_input:
+            # A skipped optional input still occupies a positional slot. Emit a
+            # None placeholder so any later provided input keeps its position;
+            # serialization renders None as the "" empty-input marker.
+            onnx_inputs.append(None)
 
     if not allow_extra_args and not has_variadic and len(args) > len(op_signature.params):
         raise TypeError(
             f"Too many positional arguments: expected {len(op_signature.params)}, "
             f"got {len(args)}"
         )
+
+    # Interior skipped optional inputs must stay as None (-> "") to hold their
+    # positional slot. Trailing optional inputs may be omitted per ONNX, so drop
+    # trailing Nones. This also drops an explicit trailing None (e.g.
+    # Foo(x, y, None)), which is ONNX-equivalent to omitting it.
+    while onnx_inputs and onnx_inputs[-1] is None:
+        onnx_inputs.pop()
 
     return onnx_inputs, onnx_attributes
 

--- a/onnxscript/_internal/param_manipulation_test.py
+++ b/onnxscript/_internal/param_manipulation_test.py
@@ -265,6 +265,52 @@ class TestSeparateInputAttributesFromArguments(unittest.TestCase):
                 allow_extra_kwargs=allow_extra_kwargs,
             )
 
+    def test_it_emits_placeholder_for_skipped_optional_input(self):
+        # Signature with one required input followed by two optional inputs.
+        type_constraint = ir.schemas.TypeConstraintParam.any_tensor("T")
+        op_signature = ir.schemas.OpSignature(
+            domain="",
+            name="TestOp",
+            overload="",
+            params=[
+                ir.schemas.Parameter(
+                    name="a", type_constraint=type_constraint, required=True, variadic=False
+                ),
+                ir.schemas.Parameter(
+                    name="b", type_constraint=type_constraint, required=False, variadic=False
+                ),
+                ir.schemas.Parameter(
+                    name="c", type_constraint=type_constraint, required=False, variadic=False
+                ),
+            ],
+            outputs=[],
+        )
+
+        # Interior optional input skipped via keyword -> None placeholder holds the slot.
+        inputs, attributes = param_manipulation.separate_input_attributes_from_arguments(
+            op_signature, ("A",), {"c": "C"}
+        )
+        self.assertEqual(inputs, ["A", None, "C"])
+        self.assertEqual(attributes, collections.OrderedDict())
+
+        # Trailing optional inputs are omitted, not materialized as placeholders.
+        inputs, _ = param_manipulation.separate_input_attributes_from_arguments(
+            op_signature, ("A",), {}
+        )
+        self.assertEqual(inputs, ["A"])
+
+        # b provided positionally, c trailing -> trimmed.
+        inputs, _ = param_manipulation.separate_input_attributes_from_arguments(
+            op_signature, ("A", "B"), {}
+        )
+        self.assertEqual(inputs, ["A", "B"])
+
+        # An interior explicit None is preserved (guards the is-None trailing trim).
+        inputs, _ = param_manipulation.separate_input_attributes_from_arguments(
+            op_signature, ("A", None, "C"), {}
+        )
+        self.assertEqual(inputs, ["A", None, "C"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
An ONNX op called with a keyword that skips an interior optional input — `op.Resize(X, sizes=[512, 512])` skips `roi` and `scales` — dropped those inputs entirely, so `sizes` slid into `roi`'s slot and the graph failed ONNX Runtime validation. `op.Clip(x, max=1.0)` was quieter but just as wrong: `max` bound to `min`'s slot.

`separate_input_attributes_from_arguments` now emits a `None` placeholder for each skipped optional input (serialized as the `""` empty-input marker) and trims only trailing ones, which ONNX permits to be omitted. `_translate_opt_expr` accepts those injected `None`s.

New tests in `param_manipulation_test.py` and `converter_test.py` cover interior skips, trailing trims, and an explicit interior `None`.

Fixes #2007.
