### PR TITLE
Fix float16 trunc division rounding

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -3246,7 +3246,10 @@ def aten_div_mode(self: TReal, other: TReal, rounding_mode: Optional[str] = None
     if rounding_mode == "trunc":
         # Rounds the results of the division towards zero.
         # Equivalent to C-style integer division
-        return aten_trunc(op.Div(self, other))
+        quotient = op.Div(self, other)
+        if self.dtype == ir.DataType.FLOAT16:
+            quotient = op.Cast(quotient, to=FLOAT16.dtype)
+        return aten_trunc(quotient)
     if rounding_mode == "floor":
         return op.Floor(op.Div(self, other))
 

--- a/tests/function_libs/torch_lib/ops_test_data.py
+++ b/tests/function_libs/torch_lib/ops_test_data.py
@@ -676,16 +676,9 @@ TESTED_TORCHLIB_OPS: tuple[TorchLibOpInfo, ...] = (
     ),
     TorchLibOpInfo("true_divide", core_ops.aten_div),
     TorchLibOpInfo("true_divide", core_ops.aten_div_complex, complex=True),
-    TorchLibOpInfo("div_mode", core_ops.aten_div_mode)
-    .skip(
+    TorchLibOpInfo("div_mode", core_ops.aten_div_mode).skip(
         variant_name="no_rounding_mode",
         reason="this variation requires the rounding_mode argument",
-    )
-    .skip(
-        variant_name="trunc_rounding",
-        dtypes=(torch.float16,),
-        # Numbers match sometimes but not other times
-        reason="fixme: off-by-one. https://github.com/microsoft/onnxscript/issues/990",
     ),
     TorchLibOpInfo("dot", core_ops.aten_dot),
     TorchLibOpInfo(


### PR DESCRIPTION
## Summary

Fixes #990.

ONNX Runtime can evaluate the float16 division in `aten::div(..., rounding_mode="trunc")` with a higher-precision intermediate than PyTorch. Applying truncation to that value can produce an off-by-one result at float16 boundaries.

Materialize the float16 quotient before truncation, matching PyTorch's float16 rounding semantics. The existing float16 `trunc_rounding` regression case is enabled again.

## Tests

- `python -m pytest tests/function_libs/torch_lib/ops_test.py -k test_output_match_opinfo__div_mode -vv`
- `ruff check onnxscript/function_libs/torch_lib/ops/core.py tests/function_libs/torch_lib/ops_test_data.py`
- `ruff format --check onnxscript/function_libs/torch_lib/ops/core.py tests/function_libs/torch_lib/ops_test_data.py`
- `git diff --check`
