### PR TITLE
Fix optimize.py crash when the model path has no directory component

### DIFF
--- a/tools/optimize.py
+++ b/tools/optimize.py
@@ -27,7 +27,8 @@ def main(args) -> None:
     # TODO: Remove this hack by fixing the optimizer to handle external data files properly.
     pwd = os.getcwd()
     model_dir = os.path.dirname(path)
-    os.chdir(model_dir)
+    if model_dir:
+        os.chdir(model_dir)
     model = onnxscript.optimizer.optimize(model)
     model = onnx.inliner.inline_local_functions(model)
     # Optimize again in case inlining created new opportunities.


### PR DESCRIPTION
`tools/optimize.py` calls `os.chdir(os.path.dirname(path))` unconditionally. For a bare filename `os.path.dirname` returns `''`, and `os.chdir('')` raises. That is the usage the module docstring documents:

```
Usage:
    python optimize.py model.onnx optimized_model.onnx
```

Before, run from the model's own directory against a real checker-valid model:

```
  File "tools/optimize.py", line 30, in main
    os.chdir(model_dir)
OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect: ''
```

After, the same command exits 0 and writes `optimized_model.onnx`, which `onnx.checker.check_model` reloads clean. A path that does carry a directory component still works, checked from an unrelated cwd.

No test added: `tools/` has no coverage here. There is no `tools/*_test.py`, `noxfile.py`'s test session does not reach it, and `pyproject.toml` groups `tools` with `examples,docs,utils,opgen` as supporting code. Adding a test file to a directory the project does not test looked like scope creep rather than the requested fix.

`ruff check` and `ruff format --check` on the changed file: 0 violations. `lintrunner -a --take RUFF`: no lint issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
