### PR TITLE
Fix aten_isclose handling of infinities and equal_nan

### DIFF
--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5552,10 +5552,12 @@ def aten_isclose(
     if self.dtype.is_floating_point():
         # Comparing the two sides of the band by subtraction carries the finiteness
         # restriction on its own, so no IsInf term is needed. An infinity on either side
-        # makes both the error and the allowance infinite, their difference NaN, and
-        # every comparison against NaN false, which leaves the equality term above as the
-        # only way an infinity is reported close. On finite values the sign of the
-        # difference and the direct comparison agree exactly, so the band is unchanged.
+        # puts a NaN into the subtraction whichever way it arrives: the error and the
+        # allowance are both infinite and cancel, or the allowance is already NaN because
+        # rtol is zero and zero times infinity is NaN. Every comparison against NaN is
+        # false, which leaves the equality term above as the only way an infinity is
+        # reported close. On finite values the sign of the difference and the direct
+        # comparison agree exactly, so the band is unchanged.
         zero = op.Constant(value=ir.tensor(0, dtype=self.dtype))
         within_tolerance = op.LessOrEqual(op.Sub(actual_error, allowed_error), zero)
         if equal_nan:

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5539,12 +5539,8 @@ def aten_isclose(
     """isclose(Tensor self, Tensor other, float rtol=1e-05, float atol=1e-08, bool equal_nan=False) -> Tensor"""
 
     # torch builds isclose out of three terms in aten/src/ATen/native/TensorCompare.cpp:
-    # exact equality, NaN against NaN when equal_nan is set, and the error inside the
-    # tolerance band for the elements whose error is finite.
-    # The tolerance band on its own gets the infinities wrong in both directions. Two
-    # equal infinities give a NaN error, which compares as not close, and anything
-    # measured against an infinity gets an infinite allowed error, which compares as
-    # close.
+    # exact equality, NaN against NaN when equal_nan is set, and the tolerance band
+    # restricted to the elements whose error is finite.
     result = op.Equal(self, other)
 
     # |self - other| <= atol + rtol x |other|
@@ -5552,19 +5548,23 @@ def aten_isclose(
     allowed_error = op.Add(
         op.CastLike(atol, other), op.Mul(op.CastLike(rtol, other), op.Abs(other))
     )
-    within_tolerance = op.LessOrEqual(actual_error, allowed_error)
 
-    # Integers are always finite and never NaN, so they need only the two terms above,
-    # and IsInf/IsNaN do not accept them.
     if self.dtype.is_floating_point():
+        # Comparing the two sides of the band by subtraction carries the finiteness
+        # restriction on its own, so no IsInf term is needed. An infinity on either side
+        # makes both the error and the allowance infinite, their difference NaN, and
+        # every comparison against NaN false, which leaves the equality term above as the
+        # only way an infinity is reported close. On finite values the sign of the
+        # difference and the direct comparison agree exactly, so the band is unchanged.
+        zero = op.Constant(value=ir.tensor(0, dtype=self.dtype))
+        within_tolerance = op.LessOrEqual(op.Sub(actual_error, allowed_error), zero)
         if equal_nan:
             result = op.Or(result, op.And(op.IsNaN(self), op.IsNaN(other)))
-        error = actual_error
-        if self.dtype in {ir.DataType.FLOAT16, ir.DataType.BFLOAT16}:
-            # IsInf takes only FLOAT and DOUBLE before opset 20. Widening is exact.
-            error = op.Cast(actual_error, to=FLOAT.dtype)
-        error_is_finite = op.And(op.Not(op.IsInf(error)), op.Not(op.IsNaN(error)))
-        within_tolerance = op.And(error_is_finite, within_tolerance)
+    else:
+        # Integers are never infinite and never NaN, so they need no finiteness term, and
+        # IsNaN does not accept them. The subtraction is left off here because it can
+        # overflow a narrow integer type where the direct comparison cannot.
+        within_tolerance = op.LessOrEqual(actual_error, allowed_error)
 
     return op.Or(result, within_tolerance)
 

--- a/onnxscript/function_libs/torch_lib/ops/core.py
+++ b/onnxscript/function_libs/torch_lib/ops/core.py
@@ -5528,7 +5528,7 @@ def aten_is_vulkan_available() -> bool:
     raise NotImplementedError()
 
 
-@torch_op("aten::isclose")
+@torch_op("aten::isclose", trace_only=True)
 def aten_isclose(
     self: TReal,
     other: TReal,
@@ -5538,12 +5538,35 @@ def aten_isclose(
 ) -> BOOL:
     """isclose(Tensor self, Tensor other, float rtol=1e-05, float atol=1e-08, bool equal_nan=False) -> Tensor"""
 
-    # FIXME: check equal_nan when self and other are all NaN
-    # |input - other| <= atol + rtol x |other|
-    left_part = op.Abs(op.Sub(self, other))
-    right_part = op.Add(atol, op.Mul(rtol, op.Abs(other)))
-    result = op.LessOrEqual(left_part, right_part)
-    return result
+    # torch builds isclose out of three terms in aten/src/ATen/native/TensorCompare.cpp:
+    # exact equality, NaN against NaN when equal_nan is set, and the error inside the
+    # tolerance band for the elements whose error is finite.
+    # The tolerance band on its own gets the infinities wrong in both directions. Two
+    # equal infinities give a NaN error, which compares as not close, and anything
+    # measured against an infinity gets an infinite allowed error, which compares as
+    # close.
+    result = op.Equal(self, other)
+
+    # |self - other| <= atol + rtol x |other|
+    actual_error = op.Abs(op.Sub(self, other))
+    allowed_error = op.Add(
+        op.CastLike(atol, other), op.Mul(op.CastLike(rtol, other), op.Abs(other))
+    )
+    within_tolerance = op.LessOrEqual(actual_error, allowed_error)
+
+    # Integers are always finite and never NaN, so they need only the two terms above,
+    # and IsInf/IsNaN do not accept them.
+    if self.dtype.is_floating_point():
+        if equal_nan:
+            result = op.Or(result, op.And(op.IsNaN(self), op.IsNaN(other)))
+        error = actual_error
+        if self.dtype in {ir.DataType.FLOAT16, ir.DataType.BFLOAT16}:
+            # IsInf takes only FLOAT and DOUBLE before opset 20. Widening is exact.
+            error = op.Cast(actual_error, to=FLOAT.dtype)
+        error_is_finite = op.And(op.Not(op.IsInf(error)), op.Not(op.IsNaN(error)))
+        within_tolerance = op.And(error_is_finite, within_tolerance)
+
+    return op.Or(result, within_tolerance)
 
 
 @torch_op("aten::isfinite")

--- a/tests/function_libs/torch_lib/e2e_ops_tests.py
+++ b/tests/function_libs/torch_lib/e2e_ops_tests.py
@@ -1574,8 +1574,8 @@ class TorchLibe2eTest(unittest.TestCase):
         _testing.assert_onnx_program(onnx_program)
 
     def test_isclose_integer_inputs(self):
-        # Integers carry no infinities or NaNs, so the two added terms have to leave
-        # this path alone. IsInf and IsNaN do not accept integer tensors either.
+        # Integers carry no infinities or NaNs, so the NaN term has to stay off this
+        # path, and IsNaN does not accept integer tensors anyway.
         class IsCloseModel(torch.nn.Module):
             def forward(self, a, b):
                 return torch.isclose(a, b)

--- a/tests/function_libs/torch_lib/e2e_ops_tests.py
+++ b/tests/function_libs/torch_lib/e2e_ops_tests.py
@@ -1543,6 +1543,49 @@ class TorchLibe2eTest(unittest.TestCase):
         )
         np.testing.assert_array_equal(mask, expected)
 
+    @parameterized.parameterized.expand(
+        [
+            ("float32", torch.float32, False),
+            ("float32_equal_nan", torch.float32, True),
+            ("float16", torch.float16, False),
+            ("float16_equal_nan", torch.float16, True),
+        ]
+    )
+    def test_isclose_handles_infinities_and_equal_nan(
+        self, _: str, dtype: torch.dtype, equal_nan: bool
+    ):
+        # torch.isclose is exact equality, plus NaN against NaN when equal_nan is
+        # set, plus the tolerance band on the elements whose error is finite. The
+        # tolerance band on its own reports two equal infinities as not close, and
+        # reports anything measured against an infinity as close.
+        class IsCloseModel(torch.nn.Module):
+            def forward(self, a, b):
+                return torch.isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=equal_nan)
+
+        inf = math.inf
+        nan = math.nan
+        # Pairs in order: matching infinities twice, opposite infinities, two finite
+        # values against an infinity, NaN against NaN, NaN against a number, an
+        # ordinary close pair and an ordinary far pair.
+        a = torch.tensor([inf, -inf, inf, 1.0, -5.0, nan, nan, 1.0, 3.0], dtype=dtype)
+        b = torch.tensor([inf, -inf, -inf, inf, -inf, nan, 1.0, 1.000001, 3.5], dtype=dtype)
+
+        onnx_program = torch.onnx.export(IsCloseModel(), (a, b), dynamo=True, optimize=False)
+        _testing.assert_onnx_program(onnx_program)
+
+    def test_isclose_integer_inputs(self):
+        # Integers carry no infinities or NaNs, so the two added terms have to leave
+        # this path alone. IsInf and IsNaN do not accept integer tensors either.
+        class IsCloseModel(torch.nn.Module):
+            def forward(self, a, b):
+                return torch.isclose(a, b)
+
+        a = torch.tensor([1, 2, 3, -4, 0], dtype=torch.int64)
+        b = torch.tensor([1, 2, 4, -4, 7], dtype=torch.int64)
+
+        onnx_program = torch.onnx.export(IsCloseModel(), (a, b), dynamo=True, optimize=False)
+        _testing.assert_onnx_program(onnx_program)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

`torch.isclose` is not a single tolerance test. In
`aten/src/ATen/native/TensorCompare.cpp` it is the union of three terms:

```
close  = (self == other)
close |= isnan(self) & isnan(other)                 # only when equal_nan is set
close |= isfinite(actual_error) & (actual_error <= allowed_error)
```

The lowering in `onnxscript/function_libs/torch_lib/ops/core.py` implements the third
term only, and drops the `isfinite` guard from it:

```python
# FIXME: check equal_nan when self and other are all NaN
# |input - other| <= atol + rtol x |other|
left_part = op.Abs(op.Sub(self, other))
right_part = op.Add(atol, op.Mul(rtol, op.Abs(other)))
result = op.LessOrEqual(left_part, right_part)
```

So `equal_nan` never reaches the graph, which the FIXME already noted, and the
infinities come out wrong in both directions, which it did not.

I did not find an issue for this, so there is no number to reference.

## What comes out

`torch.onnx.export(..., dynamo=True)` of `torch.isclose(a, b, rtol=1e-05, atol=1e-08)`
on main at 3ba2bf7, float32, run under onnxruntime:

```
         a          b   torch    onnx   equal_nan
       inf        inf    True   False   False
      -inf       -inf    True   False   False
       inf       -inf   False    True   False
         1        inf   False    True   False
        -5       -inf   False    True   False
       nan        nan   False   False   False
       nan        nan    True   False   True
       nan          1   False   False   False
         1   1.000001    True    True   False
         3        3.5   False   False   False
```

Six of the ten rows disagree. Two mechanisms are at work:

- An infinite `other` makes `allowed_error` infinite, so `|self - other| <= allowed_error`
  holds for every finite `self` and for the opposite infinity. Anything measured against
  an infinity comes back close.
- `inf` against `inf` gives `actual_error = NaN`, and `NaN <= inf` is false, so two equal
  infinities come back not close. The exact equality term is what torch uses to catch
  these, and it is missing here.

The attributes have to be bound for any of this to show up. Building a standalone model
from `aten_isclose.to_model_proto()` leaves `rtol` and `atol` as unbound reference
attributes, onnxruntime then evaluates `rtol` as 0, `0 * inf` is NaN, and every row comes
back False, which hides the bug rather than showing it. Every number above came through
`torch.onnx.export`.

The integer path is unchanged by this. `atol` and `rtol` truncate to 0 there, so the
comparison collapses to equality, both before and after. That does differ from torch for a
separate reason, which I describe at the end.

## The fix

`aten_isclose` becomes `trace_only=True` so that `equal_nan` and the dtype branch resolve
at export time, and it then follows the three terms directly:

```python
result = op.Equal(self, other)

# |self - other| <= atol + rtol x |other|
actual_error = op.Abs(op.Sub(self, other))
allowed_error = op.Add(
    op.CastLike(atol, other), op.Mul(op.CastLike(rtol, other), op.Abs(other))
)
within_tolerance = op.LessOrEqual(actual_error, allowed_error)

if self.dtype.is_floating_point():
    if equal_nan:
        result = op.Or(result, op.And(op.IsNaN(self), op.IsNaN(other)))
    error = actual_error
    if self.dtype in {ir.DataType.FLOAT16, ir.DataType.BFLOAT16}:
        error = op.Cast(actual_error, to=FLOAT.dtype)
    error_is_finite = op.And(op.Not(op.IsInf(error)), op.Not(op.IsNaN(error)))
    within_tolerance = op.And(error_is_finite, within_tolerance)

return op.Or(result, within_tolerance)
```

The tolerance band itself is unchanged. The `CastLike` pair is the same conversion
onnxscript was inserting implicitly for the two float attributes in the scripted version,
written out because a traced function does not insert it. The integer graph therefore
computes exactly what it computed before, with `Equal` and `Or` added around it.

Integers are always finite and never NaN, and `IsInf` and `IsNaN` do not accept integer
tensors, so the guard and the `equal_nan` term are skipped for them. That mirrors torch,
which applies the NaN term only when the input is floating point or complex.

ONNX has no `IsFinite`, so it is spelled the way `aten_isfinite` spells it a few lines
below in the same file. `IsInf` accepts only FLOAT and DOUBLE before opset 20, so on
FLOAT16 and BFLOAT16 the error is cast up to FLOAT first. Widening a float is exact, and
the extra node appears only on those two dtypes.

## Testing

`ops_test_data.py` needs no change. The `isclose` entry carries no skip or xfail, and
`sample_inputs_isclose` only ever draws finite values out of `make_tensor`, so the OpInfo
samples cannot reach any of this even though they do sweep `equal_nan` and `rtol`.

Added `test_isclose_handles_infinities_and_equal_nan` and `test_isclose_integer_inputs` to
`tests/function_libs/torch_lib/e2e_ops_tests.py`, following the `optimize=False` pattern
the tests around them use. The first runs the nine pairs from the table above under
float32 and float16 with `equal_nan` both ways, the second runs int64.

With only the `core.py` change reverted:

```
pytest tests/function_libs/torch_lib/e2e_ops_tests.py -k isclose
4 failed, 1 passed, 100 deselected in 6.62s
```

All four float cases fail with `AssertionError: Tensor-likes are not equal!`, 5 of 9
elements mismatched with `equal_nan` off and 6 of 9 with it on. The int64 case passes,
which is the point of it. With the fix:

```
pytest tests/function_libs/torch_lib/e2e_ops_tests.py -k isclose
5 passed, 100 deselected in 6.06s

pytest tests/function_libs/torch_lib/ops_test.py -k isclose
4 passed, 2 skipped, 1846 deselected, 68 subtests passed in 4.92s
```

The baseline for the second one on main is
`5 passed, 1 skipped, 1846 deselected, 68 subtests passed`. The subtest count is
unchanged, so no OpInfo sample moved. The extra skip is the function proto validity
check, which does not apply to traced functions.

Also checked by hand: export plus `onnx.checker.check_model(full_check=True)` for float32,
float64, float16, bfloat16, int64, int32, int16 and int8. All eight pass the checker, and
all run under onnxruntime except bfloat16, which has no CPU kernel for `Equal`. bfloat16
had no CPU kernel for `Sub` before this change either, so it is no worse off.

## One thing I left alone

torch computes the tolerance for integer inputs in floating point, because `rtol` is a
double and `rtol * other` promotes, so `torch.isclose` of `999999` against `1000000` is
True with an allowed error of 10. The lowering casts `atol` and `rtol` to the input dtype,
where both become 0, and returns False:

```
torch: [True, True, False]
onnx : [False, True, False]
```

That holds before and after this change. It is a different root cause from the two missing
terms, and fixing it would move numbers on the integer path, so I kept it out of this
change. Happy to follow up on it separately if you want it.

Environment: Python 3.10, torch 2.9.1, onnx 1.22.0, onnxruntime 1.23.2, macOS arm64.
