### PR TITLE
Preserve output names for returned input aliases

### DIFF
--- a/onnxscript/_internal/converter.py
+++ b/onnxscript/_internal/converter.py
@@ -1108,7 +1108,12 @@ class Converter:
                 if val.value.is_graph_input():
                     # In ONNX, a graph-input cannot be an output of the graph.
                     # We need to insert a copy.
-                    return_var = self._emit_copy(return_var, preferred_name)
+                    copy_name = (
+                        exp.id
+                        if isinstance(exp, ast.Name) and exp.id != return_var.name
+                        else preferred_name
+                    )
+                    return_var = self._emit_copy(return_var, copy_name)
             for prev_output in self._current_fn.outputs:
                 if prev_output.name == return_var.name:
                     # ONNX does not allow duplicate output names.

--- a/onnxscript/_internal/converter.py
+++ b/onnxscript/_internal/converter.py
@@ -1103,17 +1103,14 @@ class Converter:
         def ret(exp, i, suffix):
             preferred_name = f"return_val{suffix}"
             return_var = self._translate_expr(exp, preferred_name)
-            val = self._lookup(return_var.name, self._source_of(exp), raise_exception=False)
-            if isinstance(val, values.SymbolValue) and isinstance(val.value, ir.Value):
-                if val.value.is_graph_input():
-                    # In ONNX, a graph-input cannot be an output of the graph.
-                    # We need to insert a copy.
-                    copy_name = (
-                        exp.id
-                        if isinstance(exp, ast.Name) and exp.id != return_var.name
-                        else preferred_name
-                    )
-                    return_var = self._emit_copy(return_var, copy_name)
+            if return_var.is_graph_input():
+                # Use the resolved ONNX value: the Python input name may have been rebound.
+                copy_name = (
+                    exp.id
+                    if isinstance(exp, ast.Name) and exp.id != return_var.name
+                    else preferred_name
+                )
+                return_var = self._emit_copy(return_var, copy_name)
             for prev_output in self._current_fn.outputs:
                 if prev_output.name == return_var.name:
                     # ONNX does not allow duplicate output names.

--- a/onnxscript/_internal/converter_test.py
+++ b/onnxscript/_internal/converter_test.py
@@ -607,6 +607,23 @@ class TestConverter(testutils.TestBase):
         outputs = duplicate_output.to_function_proto().output
         self.assertNotEqual(outputs[0], outputs[1])
 
+    def test_returned_input_alias_preserves_name(self):
+        @script(default_opset=op)
+        def returned_alias(X):
+            Y = X
+            return Y
+
+        function_proto = returned_alias.to_function_proto()
+        self.assertEqual(function_proto.output[0], "Y")
+        self.assertEqual(function_proto.node[-1].op_type, "Identity")
+        self.assertEqual(function_proto.node[-1].output[0], "Y")
+
+        @script(default_opset=op)
+        def returned_input(X):
+            return X
+
+        self.assertEqual(returned_input.to_function_proto().output[0], "return_val")
+
     def test_bool_attr_promotion(self):
         @script()
         def if_then_else(flag: bool, Y, Z):

--- a/onnxscript/_internal/converter_test.py
+++ b/onnxscript/_internal/converter_test.py
@@ -624,6 +624,41 @@ class TestConverter(testutils.TestBase):
 
         self.assertEqual(returned_input.to_function_proto().output[0], "return_val")
 
+    def test_returned_input_alias_after_rebinding_input(self):
+        @script(default_opset=op)
+        def returned_alias(X: FLOAT[2]) -> FLOAT[2]:
+            Y = X
+            X = op.Neg(X)
+            return Y
+
+        model = returned_alias.to_model_proto()
+        onnx.checker.check_model(model, full_check=True)
+        self.assertEqual(model.graph.output[0].name, "Y")
+        self.assertEqual(model.graph.node[-1].op_type, "Identity")
+        self.assertEqual(list(model.graph.node[-1].input), ["X"])
+        x = np.array([1.0, -2.0], dtype=np.float32)
+        actual = create_cpu_inference_session(model.SerializeToString()).run(None, {"X": x})
+        np.testing.assert_array_equal(actual[0], x)
+
+    def test_returned_input_alias_name_collision(self):
+        @script(default_opset=op)
+        def returned_alias(X: FLOAT[2], Y: FLOAT[2]) -> (FLOAT[2], FLOAT[2]):
+            Y = X
+            return Y, Y
+
+        model = returned_alias.to_model_proto()
+        onnx.checker.check_model(model, full_check=True)
+        outputs = [value.name for value in model.graph.output]
+        self.assertEqual(len(set(outputs)), 2)
+        self.assertTrue(all(name.startswith("Y_") for name in outputs))
+        self.assertTrue(set(outputs).isdisjoint({"X", "Y"}))
+        x = np.array([1.0, -2.0], dtype=np.float32)
+        actual = create_cpu_inference_session(model.SerializeToString()).run(
+            None, {"X": x, "Y": -x}
+        )
+        for output in actual:
+            np.testing.assert_array_equal(output, x)
+
     def test_bool_attr_promotion(self):
         @script()
         def if_then_else(flag: bool, Y, Z):


### PR DESCRIPTION
Fixes #2714.

When a graph input is returned through a local alias, use the alias name for the inserted `Identity` output instead of the generic `return_val` name. Directly returning an unchanged graph input keeps the existing naming behavior. Generated names still go through the existing uniqueness allocator.

The method audit found a missed case: `Y = X; X = op.Neg(X); return Y` returned the original input under the name `X`, not `Y`. Looking up the resolved ONNX name in the mutable Python symbol table incorrectly classified the value after `X` was rebound. The converter now checks the resolved IR value directly.

Regression coverage includes input-name rebinding, collisions with an existing input name, duplicate alias returns, ONNX checker validation, and runtime output parity. The rebinding regression fails before the follow-up fix (`'X' != 'Y'`) and passes afterward.

Tests (2026-09-07):
- `python -m pytest onnxscript/_internal/converter_test.py -q`: **56 passed, 1 skipped, 1 xfailed, 3 xpassed; 160 subtests passed**, both with ONNX 1.22.0 / ONNX Runtime 1.29.0 and with ONNX 1.18.0 / ONNX Runtime 1.23.0 / ONNX IR 0.1.16.
- `lintrunner -a`: no lint issues.
- `git diff --check`: clean.

Revalidation on 2026-09-08 at unchanged head `cbcda16aa93281d0c5e5dcb50baa96951e3a2f08`: both converter-suite results above were reproduced.

AI assistance was used for the source audit, patch preparation, and validation. The existing expected-failure / unexpected-pass results are reported above, not counted as ordinary passes.
