### PR TITLE
Materialize the DFT axis default when converting opset 19 to 20

### DIFF
--- a/onnxscript/version_converter/_version_converter.py
+++ b/onnxscript/version_converter/_version_converter.py
@@ -160,11 +160,14 @@ def dft_19_20(node: ir.Node, op):
     dft_length = node.inputs[1] if len(node.inputs) > 1 else None
     inverse = _get_int_attribute(node, "inverse", 0)
     onesided = _get_int_attribute(node, "onesided", 0)
-    axis = _get_int_attribute(node, "axis", None)
-    if axis is not None:
-        axis_value = op.Constant(value_int=axis)
-        return op.DFT(input, dft_length, axis_value, inverse=inverse, onesided=onesided)
-    return None
+    # In opset 19 `axis` is an attribute defaulting to 1; in opset 20 it became an
+    # input defaulting to -2. An omitted attribute must therefore be materialized
+    # explicitly, or the converted node silently transforms a different axis.
+    axis = _get_int_attribute(node, "axis", 1)
+    if axis is None:
+        return None
+    axis_value = op.Constant(value_int=axis)
+    return op.DFT(input, dft_length, axis_value, inverse=inverse, onesided=onesided)
 
 
 @register("GridSample", node_version=19, up_conversion=True)

--- a/onnxscript/version_converter/_version_converter_test.py
+++ b/onnxscript/version_converter/_version_converter_test.py
@@ -146,6 +146,29 @@ class VersionConverter19to20Test(unittest.TestCase):
         self.assertEqual(model.graph.node(3).version, 20)
         self.assertEqual(len(model.graph.node(3).inputs), 3)
 
+    def test_version_convert_dft_without_axis_attribute(self):
+        # Opset 19 defines DFT axis as an attribute defaulting to 1. Opset 20 moved
+        # it to an input defaulting to -2, so an omitted attribute has to be
+        # materialized or the converted node transforms a different axis.
+        model = ir.from_onnx_text(
+            """
+            <ir_version: 7, opset_import: [ "" : 19]>
+            agraph (float[2, 3, 4, 2] input_x) => (float[2, 3, 4, 2] output)
+            {
+                output = DFT (input_x)
+            }
+        """
+        )
+        version_converter.convert_version(model, target_version=20)
+        self.assertEqual(model.opset_imports[""], 20)
+
+        dft_node = next(node for node in model.graph if node.op_type == "DFT")
+        self.assertEqual(len(dft_node.inputs), 3)
+        axis_input = dft_node.inputs[2]
+        self.assertIsNotNone(axis_input)
+        self.assertEqual(axis_input.producer().attributes["value_int"].value, 1)
+
+
     def test_version_convert_gridsample_linear(self):
         model = ir.from_onnx_text(
             """

--- a/onnxscript/version_converter/_version_converter_test.py
+++ b/onnxscript/version_converter/_version_converter_test.py
@@ -168,7 +168,6 @@ class VersionConverter19to20Test(unittest.TestCase):
         self.assertIsNotNone(axis_input)
         self.assertEqual(axis_input.producer().attributes["value_int"].value, 1)
 
-
     def test_version_convert_gridsample_linear(self):
         model = ir.from_onnx_text(
             """


### PR DESCRIPTION
Opset 19 defines DFT `axis` as an attribute defaulting to 1. Opset 20 moved it to an input defaulting to -2. `dft_19_20` read the attribute with a `None` default and returned early when it was absent, so the node was left untouched while the model opset was bumped. For any input of rank greater than 3 the converted model silently computes a different transform.

Measured on a rank-4 input with no `axis` attribute, numpy as ground truth, at the parent commit:

```
converted DFT inputs: ['input_x']
opset-19 result == numpy fft(axis=1): True
opset-20 result == numpy fft(axis=2): True
max abs diff: 4.825716018676758
```

onnx 1.22.0's own converter emits an axis Constant of 1 for this model, so the fix makes onnxscript agree with it.

The existing DFT tests all set `axis` explicitly, so the default path was never exercised. The added test omits it and fails on the unpatched source with `1 != 3`.

`version_converter`, `optimizer` and `rewriter`: 573 passed, 2 skipped, 6 xfailed.

The `None` guard stays: `_get_int_attribute` also returns `None` for a wrongly-typed attribute. Open PR #2941 changes only the `@register` decorator on this function, so the two do not overlap.
