### PR TITLE
Fix aten_roll for negative dims and shifts past the dimension length

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -8809,7 +8809,9 @@ def _aten_roll_shift_no_dim_onnx(self: TTensor, shift: int) -> TTensor:
     prefix = op.Slice(self_flatten, slice_length, total_length)
     # Concat first+second together, e.g. [D,A,B,C]
     result = op.Concat(prefix, suffix, axis=0)
-    return op.Reshape(result, op.Shape(self))
+    # allowzero so a dimension that is only zero at run time stays zero here, rather than
+    # being read as "copy the input dimension" against a flattened tensor.
+    return op.Reshape(result, op.Shape(self), allowzero=True)
 
 
 def _aten_roll_shift_and_dim_onnx(self: TTensor, shift: int, dim: int) -> TTensor:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -8735,6 +8735,9 @@ def aten_roll(self: TTensor, shifts: Sequence[int], dims: Sequence[int] = ()) ->
         result = self
         for i, shift in enumerate(shifts):
             dim = dims[i]
+            # PyTorch accepts negative dim as reversed counting
+            if dim < 0:
+                dim = self_rank + dim
             result = _aten_roll_shift_and_dim_onnx(result, shift, dim)
         return result
 
@@ -8770,6 +8773,9 @@ def aten_roll_complex(
     else:
         assert len(shifts) == len(dims)
         for i, dim in enumerate(dims):
+            if dim < 0:
+                # Account for the complex dimension in ONNX
+                dim = self_rank + dim - 1
             self_real = _aten_roll_shift_and_dim_onnx(self_real, shifts[i], dim)
             self_imag = _aten_roll_shift_and_dim_onnx(self_imag, shifts[i], dim)
 
@@ -8781,33 +8787,30 @@ def _aten_roll_shift_no_dim_onnx(self: TTensor, shift: int) -> TTensor:
     neg_1 = op.Constant(value_ints=[-1])
     # flatten the self tensor: from [[A,B],[C,D]] to [A,B,C,D]
     self_flatten = op.Reshape(self, neg_1)
-    # Compute slice length
-    if shift < 0:
-        # For [A,B,C,D], if shift is -1, slice_length = -(-1) = 1, means move [A] to the end
-        slice_length = op.Constant(value_ints=[-shift])
-    else:
-        # For [A,B,C,D], if shift is 1, slice_length = 4 - 1 = 3, means move [A,B,C] to the end
-        # The effect equals to move [D] to the beginning
-        slice_length = op.Size(self_flatten) - op.Constant(value_ints=[shift])
+    total_length = op.Shape(self_flatten)
+    # Compute slice length. roll is circular, so the shift is taken modulo the number
+    # of elements. For [A,B,C,D], if shift is 1, slice_length = 3, means move [A,B,C]
+    # to the end. The effect equals to move [D] to the beginning.
+    slice_length = op.Mod(op.Constant(value_ints=[-shift]), total_length)
     # Get second part of the tensor, e.g. [A,B,C]
     suffix = op.Slice(self_flatten, op.Constant(value_ints=[0]), slice_length)
     # Get first part of the tensor, e.g. [D]
-    prefix = op.Slice(self_flatten, slice_length, op.Reshape(op.Size(self_flatten), neg_1))
+    prefix = op.Slice(self_flatten, slice_length, total_length)
     # Concat first+second together, e.g. [D,A,B,C]
     result = op.Concat(prefix, suffix, axis=0)
     return op.Reshape(result, op.Shape(self))
 
 
 def _aten_roll_shift_and_dim_onnx(self: TTensor, shift: int, dim: int) -> TTensor:
-    neg_1 = op.Constant(value_ints=[-1])
+    # dim must already be normalized to a nonnegative axis, because Shape below
+    # reads an empty range when start is negative and end is zero.
     dim_tensor = op.Constant(value_ints=[dim])
-    if shift < 0:
-        slice_length = op.Constant(value_ints=[-shift])
-    else:
-        slice_length = op.Shape(self, start=dim, end=dim + 1) - op.Constant(value_ints=[shift])
+    dim_length = op.Shape(self, start=dim, end=dim + 1)
+    # roll is circular, so the shift is taken modulo the length of the dimension
+    slice_length = op.Mod(op.Constant(value_ints=[-shift]), dim_length)
     # from [A,B,C,D] -> [D,A,B,C], [D] is prefix, [A,B,C] is suffix
     suffix = op.Slice(self, op.Constant(value_ints=[0]), slice_length, axes=dim_tensor)
-    prefix = op.Slice(self, slice_length, op.Reshape(op.Size(self), neg_1), axes=dim_tensor)
+    prefix = op.Slice(self, slice_length, dim_length, axes=dim_tensor)
     result = op.Concat(prefix, suffix, axis=dim)
     return result
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -8723,7 +8723,9 @@ def aten_roll(self: TTensor, shifts: Sequence[int], dims: Sequence[int] = ()) ->
     self_rank = len(self.shape)
     if self_rank == 0:
         return op.Identity(self)
-    elif self.shape[0] == 0:  # empty tensor
+    elif 0 in self.shape:
+        # A tensor with no elements rolls to itself, which is what torch returns. It is
+        # also what keeps a zero length out of the modulo in the helpers below.
         return op.Identity(self)
 
     # NOTE: In pytorch, default value of dims is an empty list.
@@ -8758,7 +8760,10 @@ def aten_roll_complex(
     if self_rank == 1:
         return op.Identity(self)
 
-    if self.shape[0] == 0:  # empty tensor
+    if 0 in self.shape:
+        # Same as aten_roll: a tensor with no elements rolls to itself. The trailing
+        # dimension that carries the real and imaginary parts is never zero, so this
+        # only ever sees a dimension torch can see.
         return op.Identity(self)
 
     self_real = op.Slice(self, [0], [1], axes=[-1])
@@ -8784,6 +8789,12 @@ def aten_roll_complex(
 
 
 def _aten_roll_shift_no_dim_onnx(self: TTensor, shift: int) -> TTensor:
+    # The element count is the divisor of the Mod below, and Mod by zero is undefined in
+    # ONNX. Both callers return a tensor with no elements unchanged before reaching here.
+    assert self.shape is None or 0 not in self.shape, (
+        "the element count must not be zero because Mod by zero is undefined"
+    )
+
     neg_1 = op.Constant(value_ints=[-1])
     # flatten the self tensor: from [[A,B],[C,D]] to [A,B,C,D]
     self_flatten = op.Reshape(self, neg_1)
@@ -8804,6 +8815,13 @@ def _aten_roll_shift_no_dim_onnx(self: TTensor, shift: int) -> TTensor:
 def _aten_roll_shift_and_dim_onnx(self: TTensor, shift: int, dim: int) -> TTensor:
     # dim must already be normalized to a nonnegative axis, because Shape below
     # reads an empty range when start is negative and end is zero.
+    # The length of that dimension is the divisor of the Mod below, and Mod by zero is
+    # undefined in ONNX. Both callers return a tensor with no elements unchanged before
+    # reaching here.
+    assert self.shape is None or self.shape[dim] != 0, (
+        "the dimension length must not be zero because Mod by zero is undefined"
+    )
+
     dim_tensor = op.Constant(value_ints=[dim])
     dim_length = op.Shape(self, start=dim, end=dim + 1)
     # roll is circular, so the shift is taken modulo the length of the dimension

--- a/tests/function_libs/torch_lib/e2e_ops_tests.py
+++ b/tests/function_libs/torch_lib/e2e_ops_tests.py
@@ -958,6 +958,44 @@ class TorchLibe2eTest(unittest.TestCase):
         )
         _testing.assert_onnx_program(onnx_program)
 
+    @parameterized.parameterized.expand(
+        [
+            ("trailing_dim", (2, 0), 1, 1),
+            ("trailing_dim_no_dim", (2, 0), 3, ()),
+            ("leading_dim", (0, 3), 1, 1),
+            ("leading_dim_no_dim", (0, 3), 2, ()),
+        ]
+    )
+    def test_roll_empty_tensor_is_an_identity(
+        self, _: str, shape: tuple[int, ...], shifts: int, dims: int | tuple[int, ...]
+    ):
+        # A tensor with no elements rolls to itself. It must not reach the modulo in the
+        # helpers, because the length it would divide by is zero and ONNX leaves Mod by
+        # zero undefined.
+        class RollModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.roll(x, shifts=shifts, dims=dims)
+
+        onnx_program = torch.onnx.export(
+            RollModel(), (torch.zeros(shape),), dynamo=True, optimize=False
+        )
+        self.assertNotIn("Mod", [node.op_type for node in onnx_program.model.graph])
+        _testing.assert_onnx_program(onnx_program)
+
+    def test_roll_complex_empty_tensor_is_an_identity(self):
+        class RollModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.roll(x, shifts=3, dims=1)
+
+        onnx_program = torch.onnx.export(
+            RollModel(),
+            (torch.zeros(2, 0, dtype=torch.complex64),),
+            dynamo=True,
+            optimize=False,
+        )
+        self.assertNotIn("Mod", [node.op_type for node in onnx_program.model.graph])
+        _testing.assert_onnx_program(onnx_program)
+
     def test_quantize_per_channel_int8(self):
         class Model(torch.nn.Module):
             def forward(self, x):

--- a/tests/function_libs/torch_lib/e2e_ops_tests.py
+++ b/tests/function_libs/torch_lib/e2e_ops_tests.py
@@ -912,6 +912,52 @@ class TorchLibe2eTest(unittest.TestCase):
         )
         _testing.assert_onnx_program(onnx_program)
 
+    @parameterized.parameterized.expand(
+        [
+            ("negative_dim", 1, -1),
+            ("shift_larger_than_dim", 7, 1),
+            ("negative_shift_larger_than_dim", -4, 1),
+            ("no_dim_shift_larger_than_numel", 14, ()),
+            ("no_dim_negative_shift_larger_than_numel", -8, ()),
+        ]
+    )
+    def test_roll_wraps_shifts_and_normalizes_negative_dims(
+        self, _: str, shifts: int, dims: int | tuple[int, ...]
+    ):
+        # roll is circular, so a shift that exceeds the length of the dimension has
+        # to wrap instead of relying on Slice to clamp it.
+        class RollModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.roll(x, shifts=shifts, dims=dims)
+
+        onnx_program = torch.onnx.export(
+            RollModel(), (torch.randn(2, 3),), dynamo=True, optimize=False
+        )
+        _testing.assert_onnx_program(onnx_program)
+
+    @parameterized.parameterized.expand(
+        [
+            ("negative_dim", 1, -1),
+            ("shift_larger_than_dim", 7, 1),
+        ]
+    )
+    def test_roll_complex_wraps_shifts_and_normalizes_negative_dims(
+        self, _: str, shifts: int, dims: int
+    ):
+        # The complex variant carries a trailing axis for the real and imaginary
+        # parts, so a negative dim resolves against a rank one larger than torch's.
+        class RollModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.roll(x, shifts=shifts, dims=dims)
+
+        onnx_program = torch.onnx.export(
+            RollModel(),
+            (torch.randn(2, 3, dtype=torch.complex64),),
+            dynamo=True,
+            optimize=False,
+        )
+        _testing.assert_onnx_program(onnx_program)
+
     def test_quantize_per_channel_int8(self):
         class Model(torch.nn.Module):
             def forward(self, x):


### PR DESCRIPTION

`torch.roll` is circular. The shift is taken modulo the length of the dimension,
and a negative `dims` counts from the end. The lowering in
`onnxscript/function_libs/torch_lib/ops/core.py` does neither. It slices at
`dim_size - shift` for a positive shift and at `-shift` for a negative one, and
leans on `Slice` clamping to keep that in range, which only holds while the
shift stays inside a single wrap.

## A negative dim emits a model onnxruntime will not load

`_aten_roll_shift_and_dim_onnx` reads the dimension length with
`op.Shape(self, start=dim, end=dim + 1)`. For `dim = -1` that is
`start=-1, end=0`, and ONNX reads `end=0` as the absolute index 0, not as the
end of the shape. The range is empty, so `Shape` returns an empty tensor, and
that empty tensor is what reaches the `ends` input of `Slice`.

Unoptimized graph for `torch.roll(x, shifts=1, dims=-1)` on main, `x` of shape
`(2, 3)`:

```
Shape    node_Shape_2   in=['x']                        out=['val_2']  attrs={'end': 0, 'start': -1}
Sub      node_Sub_4     in=['val_2', 'val_3']           out=['val_4']
Slice    node_Slice_6   in=['x', 'val_5', 'val_4', ...] out=['val_6']
Concat   node_roll      in=['val_9', 'val_6']           out=['roll']   attrs={'axis': -1}
```

```
torch.roll(x, shifts=1, dims=-1)
  torch        [[2.0, 0.0, 1.0], [5.0, 3.0, 4.0]]
  onnxruntime  [ONNXRuntimeError] : 1 : FAIL : Node (node_Slice_6) Op (Slice)
               [ShapeInferenceError] Incorrect or missing input value for starts and ends
```

Those nodes are this lowering rather than a torch decomposition. They are the
`Shape`, `Sub`, `Slice`, `Slice`, `Concat` chain from
`_aten_roll_shift_and_dim_onnx`, the output node keeps the `node_roll` name, and
editing `core.py` changes what onnxruntime returns, which is how every number
below was produced.

The export above uses `optimize=False` so the model gets as far as being saved.
With the default `optimize=True` it does not get that far: the empty tensor
trips the rewrite pass first and the export raises `PassError`. Same root cause.

Only `dim = -1` breaks this way. `dim = -2` on a rank 2 tensor gives
`start=-2, end=-1`, which is a nonempty range, and comes out correct.

## A shift past the dimension length is silently wrong

```
x = torch.arange(6, dtype=torch.float32).reshape(2, 3)

torch.roll(x, shifts=-4, dims=1)
  torch        [[1.0, 2.0, 0.0], [4.0, 5.0, 3.0]]
  onnxruntime  [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]

torch.roll(x, shifts=7, dims=1)
  torch        [[2.0, 0.0, 1.0], [5.0, 3.0, 4.0]]
  onnxruntime  [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]

torch.roll(x, shifts=14)
  torch        [[4.0, 5.0, 0.0], [1.0, 2.0, 3.0]]
  onnxruntime  [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
```

The boundary is narrow, which is why this went unnoticed. A shift of exactly one
dimension length is right because the rotation is the identity. A positive shift
between one and two lengths is also right, because `dim_size - shift` goes
negative and `Slice` reads a negative start as an index from the end, which
happens to be one wrap. It only goes wrong once a positive shift exceeds twice
the length, and for any negative shift whose magnitude is not a multiple of the
length. The last case above is the `dims=()` path, where the same thing happens
against the element count.

## The fix

`aten_roll` normalizes a negative dim against the rank, which is known at export
time, in the same shape `aten_unflatten` already uses:

```python
# PyTorch accepts negative dim as reversed counting
if dim < 0:
    dim = self_rank + dim
```

`aten_roll_complex` needs its own version. The real representation carries a
trailing axis for the real and imaginary parts, so a negative dim resolves
against a rank one larger than the one torch sees. This matches
`aten_slice_complex` and `aten_squeeze_dim_complex`:

```python
if dim < 0:
    # Account for the complex dimension in ONNX
    dim = self_rank + dim - 1
```

Both helpers then take the shift modulo the length. ONNX `Mod` with `fmod=0`
gives the remainder the sign of the divisor, the same as Python, so
`(-shift) % length` is the split point for either sign of shift and any
magnitude:

```python
dim_length = op.Shape(self, start=dim, end=dim + 1)
slice_length = op.Mod(op.Constant(value_ints=[-shift]), dim_length)
```

The branch on the sign of the shift goes away in both helpers. The second
`Slice` was passing the total element count as its `ends` and relying on
clamping; it now takes the dimension length it already has. The graph for the
case above goes from 11 nodes to 8, and `Shape` now reads `start=1, end=2`.

## Testing

Added `test_roll_wraps_shifts_and_normalizes_negative_dims` and
`test_roll_complex_wraps_shifts_and_normalizes_negative_dims` to
`tests/function_libs/torch_lib/e2e_ops_tests.py`, following the `optimize=False`
pattern the tests around them use. Seven cases between them: negative dim,
positive and negative shifts past the dimension length, and the `dims=()` path
where the shift runs past the element count.

With only the `core.py` change reverted, all seven fail. Two fail at session
creation with the error quoted above, the other five with
`AssertionError: Tensor-likes are not close!`. With the fix all seven pass.

```
pytest tests/function_libs/torch_lib/e2e_ops_tests.py -k roll
7 passed, 100 deselected in 6.88s

pytest tests/function_libs/torch_lib/ops_test.py -k roll
6 passed, 2 skipped, 1844 deselected, 102 subtests passed in 4.87s
```

The existing OpInfo suite is unchanged, and it could not have caught this.
`sample_inputs_roll` uses only nonnegative dims, and its one large shift sample
rolls a `(5, 5, 5)` tensor by 10000, which is a multiple of 5 and therefore the
identity. Neither roll entry in `ops_test_data.py` carries a skip or an xfail,
so there was nothing to remove.

Also checked by hand and passing: several dims in one call, rank 3 with
`dims=-2`, a shift of zero, a shift that is an exact multiple of the length, a
dimension of length zero, and a dynamic dimension whose length is only known at
run time, which is the case where the `Mod` node has to survive into the graph
instead of folding away.

One case worth flagging for review. Rolling a dimension whose length is zero now
evaluates `Mod` with a zero divisor, which the ONNX spec leaves undefined.
onnxruntime returns the dividend, so both slices come back empty and `Concat`
returns the input unchanged, which is what torch does. If you would rather not
depend on that, the alternative is to guard the modulo when the length is
statically zero. Separately, `torch.roll(torch.zeros(2, 0), shifts=3)` with no
dims still fails at `Reshape` with `Invalid position of 0`. That is unrelated to
this change and fails the same way before it.

Environment: Python 3.10, torch 2.9.1, onnx 1.22.0, onnxruntime 1.23.2, macOS
arm64.
